### PR TITLE
Fix runtime error in k8s namer configuration.

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -185,7 +185,10 @@ lazy val `linkerd-namer-k8s` =
   project.in(file("linkerd/namer/k8s")).
     settings(BaseSettings:_*).settings(
       name := "linkerd-namer-k8s",
-      libraryDependencies += Deps.finagle("core")
+      libraryDependencies ++=
+        Deps.finagle("core") ::
+        Deps.scalatest % "test" ::
+        Nil
     ).dependsOn(
       `k8s`,
       `linkerd-core`

--- a/k8s/src/main/scala/io/buoyant/k8s/AuthFilter.scala
+++ b/k8s/src/main/scala/io/buoyant/k8s/AuthFilter.scala
@@ -1,0 +1,11 @@
+package io.buoyant.k8s
+
+import com.twitter.finagle.{Service, SimpleFilter}
+import com.twitter.finagle.http.{Request, Response}
+
+class AuthFilter(token: String) extends SimpleFilter[Request, Response] {
+  def apply(req: Request, service: Service[Request, Response]) = {
+    req.headerMap("Authorization") = s"Bearer $token"
+    service(req)
+  }
+}

--- a/k8s/src/main/scala/io/buoyant/k8s/EndpointsNamer.scala
+++ b/k8s/src/main/scala/io/buoyant/k8s/EndpointsNamer.scala
@@ -34,13 +34,6 @@ object masterAuth extends GlobalFlag(
       master.log.warning(s"failed to load k8s credentials: ${apply().show}: ${e.getMessage}")
       Filter.identity[Request, Response]
   }
-
-  private[this] class AuthFilter(token: String) extends SimpleFilter[Request, Response] {
-    def apply(req: Request, service: Service[Request, Response]) = {
-      req.headerMap("Authorization") = s"Bearer $token"
-      service(req)
-    }
-  }
 }
 
 object master {

--- a/linkerd/namer/k8s/src/test/scala/io/l5d/K8sTest.scala
+++ b/linkerd/namer/k8s/src/test/scala/io/l5d/K8sTest.scala
@@ -1,0 +1,12 @@
+package io.l5d.experimental
+
+import org.scalatest.FunSuite
+import scala.io.Source
+
+class K8sTest extends FunSuite {
+
+  test("sanity") {
+    // ensure it doesn't totally blowup
+    new k8s().newNamer()
+  }
+}


### PR DESCRIPTION
Problem

When configuring the io.l5d.experimental.k8s namer, a 'Malformed class name'
internal exception was thrown, because .getClass.getSimpleName was called on the
AuthTokenFile.Filter class, which is private.

Solution

Replace AuthTokenFile.filter() with AuthTokenFile.module() so that we can avoid
stringification of class names.
