### PR TITLE
Import of Consul namer and api, Create NameInitializer

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,6 @@ project/boot/
 project/plugins/project/
 project/plugins/src_managed/
 .sbt-launch.jar
+.idea
+.iml
+.DS_Store

--- a/README.md
+++ b/README.md
@@ -41,6 +41,11 @@ The _k8s_ project implements a client for a subset of the [Kubernetes][k8s]
 master API. This package provides the `io.buoyant.k8s.endpoints` namer that may
 be used with finagle clients or routers, independently of _linkerd_.
 
+#### consul ####
+
+The _consul_ project implements a client for a subset of the
+[Consul][consul] Catalog API.  It provides the `io.buoyant.consul.catalog` namer.
+
 #### test-util ####
 
 The _test-util_ project provides some helpers for writing tests against
@@ -67,3 +72,4 @@ specific language governing permissions and limitations under the License.
 
 [finagle]: https://twitter.github.io/finagle/
 [k8s]: https://k8s.io/
+[consul]: https://consul.io/

--- a/consul/src/main/scala/io/buoyant/consul/CatalogNamer.scala
+++ b/consul/src/main/scala/io/buoyant/consul/CatalogNamer.scala
@@ -1,0 +1,237 @@
+package io.buoyant.consul
+
+import com.google.common.net.InetAddresses
+import com.twitter.app.{Flag, GlobalFlag}
+import com.twitter.finagle._
+import com.twitter.finagle.http.{Request, Response}
+import com.twitter.finagle.service.FailFastFactory.FailFast
+import com.twitter.logging.Level
+import com.twitter.util._
+import io.buoyant.consul.v1.ServiceNode
+import java.net.{InetSocketAddress, SocketAddress}
+
+class CatalogNamer(
+  idPrefix: Path,
+  mkApi: (String) => v1.CatalogApi
+) extends Namer {
+
+  import CatalogNamer._
+
+  /**
+   * Accepts names in the form:
+   * /<datacenter>/<svc-name>/residual/path
+   */
+  def lookup(path: Path): Activity[NameTree[Name]] =
+    path.take(PrefixLen) match {
+      case id@Path.Utf8(dcName, serviceName) =>
+        val residual = path.drop(PrefixLen)
+        log.debug("consul lookup: %s %s", id.show, path.show)
+        Activity(Dc.get(dcName).services).map { services =>
+          log.debug("consul dc %s initial state: %s", dcName, services.keys.mkString(", "))
+          services.get(serviceName) match {
+            case None =>
+              log.debug("consul dc %s service %s missing", dcName, serviceName)
+              NameTree.Neg
+
+            case Some(service) =>
+              log.debug("consul ns %s service %s found + %s", dcName, serviceName, residual.show)
+              NameTree.Leaf(Name.Bound(service.addrs, idPrefix ++ id, residual))
+          }
+        }
+
+      case _ =>
+        Activity.value(NameTree.Neg)
+    }
+
+  /**
+   * Contains all cached responses from the Consul API
+   */
+  private[this] object Dc {
+    private[this] val activity: ActUp[Map[String, DcCache]] =
+      Var(Activity.Pending)
+
+    /**
+     * Returns existing datacenter cache with that name
+     * or creates a new one
+     */
+    def get(name: String): DcCache = synchronized {
+      activity.sample() match {
+        case Activity.Ok(snap) =>
+          snap.get(name).getOrElse {
+            val dc = new DcCache(name, Var(Activity.Pending))
+            activity() = Activity.Ok(snap + (name -> dc))
+            dc
+          }
+
+        case _ =>
+          val dc = new DcCache(name, Var(Activity.Pending))
+          activity() = Activity.Ok(Map(name -> dc))
+          dc
+      }
+    }
+  }
+
+  /**
+   * Contains all cached serviceNodes responses for a particular serviceName in a particular datacenter
+   */
+  case class SvcCache(datacenter: String, name: String, updateableAddr: VarUp[Addr]) {
+
+    def addrs: VarUp[Addr] = updateableAddr
+
+    var index = "0"
+    val api = mkApi(name)
+    init()
+
+    def mkRequest(): Future[Seq[ServiceNode]] =
+      api.serviceNodes(name, datacenter = Some(datacenter), blockingIndex = Some(index)).map { indexedNodes =>
+        indexedNodes.index map {
+          index = _
+        }
+        indexedNodes.value
+      }
+
+    def clear(): Unit = synchronized {
+      updateableAddr() = Addr.Pending
+    }
+
+    def init(): Unit = mkRequest().map(update).handle(handleUnexpected)
+
+    def serviceNodeToAddr(node: ServiceNode): Option[SocketAddress] = {
+      (node.Address, node.ServiceAddress, node.ServicePort) match {
+        case (_, Some(addr), Some(port)) if !addr.isEmpty =>
+          Some(new InetSocketAddress(InetAddresses.forString(addr), port))
+        case (Some(addr), _, Some(port)) if !addr.isEmpty =>
+          Some(new InetSocketAddress(InetAddresses.forString(addr), port))
+        case _ => None
+      }
+    }
+
+    def update(nodes: Seq[ServiceNode]): Unit = {
+      synchronized {
+        try {
+          val socketAddrs = nodes.map(serviceNodeToAddr).flatten.toSet
+          updateableAddr() = if (socketAddrs.isEmpty) Addr.Neg else Addr.Bound(socketAddrs)
+        } catch {
+          // in the event that we are trying to parse an invalid addr
+          case e: IllegalArgumentException =>
+            updateableAddr() = Addr.Failed(e)
+        }
+      }
+      mkRequest().map(update).handle(handleUnexpected)
+    }
+
+    val handleUnexpected: PartialFunction[Throwable, Unit] = {
+      //TODO: reconnect to consul when consul gets back up
+      case e: ChannelClosedException =>
+        log.error(s"""lost consul connection while querying for $datacenter/$name updates""")
+      case e: Throwable =>
+        updateableAddr() = Addr.Failed(e)
+    }
+  }
+
+  /**
+   * Contains all cached serviceMap responses and the mapping of names
+   * to SvcCaches for a particular datacenter.
+   */
+  class DcCache(name: String, activity: ActUp[Map[String, SvcCache]]) {
+
+    def services: Var[Activity.State[Map[String, SvcCache]]] = activity
+
+    var index = "0"
+    val api = mkApi(name)
+    init()
+
+    def mkRequest(): Future[Seq[String]] =
+      api.serviceMap(datacenter = Some(name), blockingIndex = Some(index)).map { indexedSvcs =>
+        indexedSvcs.index map {
+          index = _
+        }
+        indexedSvcs.value.keySet.toSeq
+      }
+
+    def clear(): Unit = synchronized {
+      activity.sample() match {
+        case Activity.Ok(snap) =>
+          for (svc <- snap.values) {
+            svc.clear()
+          }
+        case _ =>
+      }
+      activity() = Activity.Pending
+    }
+
+    def init(): Unit =
+      mkRequest().map { serviceNames =>
+
+        val services = Map(serviceNames.map { serviceName =>
+          serviceName -> mkSvc(serviceName)
+        }: _*)
+
+        synchronized {
+          activity() = Activity.Ok(services)
+        }
+
+        mkRequest().map(update)
+      }.handle {
+        case e: UnexpectedResponse => activity() = Activity.Ok(Map.empty)
+        case e: Throwable => activity() = Activity.Failed(e)
+      }
+
+    def update(serviceNames: Seq[String]): Unit = {
+      synchronized {
+        val svcs = services.sample() match {
+          case Activity.Ok(svcs) => svcs
+          case _ => Map.empty[String, SvcCache]
+        }
+
+        serviceNames.foreach { serviceName =>
+          if (!svcs.contains(serviceName))
+            add(serviceName)
+        }
+
+        svcs.foreach {
+          case (serviceName, _) =>
+            if (!serviceNames.contains(serviceName))
+              delete(serviceName)
+        }
+      }
+
+      mkRequest().map(update)
+    }
+
+    private[this] def mkSvc(serviceName: String): SvcCache = SvcCache(name, serviceName, Var(Addr.Pending))
+
+    private[this] def add(serviceName: String): Unit = {
+      log.debug("consul added: %s", serviceName)
+      val svcs = services.sample() match {
+        case Activity.Ok(svcs) => svcs
+        case _ => Map.empty[String, SvcCache]
+      }
+      activity() = Activity.Ok(svcs + (serviceName -> mkSvc(serviceName)))
+    }
+
+    private[this] def delete(serviceName: String): Unit = {
+      log.debug("consul deleted: %s", serviceName)
+      val svcs = services.sample() match {
+        case Activity.Ok(svcs) => svcs
+        case _ => Map.empty[String, SvcCache]
+      }
+      svcs.get(serviceName) match {
+        case Some(svc) =>
+          svc.clear()
+          activity() = Activity.Ok(svcs - name)
+        case _ =>
+      }
+    }
+
+  }
+
+}
+
+object CatalogNamer {
+  val log = v1.log
+  val PrefixLen = 2
+  type VarUp[T] = Var[T] with Updatable[T]
+  type ActUp[T] = VarUp[Activity.State[T]]
+}
+

--- a/consul/src/main/scala/io/buoyant/consul/SetHostFilter.scala
+++ b/consul/src/main/scala/io/buoyant/consul/SetHostFilter.scala
@@ -1,0 +1,19 @@
+package io.buoyant.consul
+
+import com.twitter.finagle.{Service, SimpleFilter}
+import com.twitter.finagle.http.{Request, Response}
+import java.net.InetSocketAddress
+
+class SetHostFilter(hostname: String, port: Int) extends SimpleFilter[Request, Response] {
+  def this(addr: InetSocketAddress) = this(addr.getHostString, addr.getPort)
+
+  val host: String = port match {
+    case 80 | 443 => hostname
+    case port => s"$hostname:$port"
+  }
+
+  def apply(req: Request, svc: Service[Request, Response]) = {
+    req.host = host
+    svc(req)
+  }
+}

--- a/consul/src/main/scala/io/buoyant/consul/v1.scala
+++ b/consul/src/main/scala/io/buoyant/consul/v1.scala
@@ -1,0 +1,114 @@
+package io.buoyant.consul
+
+import com.fasterxml.jackson.databind.{DeserializationFeature, ObjectMapper}
+import com.fasterxml.jackson.module.scala.DefaultScalaModule
+import com.fasterxml.jackson.module.scala.experimental.ScalaObjectMapper
+import com.twitter.finagle.{Service, http}
+import com.twitter.io.Buf
+import com.twitter.logging.Logger
+import com.twitter.util._
+
+case class UnexpectedResponse(rsp: http.Response) extends Throwable
+
+/**
+ * A partial implementation of the Consul V1 API.
+ */
+package object v1 {
+
+  type Client = Service[http.Request, http.Response]
+  val versionString = "v1"
+
+  private[consul] val log = Logger.get("consul")
+
+  private[this] def mkreq(
+    method: http.Method,
+    path: String,
+    optParams: (String, Option[String])*
+  ): http.Request = {
+    val params = optParams collect { case (k, Some(v)) => (k, v) }
+    val req = http.Request(path, params: _*)
+    req.method = method
+    req
+  }
+
+  private[this] val mapper = new ObjectMapper with ScalaObjectMapper
+  mapper.registerModule(DefaultScalaModule)
+  mapper.configure(DeserializationFeature.FAIL_ON_UNKNOWN_PROPERTIES, false);
+  private[this] def readJson[T: Manifest](buf: Buf): Try[T] = {
+    val Buf.ByteArray.Owned(bytes, begin, end) = Buf.ByteArray.coerce(buf)
+    Try(mapper.readValue[T](bytes, begin, end - begin))
+  }
+
+  object Api {
+    def apply(c: Client): CatalogApi = new CatalogApi(c, s"/$versionString")
+  }
+
+  class CatalogApi(client: Client, uriPrefix: String) extends Closable {
+    def close(deadline: Time) = client.close(deadline)
+    val catalogPrefix = s"$uriPrefix/catalog"
+
+    // https://www.consul.io/docs/agent/http/catalog.html#catalog_datacenters
+    def datacenters: Future[Seq[String]] = {
+      val req = mkreq(http.Method.Get, s"$catalogPrefix/datacenters")
+      client(req).flatMap {
+        case rsp if rsp.status == http.Status.Ok =>
+          Future.const(readJson[Seq[String]](rsp.content))
+        case rsp => Future.exception(UnexpectedResponse(rsp))
+      }
+    }
+
+    // https://www.consul.io/docs/agent/http/catalog.html#catalog_services
+    def serviceMap(
+      datacenter: Option[String] = None,
+      blockingIndex: Option[String] = None
+    ): Future[Indexed[Map[String, Seq[String]]]] = {
+      val req = mkreq(
+        http.Method.Get,
+        s"$catalogPrefix/services",
+        "index" -> blockingIndex,
+        "dc" -> datacenter
+      )
+      client(req).flatMap { rsp => Future.const(Indexed.mk[Map[String, Seq[String]]](rsp)) }
+    }
+
+    // https://www.consul.io/docs/agent/http/catalog.html#catalog_service
+    def serviceNodes(
+      serviceName: String,
+      datacenter: Option[String] = None,
+      blockingIndex: Option[String] = None
+    ): Future[Indexed[Seq[ServiceNode]]] = {
+      val req = mkreq(
+        http.Method.Get,
+        s"$catalogPrefix/service/$serviceName",
+        "index" -> blockingIndex,
+        "dc" -> datacenter
+      )
+      client(req).flatMap { rsp => Future.const(Indexed.mk[Seq[ServiceNode]](rsp)) }
+    }
+  }
+
+  object Headers {
+    val Index = "X-Consul-Index"
+  }
+
+  case class Indexed[T](value: T, index: Option[String])
+  object Indexed {
+    def mk[T: Manifest](rsp: http.Response): Try[Indexed[T]] = rsp.status match {
+      case http.Status.Ok =>
+        readJson[T](rsp.content).map { t =>
+          Indexed[T](t, rsp.headerMap.get(Headers.Index))
+        }
+      case status => throw UnexpectedResponse(rsp)
+    }
+  }
+
+  case class ServiceNode(
+    Node: Option[String],
+    Address: Option[String],
+    ServiceID: Option[String],
+    ServiceName: Option[String],
+    ServiceTags: Option[Seq[String]],
+    ServiceAddress: Option[String],
+    ServicePort: Option[Int]
+  )
+}

--- a/consul/src/test/scala/io/buoyant/consul/ApiTest.scala
+++ b/consul/src/test/scala/io/buoyant/consul/ApiTest.scala
@@ -1,0 +1,89 @@
+package io.buoyant.consul.v1
+
+import com.twitter.finagle.Service
+import com.twitter.finagle.http.{Response, Request}
+import com.twitter.io.Buf
+import com.twitter.util.Future
+import io.buoyant.consul.UnexpectedResponse
+import io.buoyant.test.Awaits
+import org.scalatest.FunSuite
+
+class ApiTest extends FunSuite with Awaits {
+  val datacentersBuf = Buf.Utf8("""["dc1", "dc2"]""")
+  val nodesBuf = Buf.Utf8("""[{"Node":"Sarahs-MBP-2","Address":"192.168.1.37","ServiceID":"hosted_web","ServiceName":"hosted_web","ServiceTags":["master"],"ServiceAddress":"","ServicePort":8084}]""")
+  val mapBuf = Buf.Utf8("""{"consul":[],"hosted_web":["master"],"redis":[]}""")
+  var lastUri = ""
+
+  def stubService(buf: Buf) = Service.mk[Request, Response] { req =>
+    val rsp = Response()
+    rsp.setContentTypeJson()
+    rsp.content = buf
+    rsp.headerMap.set("X-Consul-Index", "4")
+    lastUri = req.uri
+    Future.value(rsp)
+  }
+
+  test("datacenters endpoint returns a seq of datacenter names") {
+    val service = stubService(datacentersBuf)
+
+    val response = await(Api(service).datacenters)
+    assert(response.size == 2)
+    assert(response.head == "dc1")
+  }
+
+  test("serviceNodes endpoint returns a seq of ServiceNodes") {
+    val service = stubService(nodesBuf)
+
+    val response = await(Api(service).serviceNodes("hosted_web")).value
+    assert(response.size == 1)
+    assert(response.head.ServiceName == Some("hosted_web"))
+    assert(response.head.Node == Some("Sarahs-MBP-2"))
+    assert(response.head.ServiceAddress == Some(""))
+    assert(response.head.ServicePort == Some(8084))
+  }
+
+  test("serviceMap endpoint returns a map of serviceNames to tags") {
+    val service = stubService(mapBuf)
+
+    val response = await(Api(service).serviceMap()).value
+    assert(response.get("consul") == Some(Seq.empty))
+    assert(response.get("hosted_web") == Some(Seq("master")))
+  }
+
+  test("blocking index returned from one call can be used to set index on subsequent calls") {
+    val service = stubService(mapBuf)
+    val index = await(Api(service).serviceMap()).index.get
+
+    await(Api(service).serviceMap(blockingIndex = Some(index)))
+    assert(lastUri.contains(s"index=$index"))
+  }
+
+  test("propagates client failures") {
+    val failureService = Service.mk[Request, Response] { req =>
+      Future.exception(new Exception("I have no idea who to talk to"))
+    }
+    try {
+      await(Api(failureService).serviceMap())
+      assert(false)
+    } catch {
+      case e: Exception => assert(true)
+    }
+  }
+
+  test("reports invalid datacenter as an unexpected response") {
+    val failureService = Service.mk[Request, Response] { req =>
+      val rsp = Response()
+      rsp.content = Buf.Utf8("No path to datacenter")
+      rsp.headerMap.set("X-Consul-Index", "0")
+      rsp.setStatusCode(500) //weird that they return 500 for this
+      lastUri = req.uri
+      Future.value(rsp)
+    }
+    try {
+      await(Api(failureService).serviceMap(datacenter = Some("non-existant dc")))
+      assert(false)
+    } catch {
+      case e: UnexpectedResponse => assert(true)
+    }
+  }
+}

--- a/consul/src/test/scala/io/buoyant/consul/CatalogNamerTest.scala
+++ b/consul/src/test/scala/io/buoyant/consul/CatalogNamerTest.scala
@@ -1,0 +1,223 @@
+package io.buoyant.consul
+
+import java.net.{InetSocketAddress, SocketAddress}
+
+import com.twitter.app.{GlobalFlag, Flag}
+import com.twitter.finagle._
+import com.twitter.io.Buf
+import com.twitter.util.{Activity, Future, Promise}
+import io.buoyant.consul.v1.{CatalogApi, Indexed, ServiceNode}
+import io.buoyant.test.Awaits
+import org.scalatest.FunSuite
+
+class CatalogNamerTest extends FunSuite with Awaits {
+
+  val testPath = Path.read("/test")
+  val testServiceNode = ServiceNode(
+    Some("node"),
+    Some("192.168.1.35"),
+    Some("servicename"),
+    Some("servicename"),
+    Some(Seq.empty),
+    Some(""),
+    Some(8080)
+  )
+
+  def assertOnAddrs(state: Activity.State[NameTree[Name]])(f: Set[SocketAddress] => Unit) = state match {
+    case Activity.Ok(NameTree.Leaf(bound: Name.Bound)) =>
+      bound.addr.sample() match {
+        case Addr.Bound(addrs, metadata) => f(addrs)
+        case _ => assert(false)
+      }
+    case _ => assert(false)
+  }
+
+  test("Namer stays pending while looking up datacenter for the first time") {
+    class TestApi extends CatalogApi(null, "/v1") {
+      override def serviceMap(
+        datacenter: Option[String] = None,
+        blockingIndex: Option[String] = None
+      ): Future[Indexed[Map[String, Seq[String]]]] = Future.never
+    }
+    val namer = new CatalogNamer(testPath, _ => new TestApi())
+    @volatile var state: Activity.State[NameTree[Name]] = Activity.Pending
+
+    namer.lookup(Path.read("/dc1/servicename/residual")).states respond { state = _ }
+
+    assert(state == Activity.Pending)
+  }
+
+  test("Namer fails if the consul api cannot be reached") {
+    class TestApi extends CatalogApi(null, "/v1") {
+      override def serviceMap(
+        datacenter: Option[String] = None,
+        blockingIndex: Option[String] = None
+      ): Future[Indexed[Map[String, Seq[String]]]] = Future.exception(ChannelWriteException(null))
+    }
+    val namer = new CatalogNamer(testPath, _ => new TestApi())
+    @volatile var state: Activity.State[NameTree[Name]] = Activity.Pending
+
+    namer.lookup(Path.read("/dc1/servicename/residual")).states respond { state = _ }
+
+    assert(state == Activity.Failed(ChannelWriteException(null)))
+  }
+
+  test("Namer returns neg when dc does not exist") {
+    class TestApi extends CatalogApi(null, "/v1") {
+      override def serviceMap(
+        datacenter: Option[String] = None,
+        blockingIndex: Option[String] = None
+      ): Future[Indexed[Map[String, Seq[String]]]] = blockingIndex match {
+        case Some("0") | None => Future.exception(new UnexpectedResponse(null))
+        case _ => Future.never //don't respond to blocking index calls
+      }
+
+      override def serviceNodes(
+        serviceName: String,
+        datacenter: Option[String] = None,
+        blockingIndex: Option[String] = None
+      ): Future[Indexed[Seq[ServiceNode]]] = blockingIndex match {
+        case Some("0") | None => Future.exception(new UnexpectedResponse(null))
+        case _ => Future.never //don't respond to blocking index calls
+      }
+    }
+    val namer = new CatalogNamer(testPath, _ => new TestApi())
+    @volatile var state: Activity.State[NameTree[Name]] = Activity.Pending
+
+    namer.lookup(Path.read("/nosuchdc/servicename/residual")).states respond { state = _ }
+
+    assert(state == Activity.Ok(NameTree.Neg))
+  }
+
+  test("Namer returns neg when servicename does not exist in serviceMap response") {
+    class TestApi extends CatalogApi(null, "/v1") {
+      override def serviceMap(
+        datacenter: Option[String] = None,
+        blockingIndex: Option[String] = None
+      ): Future[Indexed[Map[String, Seq[String]]]] = blockingIndex match {
+        case Some("0") | None => Future.value(Indexed(Map("consul" -> Seq.empty), Some("1")))
+        case _ => Future.never //don't respond to blocking index calls
+      }
+
+      override def serviceNodes(
+        serviceName: String,
+        datacenter: Option[String] = None,
+        blockingIndex: Option[String] = None
+      ): Future[Indexed[Seq[ServiceNode]]] = blockingIndex match {
+        case Some("0") | None => Future.value(Indexed(Seq.empty, Some("1")))
+        case _ => Future.never //don't respond to blocking index calls
+      }
+    }
+    val namer = new CatalogNamer(testPath, _ => new TestApi())
+    @volatile var state: Activity.State[NameTree[Name]] = Activity.Pending
+
+    namer.lookup(Path.read("/dc1/nosuchservice/residual")).states respond { state = _ }
+
+    assert(state == Activity.Ok(NameTree.Neg))
+  }
+
+  test("Namer updates when serviceMap blocking calls return") {
+    val blockingCallResponder = new Promise[Unit]
+
+    class TestApi extends CatalogApi(null, "/v1") {
+      override def serviceMap(
+        datacenter: Option[String] = None,
+        blockingIndex: Option[String] = None
+      ): Future[Indexed[Map[String, Seq[String]]]] = blockingIndex match {
+        case Some("0") | None => Future.value(Indexed(Map("consul" -> Seq.empty), Some("1")))
+        case Some("1") =>
+          val rsp = Map("consul" -> Seq(), "servicename" -> Seq("master", "staging"))
+          blockingCallResponder before Future.value(Indexed(rsp, Some("2")))
+        case _ => Future.never
+      }
+
+      override def serviceNodes(
+        serviceName: String,
+        datacenter: Option[String] = None,
+        blockingIndex: Option[String] = None
+      ): Future[Indexed[Seq[ServiceNode]]] = blockingIndex match {
+        case Some("0") | None => Future.value(Indexed(Seq.empty, Some("1")))
+        case _ => Future.never //don't respond to blocking index calls
+      }
+    }
+    val namer = new CatalogNamer(testPath, _ => new TestApi())
+    @volatile var state: Activity.State[NameTree[Name]] = Activity.Pending
+
+    namer.lookup(Path.read("/dc1/servicename/residual")).states respond { state = _ }
+
+    assert(state == Activity.Ok(NameTree.Neg))
+    blockingCallResponder.setDone()
+    assert(state == Activity.Ok(NameTree.Leaf(Path(Buf.Utf8("test"), Buf.Utf8("dc1"), Buf.Utf8("servicename")))))
+  }
+
+  test("Namer returns leaf with bound addr when serviceNodes exist") {
+    class TestApi extends CatalogApi(null, "/v1") {
+      override def serviceMap(
+        datacenter: Option[String] = None,
+        blockingIndex: Option[String] = None
+      ): Future[Indexed[Map[String, Seq[String]]]] = blockingIndex match {
+        case Some("0") | None =>
+          val rsp = Map("consul" -> Seq(), "servicename" -> Seq("master", "staging"))
+          Future.value(Indexed(rsp, Some("1")))
+        case _ => Future.never //don't respond to blocking index calls
+      }
+
+      override def serviceNodes(
+        serviceName: String,
+        datacenter: Option[String] = None,
+        blockingIndex: Option[String] = None
+      ): Future[Indexed[Seq[ServiceNode]]] = blockingIndex match {
+        case Some("0") | None => Future.value(Indexed[Seq[ServiceNode]](Seq(testServiceNode), Some("1")))
+        case _ => Future.never //don't respond to blocking index calls
+      }
+    }
+
+    val namer = new CatalogNamer(Path.read("/test"), s => new TestApi())
+    @volatile var state: Activity.State[NameTree[Name]] = Activity.Pending
+    namer.lookup(Path.read("/dc1/servicename/residual")).states respond { state = _ }
+
+    assertOnAddrs(state) { addrs =>
+      assert(addrs.size == 1)
+      assert(addrs.head.toString.contains("192.168.1.35:8080"))
+    }
+  }
+
+  test("Addrs update when blocking call for serviceNodes returns") {
+    val blockingCallResponder = new Promise[Unit]
+
+    class TestApi extends CatalogApi(null, "/v1") {
+      override def serviceMap(
+        datacenter: Option[String] = None,
+        blockingIndex: Option[String] = None
+      ): Future[Indexed[Map[String, Seq[String]]]] = blockingIndex match {
+        case Some("0") | None =>
+          val rsp = Map("consul" -> Seq(), "servicename" -> Seq("master", "staging"))
+          Future.value(Indexed(rsp, Some("1")))
+        case _ => Future.never //don't respond to blocking index calls
+      }
+
+      override def serviceNodes(
+        serviceName: String,
+        datacenter: Option[String] = None,
+        blockingIndex: Option[String] = None
+      ): Future[Indexed[Seq[ServiceNode]]] = blockingIndex match {
+        case Some("0") | None => Future.value(Indexed[Seq[ServiceNode]](Seq(testServiceNode), Some("1")))
+        case Some("1") => blockingCallResponder before Future.value(Indexed[Seq[ServiceNode]](Seq.empty, Some("2")))
+        case _ => Future.never
+      }
+    }
+
+    val namer = new CatalogNamer(Path.read("/test"), s => new TestApi())
+    @volatile var state: Activity.State[NameTree[Name]] = Activity.Pending
+    namer.lookup(Path.read("/dc1/servicename/residual")).states respond { state = _ }
+
+    assertOnAddrs(state) { addrs => assert(addrs.size == 1) }
+
+    blockingCallResponder.setDone()
+
+    state match {
+      case Activity.Ok(NameTree.Leaf(bound: Name.Bound)) => assert(bound.addr.sample() == Addr.Neg)
+      case _ => assert(false)
+    }
+  }
+}

--- a/linkerd/namer/consul/src/main/resources/META-INF/services/io.buoyant.linkerd.NamerInitializer
+++ b/linkerd/namer/consul/src/main/resources/META-INF/services/io.buoyant.linkerd.NamerInitializer
@@ -1,0 +1,1 @@
+io.l5d.experimental.consul

--- a/linkerd/namer/consul/src/main/scala/io/l5d/consul.scala
+++ b/linkerd/namer/consul/src/main/scala/io/l5d/consul.scala
@@ -1,0 +1,69 @@
+package io.l5d.experimental
+
+import com.fasterxml.jackson.core.JsonParser
+import com.twitter.finagle.param.Label
+import com.twitter.finagle.{Http, Path, Stack}
+import io.buoyant.consul.{CatalogNamer, v1, SetHostFilter}
+import io.buoyant.linkerd.{NamerInitializer, Parsing}
+
+/**
+ * Supports namer configurations in the form:
+ *
+ * <pre>
+ * namers:
+ * - kind: io.l5d.experimental.consul
+ *   host: consul.site.biz
+ *   port: 8600
+ * </pre>
+ */
+object consul {
+  /** The consul host; default: localhost */
+  case class Host(host: String)
+  implicit object Host extends Stack.Param[Host] {
+    val default = Host("localhost")
+    val parser = Parsing.Param.Text("host")(Host(_))
+  }
+
+  /** The consul port; default: 8500 */
+  case class Port(port: Int)
+  implicit object Port extends Stack.Param[Port] {
+    val default = Port(8500)
+    val parser = Parsing.Param.Int("port")(Port(_))
+  }
+
+  val parser = Parsing.Params(
+    Host.parser,
+    Port.parser
+  )
+
+  val defaultParams = Stack.Params.empty +
+    NamerInitializer.Prefix(Path.Utf8("io.l5d.consul"))
+}
+
+/**
+ * Configures a Consul namer.
+ */
+class consul(val params: Stack.Params) extends NamerInitializer {
+  def this() = this(consul.defaultParams)
+  def withParams(ps: Stack.Params) = new consul(ps)
+
+  def paramKeys = consul.parser.keys
+  def readParam(k: String, p: JsonParser) =
+    withParams(consul.parser.read(k, p, params))
+
+  /**
+   * Build a Namer backed by Consul.
+   */
+  def newNamer() = {
+    val consul.Host(host) = params[consul.Host]
+    val consul.Port(port) = params[consul.Port]
+    val path = params[NamerInitializer.Prefix].path.show
+    val service = Http.client
+      .configured(Label("namer" + path))
+      .filtered(new SetHostFilter(host, port))
+      .newService(s"/$$/inet/$host/$port")
+
+    def mkNs(ns: String) = v1.Api(service)
+    new CatalogNamer(prefix, mkNs)
+  }
+}

--- a/project/LinkerdBuild.scala
+++ b/project/LinkerdBuild.scala
@@ -7,6 +7,7 @@ import scala.language.implicitConversions
  * Project layout.
  *
  * - k8s/ -- finagle kubernetes client
+ * - consul/ -- consul client
  * - router/ -- finagle router libraries
  * - linkerd/ -- configuration, runtime, and modules
  * - test-util/ -- async test helpers; provided by [[Base]]
@@ -14,6 +15,11 @@ import scala.language.implicitConversions
 object LinkerdBuild extends Base {
 
   val k8s = projectDir("k8s")
+    .withLib(Deps.finagle("http"))
+    .withLibs(Deps.jackson)
+    .withTests()
+
+  val consul = projectDir("consul")
     .withLib(Deps.finagle("http"))
     .withLibs(Deps.jackson)
     .withTests()
@@ -74,8 +80,12 @@ object LinkerdBuild extends Base {
         .dependsOn(LinkerdBuild.k8s, core)
         .withTests()
 
+      val consul = projectDir("linkerd/namer/consul")
+        .dependsOn(LinkerdBuild.consul, core)
+        .withTests()
+
       val all = projectDir("linkerd/namer")
-        .aggregate(fs, k8s)
+        .aggregate(fs, k8s, consul)
     }
 
     object Protocol {
@@ -104,6 +114,7 @@ object LinkerdBuild extends Base {
   val linkerdNamer = Linkerd.Namer.all
   val linkerdNamerFs = Linkerd.Namer.fs
   val linkerdNamerK8s = Linkerd.Namer.k8s
+  val linkerdNamerConsul = Linkerd.Namer.consul
   val linkerdProtocol = Linkerd.Protocol.all
   val linkerdProtocolHttp = Linkerd.Protocol.http
   val linkerdProtocolMux = Linkerd.Protocol.mux
@@ -117,6 +128,6 @@ object LinkerdBuild extends Base {
 
   // Unified documentation via the sbt-unidoc plugin
   val all = Project("all", file("."))
-    .aggregate(k8s, Linkerd.all, Router.all, testUtil)
+    .aggregate(k8s, consul, Linkerd.all, Router.all, testUtil)
     .settings(unidocSettings)
 }


### PR DESCRIPTION
CatalogNamer, v1, and their associated tests are all c/p from our previous repo, so feel free to skip reviewing those. 

SetHostFilter is an exact c/p from the k8s folder (wasn't sure where to put it so that both modules could share it).
