### PR TITLE
[RFC] Add server support for TLS.

### DIFF
--- a/docs/config.md
+++ b/docs/config.md
@@ -24,6 +24,9 @@ routers:
   servers:
   - port: 8080
     ip: 0.0.0.0
+    tls:
+      certPath: /foo/cert
+      keyPath: /foo/key
   timeoutMs: 1000
   dstPrefix: /ext/http
 
@@ -115,6 +118,9 @@ values. If no default is provided, the port parameter is required.
 * *ip* -- The local IP address.  By default, the loopback address is
 used.  A value like `0.0.0.0` configures the server to listen on all
 local IPv4 interfaces.
+* *tls* -- The server will serve over TLS if this parameter is provided.  It must be an object containing keys:
+** *certPath* -- File path to the TLS certificate file
+** *keyPath* -- File path to the TLS key file
 
 <a name="proto-server-params">
 ## Protocol-specific server parameters ##

--- a/linkerd/core/src/test/scala/io/buoyant/linkerd/ServerTest.scala
+++ b/linkerd/core/src/test/scala/io/buoyant/linkerd/ServerTest.scala
@@ -1,5 +1,6 @@
 package io.buoyant.linkerd
 
+import com.twitter.finagle.transport.Transport
 import com.twitter.util.{Return, Try}
 import java.net.{InetAddress, InetSocketAddress}
 import org.scalatest.FunSuite
@@ -68,5 +69,33 @@ port: 1234
 fancyRouter: true
 """
     assert(parse(TestProtocol.Fancy, yaml).isThrow)
+  }
+
+  test("invalid tls configuration") {
+    val yaml =
+      """
+        |port: 1234
+        |tls:
+      """.stripMargin
+    assert(parse(TestProtocol.Plain, yaml).isThrow)
+  }
+
+  test("valid tls configuration") {
+    val yaml =
+      """
+        |port: 1234
+        |tls:
+        |  certPath: /foo/cert
+        |  keyPath: /foo/key
+      """.stripMargin
+    assert(parse(TestProtocol.Plain, yaml).get.params.apply[Transport.TLSServerEngine].e.isDefined)
+  }
+
+  test("tls configuration absent") {
+    val yaml =
+      """
+        |port: 1234
+      """.stripMargin
+    assert(parse(TestProtocol.Plain, yaml).get.params.apply[Transport.TLSServerEngine].e.isEmpty)
   }
 }


### PR DESCRIPTION
I've got tests that ensure the param gets parsed and passed in, but I haven't tested that this actually works in real life.  To do that I'd need certificate and key files.  I've never worked with TLS before so if anyone can point me in the right direction, that would be appreciated.
