### PR TITLE
API endpoint for configured routers

### DIFF
--- a/linkerd/admin/src/main/scala/io/buoyant/linkerd/admin/LinkerdAdmin.scala
+++ b/linkerd/admin/src/main/scala/io/buoyant/linkerd/admin/LinkerdAdmin.scala
@@ -18,6 +18,7 @@ object LinkerdAdmin {
     )
     HttpMuxer.addHandler("/delegator", DelegateHandler.ui(linker))
     HttpMuxer.addHandler("/delegator.json", DelegateHandler.api)
+    HttpMuxer.addHandler("/routers.json", new RouterHandler(linker))
     HttpMuxer.addHandler("/metrics", MetricsHandler)
   }
 }

--- a/linkerd/admin/src/main/scala/io/buoyant/linkerd/admin/RouterHandler.scala
+++ b/linkerd/admin/src/main/scala/io/buoyant/linkerd/admin/RouterHandler.scala
@@ -1,0 +1,88 @@
+package io.buoyant.linkerd.admin
+
+import com.fasterxml.jackson.core.JsonGenerator
+import com.fasterxml.jackson.databind._
+import com.fasterxml.jackson.databind.module.SimpleModule
+import com.fasterxml.jackson.module.scala.DefaultScalaModule
+import com.fasterxml.jackson.module.scala.experimental.ScalaObjectMapper
+import com.twitter.finagle.http._
+import com.twitter.finagle.{Status => _, _}
+import com.twitter.io.Buf
+import io.buoyant.linkerd.Server
+import com.twitter.util._
+import io.buoyant.linkerd.{Router, Linker}
+
+private[admin] object RouterHandler {
+  object Codec {
+
+    private[this] def mkModule() = {
+      val module = new SimpleModule
+
+      /**
+       * Serializes a Router in the following form
+       *
+       * {
+       *   label: "routerLabel",
+       *   protocol: "http",
+       *   servers: [...]
+       * }
+       */
+      module.addSerializer(classOf[Router], new JsonSerializer[Router] {
+        override def serialize(router: Router, json: JsonGenerator, p: SerializerProvider) {
+          json.writeStartObject()
+          json.writeStringField("label", router.label)
+          json.writeStringField("protocol", router.protocol.name)
+          json.writeFieldName("servers")
+          json.writeRawValue(writeStr(router.servers))
+          json.writeEndObject()
+        }
+      })
+
+      /**
+       * Serializes a Server in the following form
+       *
+       * {
+       *   ip: "127.0.0.1",
+       *   port: 4140,
+       * }
+       */
+      module.addSerializer(classOf[Server], new JsonSerializer[Server] {
+        override def serialize(server: Server, json: JsonGenerator, p: SerializerProvider): Unit = {
+          json.writeStartObject()
+          json.writeStringField("ip", server.ip.getHostAddress)
+          json.writeNumberField("port", server.port)
+          json.writeEndObject()
+        }
+      })
+
+      module
+    }
+
+    private[this] val mapper = new ObjectMapper with ScalaObjectMapper
+    mapper.registerModule(DefaultScalaModule)
+    mapper.registerModule(mkModule())
+
+    def writeStr[T](t: T): String = mapper.writeValueAsString(t)
+    def writeBuf[T](t: T): Buf = Buf.ByteArray.Owned(mapper.writeValueAsBytes(t))
+  }
+}
+
+private[admin] class RouterHandler(
+  linker: Linker
+) extends Service[Request, Response] {
+
+  import RouterHandler._
+
+  private def err(status: Status) = Future.value(Response(status))
+
+  def apply(req: Request): Future[Response] = req.method match {
+    case Method.Get =>
+      val rsp = req.response
+      rsp.content = Codec.writeBuf(linker.routers)
+      rsp.contentType = MediaType.Json
+      Future.value(rsp)
+
+    //TODO: include an Allow header for RFC compliance
+    case _ => err(Status.MethodNotAllowed)
+  }
+}

--- a/linkerd/admin/src/test/scala/io/buoyant/linkerd/admin/RouterHandlerTest.scala
+++ b/linkerd/admin/src/test/scala/io/buoyant/linkerd/admin/RouterHandlerTest.scala
@@ -1,0 +1,36 @@
+package io.buoyant.linkerd.admin
+
+import com.twitter.finagle.http.{Status, Request}
+import io.buoyant.linkerd._
+import io.buoyant.test.Awaits
+import org.scalatest.FunSuite
+
+class RouterHandlerTest extends FunSuite with Awaits {
+
+  // TODO: share with LinkerTest
+  def parse(
+    yaml: String
+  ) = Linker.mk(
+    TestProtocol.DefaultInitializers,
+    NamerInitializers(new TestNamer)
+  ).read(Yaml(yaml))
+
+  test("returns the names of defined routers") {
+    val linker = parse("""
+routers:
+- protocol: plain
+  servers:
+  - port: 1
+- protocol: fancy
+  servers:
+  - port: 2
+                       """)
+    val handler = new RouterHandler(linker)
+    val req = Request()
+    val rsp = await(handler(req))
+    assert(rsp.status == Status.Ok)
+    assert(rsp.contentString ==
+      s"""[{"label":"plain","protocol":"plain","servers":[{"ip":"127.0.0.1","port":1}]},""" +
+      """{"label":"fancy","protocol":"fancy","servers":[{"ip":"127.0.0.1","port":2}]}]""")
+  }
+}


### PR DESCRIPTION
Admin pages need a list of routers in order to be able to switch between them. I was originally going to just include this info as part of the html payload, but found it awkward to have to pass the linker all the way to the adminHtml rendering method. It currently renders only a small amount of router information, but we can either 1) add more to the serializer as needed or 2) replace with a config serializer once we decide on our config parsing method
