### PR TITLE
Simplify router stats scoping under rt/$label

### DIFF
--- a/linkerd/admin/src/main/resources/io/buoyant/linkerd/admin/js/routers.js
+++ b/linkerd/admin/src/main/resources/io/buoyant/linkerd/admin/js/routers.js
@@ -1,0 +1,156 @@
+"use strict";
+
+/**
+ * Utilities for building and updating router information from raw
+ * key-val metrics.
+ *
+ * Produces a data structure in the form:
+ *
+ *   {
+ *     routerName: {
+ *       label: "routerName"
+ *       prefix: "rt/routerName/",
+ *       dstIds: {
+ *         dstName: {
+ *           label: "dstName",
+ *           router: "routerName",
+ *           prefix: "rt/routerName/dst/id/dstName/",
+ *           metrics: {...}
+ *         },
+ *       },
+ *       servers: [
+ *         { label: "0.0.0.0/8080",
+ *           ip: "0.0.0.0",
+ *           port: 8080,
+ *           router: "routerName",
+ *           prefix: "rt/routerName/srv/0.0.0.0/8080/",
+ *           metrics: {...}
+ *         }
+ *       ],
+ *       metrics: {...}
+ *     }
+ *   }
+ */
+var Routers = (function() {
+
+  var clientRE = /^rt\/(.+)\/dst\/id\/(.*)\/requests$/,
+      serverRE = /^rt\/(.+)\/srv\/([^/]+)\/(\d+)\/requests$/;
+
+  function mk(router, label, prefix) {
+    return {
+      router: router,
+      label: label,
+      prefix: prefix,
+      metrics: {requests: -1}
+    };
+  }
+
+  function mkRouter(label) {
+    var prefix = "rt/" + label + "/",
+        router = mk(label, label, prefix);
+    router.dstIds = {};
+    router.servers = [];
+    return router;
+  }
+
+  function mkDst(router, id) {
+    var prefix = "rt/" + router + "/dst/id/" + id + "/";
+    return mk(router, id, prefix);
+  }
+
+  function mkServer(router, ip, port) {
+    var label = ip + "/" + port,
+        prefix = "rt/" + router + "/srv/" + label + "/",
+        server = mk(router, label, prefix);
+    server.ip = ip;
+    server.port = port;
+    return server;
+  }
+
+  // Updates router clients and metrics from raw-key val metrics.
+  function update(routers, metrics) {
+    // first, check for new clients and add them
+    Object.keys(metrics).forEach(function(key) {
+      var match = key.match(clientRE);
+      if (match) {
+        var name = match[1], id = match[2],
+            router = routers[name];
+        if (router) {
+          router.dstIds[id] = mkDst(name, id);
+        }
+      }
+    });
+
+    // then, attach metrics to each appropriate scope
+    var routerNames = Object.keys(routers);
+
+    Object.keys(metrics).forEach(function(key) {
+      var scope = findByMetricKey(routers, key);
+      if (scope) {
+        var descoped = key.slice(scope.prefix.length);
+        scope.metrics[descoped] = metrics[key];
+      }
+    });
+  }
+
+  function updateServers(routers, metrics) {
+    Object.keys(metrics).forEach(function(key) {
+      var match = key.match(serverRE);
+      if (match) {
+        var name = match[1], ip = match[2], port = match[3];
+        var router = routers[name] = routers[name] || mkRouter(name);
+        router.servers.push(mkServer(name, ip, port));
+      }
+    });
+  }
+
+  function findMatchingRouter(routers, key) {
+    var routerNames = Object.keys(routers);
+    var name = routerNames.find(function(rn) { return key.indexOf(routers[rn].prefix) === 0; });
+    return (name === undefined) ? undefined : routers[name];
+  }
+  function findMatchingServer(servers, key) {
+    return servers.find(function(server) { return key.indexOf(server.prefix) === 0; });
+  }
+  function findMatchingDst(dsts, key) {
+    var id = Object.keys(dsts).find(function(id) { return key.indexOf(dsts[id].prefix) === 0; });
+    return (id === undefined) ? undefined : dsts[id];
+  }
+  function findByMetricKey(routers, key) {
+    var router = findMatchingRouter(routers, key);
+    if (router) {
+      var server = findMatchingServer(router.servers, key);
+      if (server) return server;
+
+      var dst = findMatchingDst(router.dstIds, key);
+      if (dst) return dst;
+    }
+    return router; // may be undefined
+  }
+
+  /**
+   * A constructor that initializes an object describing all of linker's routers,
+   * with stats, from a raw key-val metrics blob.
+   *
+   * Returns an object that may be updated with additional data.
+   */
+  return function(metrics) {
+    var routers = {};
+
+    // servers are only added the first time.
+    updateServers(routers, metrics);
+
+    // clients and metrics are initialized now, and then may be updated later.
+    update(routers, metrics);
+
+    return {
+      data: routers,
+
+      /** Updates metrics (and clients) on the underlying router data structure. */
+      update: function(metrics) { update(this.data, metrics); },
+
+      /** Finds a scope (router, dst, or server) associated with a scoped metric name. */
+      findByMetricKey: function(key) { return findByMetricKey(this.data, key); }
+    };
+  };
+})();

--- a/linkerd/admin/src/main/resources/io/buoyant/linkerd/admin/template/request_stats.template
+++ b/linkerd/admin/src/main/resources/io/buoyant/linkerd/admin/template/request_stats.template
@@ -1,4 +1,4 @@
 {{#each keys}}
-  <dt><a href="/metrics#srv/{{../server}}/{{@this}}">{{@this}}</a></dt>
-  <dd data-key="srv/{{../server}}/{{@this}}">...</dd>
+  <dt><a href="/metrics#{{../server.prefix}}{{@this}}">{{@this}}</a></dt>
+  <dd data-key="{{../server.prefix}}{{@this}}">...</dd>
 {{/each}}

--- a/linkerd/admin/src/main/scala/io/buoyant/linkerd/admin/SummaryHandler.scala
+++ b/linkerd/admin/src/main/scala/io/buoyant/linkerd/admin/SummaryHandler.scala
@@ -73,7 +73,7 @@ private object SummaryHandler {
         <div id="server-info" class="interfaces"></div>
       """,
       csses = Seq("summary.css"),
-      javaScripts = Seq("lib/handlebars-v4.0.5.js", "lib/smoothie.js", "utils.js", "summary.js")
+      javaScripts = Seq("lib/handlebars-v4.0.5.js", "lib/smoothie.js", "utils.js", "routers.js", "summary.js")
     )
   }
 }

--- a/linkerd/core/src/main/scala/io/buoyant/linkerd/Linker.scala
+++ b/linkerd/core/src/main/scala/io/buoyant/linkerd/Linker.scala
@@ -142,8 +142,8 @@ object Linker {
 
           // Ensure that neither the router name nor server sockets conflict.
           for (other <- linker.routers) {
-            if (router.name == other.name)
-              throw Parsing.error(s"conflicting routers named '${router.name}'", json)
+            if (router.label == other.label)
+              throw Parsing.error(s"conflicting routers named '${router.label}'", json)
             for ((s0, s1) <- Server.findConflict(router.servers ++ other.servers))
               throw Parsing.error(s"conflicting servers: ${s0.addr}, ${s1.addr}", json)
           }

--- a/linkerd/core/src/main/scala/io/buoyant/linkerd/ProtocolInitializer.scala
+++ b/linkerd/core/src/main/scala/io/buoyant/linkerd/ProtocolInitializer.scala
@@ -139,7 +139,7 @@ object ProtocolInitializer {
     factory: ServiceFactory[Req, Rsp]
   ) extends Server.Initializer {
     def params = server.params
-    def name: String = server.params[Label].label
+    def router: String = server.params[Server.RouterLabel].label
     def ip = addr.getAddress
     def port = addr.getPort
     def serve() = server.serve(addr, factory)

--- a/linkerd/core/src/main/scala/io/buoyant/linkerd/Server.scala
+++ b/linkerd/core/src/main/scala/io/buoyant/linkerd/Server.scala
@@ -21,8 +21,6 @@ trait Server {
   def configured[P: Stack.Param](p: P): Server = withParams(params + p)
   def configured(ps: Stack.Params): Server = withParams(params ++ ps)
 
-  def name: String = params[Label].label
-
   /**
    * Read a [[Server]] configuration in the form:
    *
@@ -46,6 +44,8 @@ trait Server {
    */
   def configuredFrom(json: JsonParser): Server
 
+  def router: String = params[Server.RouterLabel].label
+  def label: String = params[Label].label
   def ip: InetAddress = params[Server.Ip].ip
 
   def port: Int = params[Server.Port] match {
@@ -57,6 +57,10 @@ trait Server {
 }
 
 object Server {
+  case class RouterLabel(label: String)
+  implicit object RouterLabel extends Stack.Param[RouterLabel] {
+    val default = RouterLabel("")
+  }
 
   /**
    * A [[Server]] that is fully configured but not yet listening.
@@ -65,7 +69,7 @@ object Server {
     def protocol: ProtocolInitializer
     def params: Stack.Params
 
-    def name: String
+    def router: String
     def ip: InetAddress
     def port: Int
     def addr: InetSocketAddress

--- a/linkerd/core/src/test/scala/io/buoyant/linkerd/LinkerTest.scala
+++ b/linkerd/core/src/test/scala/io/buoyant/linkerd/LinkerTest.scala
@@ -33,13 +33,13 @@ routers:
 
     assert(routers.size == 2)
 
-    assert(routers(0).name == "plain")
+    assert(routers(0).label == "plain")
     assert(routers(0).protocol == TestProtocol.Plain)
     assert(routers(0).servers.size == 1)
     assert(routers(0).servers(0).addr.getAddress == InetAddress.getLoopbackAddress)
     assert(routers(0).servers(0).addr.getPort == 1)
 
-    assert(routers(1).name == "fancy")
+    assert(routers(1).label == "fancy")
     assert(routers(1).protocol == TestProtocol.Fancy)
     assert(routers(1).params[TestProtocol.Fancy.Pants].fancy == false)
     assert(routers(1).servers.size == 1)
@@ -126,7 +126,7 @@ routers:
   servers:
   - port: 2
 """
-    assert(parse(yaml).routers.map(_.name) == Seq("plain", "yohourt"))
+    assert(parse(yaml).routers.map(_.label) == Seq("plain", "yohourt"))
   }
 
   test("servers conflict") {

--- a/linkerd/core/src/test/scala/io/buoyant/linkerd/RouterTest.scala
+++ b/linkerd/core/src/test/scala/io/buoyant/linkerd/RouterTest.scala
@@ -22,9 +22,9 @@ servers:
 """
     val router = parse(yaml)
     assert(router.protocol == TestProtocol.Plain)
-    assert(router.name == "yoghurt")
+    assert(router.label == "yoghurt")
     assert(router.servers.size == 1)
-    assert(router.servers.head.name == "yoghurt/127.0.0.1/1234")
+    assert(router.servers.head.router == "yoghurt")
     assert(router.servers.head.addr.getAddress == InetAddress.getLoopbackAddress)
     assert(router.servers.head.addr.getPort == 1234)
   }
@@ -76,7 +76,8 @@ servers:
     assert(router.servers.head.addr.getAddress == InetAddress.getLoopbackAddress)
     assert(router.servers.head.addr.getPort == 1234)
 
-    assert(router.servers.head.params[param.Label].label == "fancy/127.0.0.1/1234")
+    assert(router.servers.head.router == "fancy")
+    assert(router.servers.head.params[param.Label].label == "127.0.0.1/1234")
     assert(router.servers.head.params[TestProtocol.Fancy.Pants].fancy)
 
   }

--- a/linkerd/main/src/main/scala/io/buoyant/Linkerd.scala
+++ b/linkerd/main/src/main/scala/io/buoyant/Linkerd.scala
@@ -22,7 +22,7 @@ object Linkerd extends TwitterServer {
 
   def main() {
     val build = Build.load(getClass.getResourceAsStream("/io/buoyant/linkerd-main/build.properties"))
-    log.info("Linkerd %s (rev=%s) built at %s", build.version, build.revision, build.name)
+    log.info("linkerd %s (rev=%s) built at %s", build.version, build.revision, build.name)
 
     args match {
       case Array(path) =>
@@ -37,7 +37,7 @@ object Linkerd extends TwitterServer {
           val running = router.initialize()
           closeOnExit(running)
           running.servers.map { server =>
-            log.info("serving %s", server.params[Label].label)
+            log.info("serving %s on %s:%d", server.router, server.ip, server.port)
             val listening = server.serve()
             closeOnExit(listening)
             listening

--- a/linkerd/namer/fs/src/main/scala/io/buoyant/linkerd/namer/fs/WatchingNamer.scala
+++ b/linkerd/namer/fs/src/main/scala/io/buoyant/linkerd/namer/fs/WatchingNamer.scala
@@ -42,46 +42,46 @@ object WatchingNamer {
   }
 }
 
-class WatchingNamer(rootDir: NioPath) extends Namer {
+class WatchingNamer(rootDir: NioPath, prefix: Path) extends Namer {
   import WatchingNamer._
 
   @volatile private[this] var rootCache: Watcher.File.Children = Map.empty
   private[this] lazy val root = Watcher(rootDir)
 
   def lookup(path: Path): Activity[NameTree[Name]] =
-    root.children.flatMap(lookup(Path.empty, path, _))
+    root.children.flatMap(lookup(prefix, path, _))
 
   /** Recursively resolve `path` in the given directory. */
   private[this] def lookup(
-    pfx: Path,
+    prefix: Path,
     path: Path,
     children: Watcher.File.Children
   ): Activity[NameTree[Name]] = path.take(1) match {
     case phd@Path.Utf8(name) =>
-      val id = pfx ++ phd
+      val id = prefix ++ phd
       val residual = path.drop(1)
-      log.debug("fs lookup %s %s %s", pfx.show, name, residual.show)
+      log.debug("fs lookup %s %s %s", prefix.show, name, residual.show)
 
       children.get(name) match {
         case Some(Watcher.File.Reg(data)) =>
-          log.debug("fs lookup %s file %s", pfx.show, name)
+          log.debug("fs lookup %s file %s", prefix.show, name)
 
           val addr: Var[Addr] = data.run.map {
             case Activity.Pending => Addr.Pending
             case Activity.Failed(e) => Addr.Failed(e)
             case Activity.Ok(buf@Buf.Utf8(txt)) =>
-              log.debug("fs lookup %s addr %s %d bytes", pfx.show, name, buf.length)
+              log.debug("fs lookup %s addr %s %d bytes", prefix.show, name, buf.length)
               txtToAddr(txt)
           }
 
           Activity.value(NameTree.Leaf(Name.Bound(addr, id, residual)))
 
         case Some(Watcher.File.Dir(children)) =>
-          log.debug("fs lookup %s dir %s", pfx.show, name)
+          log.debug("fs lookup %s dir %s", prefix.show, name)
           children.flatMap(lookup(id, residual, _))
 
         case None =>
-          log.debug("fs lookup %s missing %s", pfx.show, name)
+          log.debug("fs lookup %s missing %s", prefix.show, name)
           Activity.value(NameTree.Neg)
       }
 

--- a/linkerd/namer/fs/src/main/scala/io/l5d/fs.scala
+++ b/linkerd/namer/fs/src/main/scala/io/l5d/fs.scala
@@ -38,6 +38,6 @@ class fs(val params: Stack.Params) extends NamerInitializer {
     case fs.RootDir(None) => throw new IllegalArgumentException("io.l5d.fs requires a 'rootDir'")
     case fs.RootDir(Some(path)) if !path.toFile.isDirectory =>
       throw new IllegalArgumentException(s"io.l5d.fs 'rootDir' is not a directory: $path")
-    case fs.RootDir(Some(path)) => new WatchingNamer(path)
+    case fs.RootDir(Some(path)) => new WatchingNamer(path, params[NamerInitializer.Prefix].path)
   }
 }


### PR DESCRIPTION
- all router stats are scoped under rt/$label
- client stats are scoped under rt/$label/dst/id/$id
- server stats are scoped under rt/$label/srv/$host/$port
- later, additional client stats will be scoped under rt/$label/dst/path/$path.

The admin interface has been changed so that metrics processing results in
information about routers (rather than just clients and servers).  This data is
used to power the same UI without changes, although UI changes should follow
this in a followup review. Some ES6 features (string interpolation,
fat-arrow-functions, etc) are now utilized in linkerd-admin's js application.

If a Router is configured with a StatsReceiver or Tracer, this configuration is
not currently propagated to Servers.  This Router configuration should be
shared with its servers so that defaults may be specified and so that, later,
these may be configured in a per-router fashion. This change allows Tracers
and scoped StatsReceivers to be shared from a Router to its clients and servers.

Fixes #14
