### PR TITLE
Move linkerd admin off of TwitterServer.

### DIFF
--- a/docs/config.md
+++ b/docs/config.md
@@ -10,6 +10,9 @@ described below.
 ## Example ##
 
 ```yaml
+admin:
+  port: 9990
+
 baseDtab: |
   /host     => /$/io.buoyant.fs;
   /method   => /$/io.buoyant.http.anyMethodPfx/host;
@@ -50,11 +53,18 @@ routers:
 
 ## Structure ##
 
+A configuration may define an **admin** key which is an object that configures
+the admin http interface.
+
 All configurations must define a **routers** key, the value of which
 must be an array of router configurations.
 
 Additionally, any of the [basic router params](#basic-router-params)
 may be specified in the top-level object as defaults.
+
+### Admin parameters ###
+
+* *port* -- The port on which to serve the admin http interface (default `9990`)
 
 ### Routers ###
 

--- a/linkerd/admin/src/main/scala/io/buoyant/linkerd/admin/AdminHandler.scala
+++ b/linkerd/admin/src/main/scala/io/buoyant/linkerd/admin/AdminHandler.scala
@@ -62,7 +62,6 @@ object AdminHandler {
                 <ul class="nav navbar-nav">
                   <li><a href="/delegator">dtab</a></li>
                   <li><a href="/metrics">metrics</a></li>
-                  <li><a href="/admin">admin</a></li>
                   <li><a href="/admin/logging">logging</a></li>
                   <li><a href="https://linkerd.io/help/">help</a></li>
                 </ul>

--- a/linkerd/admin/src/main/scala/io/buoyant/linkerd/admin/AdminInitializer.scala
+++ b/linkerd/admin/src/main/scala/io/buoyant/linkerd/admin/AdminInitializer.scala
@@ -1,0 +1,37 @@
+package io.buoyant.linkerd.admin
+
+import com.twitter.finagle._
+import com.twitter.finagle.http.{Request, Response}
+import com.twitter.finagle.stats.NullStatsReceiver
+import com.twitter.finagle.tracing.NullTracer
+import com.twitter.logging.{Level, Logger}
+import com.twitter.server.view.NotFoundView
+import com.twitter.util.Monitor
+import io.buoyant.linkerd.Admin
+import io.buoyant.linkerd.Admin.AdminPort
+import java.net.InetSocketAddress
+
+class AdminInitializer(admin: Admin, svc: Service[Request, Response]) {
+
+  private[this] val log = Logger()
+
+  @volatile protected var _adminHttpServer: ListeningServer = NullServer
+  def adminHttpServer: ListeningServer = _adminHttpServer
+
+  def startServer(): Unit = {
+    val loggingMonitor = new Monitor {
+      def handle(exc: Throwable): Boolean = {
+        log.log(Level.ERROR, s"Caught exception in AdminInitializer: $exc", exc)
+        false
+      }
+    }
+    val AdminPort(port) = admin.params[AdminPort]
+    log.info(s"Serving admin http on $port")
+    _adminHttpServer = Http.server
+      .configured(param.Stats(NullStatsReceiver))
+      .configured(param.Tracer(NullTracer))
+      .configured(param.Monitor(loggingMonitor))
+      .configured(param.Label("adminhttp"))
+      .serve(new InetSocketAddress(port), new NotFoundView andThen svc)
+  }
+}

--- a/linkerd/admin/src/main/scala/io/buoyant/linkerd/admin/LinkerdAdmin.scala
+++ b/linkerd/admin/src/main/scala/io/buoyant/linkerd/admin/LinkerdAdmin.scala
@@ -1,24 +1,75 @@
 package io.buoyant.linkerd.admin
 
-import com.twitter.finagle.http.HttpMuxer
-import com.twitter.server.handler.ResourceHandler
-import com.twitter.server.view.NotFoundView
+import com.twitter.app.App
+import com.twitter.finagle._
+import com.twitter.finagle.http.{HttpMuxer, Request, Response}
+import com.twitter.logging.Logger
+import com.twitter.server.Admin.Path
+import com.twitter.server.handler.{SummaryHandler => TSummaryHandler, _}
+import com.twitter.server.view.{IndexView, TextBlockView}
 import io.buoyant.linkerd.Linker
 
-object LinkerdAdmin {
-  def init(linker: Linker) {
-    HttpMuxer.addHandler("/", new NotFoundView andThen new SummaryHandler(linker))
-    HttpMuxer.addHandler(
-      "/files/",
-      StaticFilter andThen ResourceHandler.fromDirectoryOrJar(
-        baseRequestPath = "/files/",
-        baseResourcePath = "io/buoyant/linkerd/admin",
-        localFilePath = "linkerd/admin/src/main/resources/io/buoyant/linkerd/admin"
-      )
+class LinkerdAdmin(app: App, linker: Linker) {
+
+  private[this] val log = Logger()
+
+  private[this] def twitterServerRoutes: Seq[(String, Service[Request, Response])] = Seq(
+    "/admin" -> new TSummaryHandler,
+    "/admin/server_info" -> (new TextBlockView andThen new ServerInfoHandler(app)),
+    "/admin/contention" -> (new TextBlockView andThen new ContentionHandler),
+    "/admin/lint" -> new LintHandler(),
+    "/admin/lint.json" -> new LintHandler(),
+    "/admin/threads" -> new ThreadsHandler,
+    "/admin/threads.json" -> new ThreadsHandler,
+    "/admin/announcer" -> (new TextBlockView andThen new AnnouncerHandler),
+    "/admin/dtab" -> (new TextBlockView andThen new DtabHandler),
+    "/admin/pprof/heap" -> new HeapResourceHandler,
+    "/admin/pprof/profile" -> new ProfileResourceHandler(Thread.State.RUNNABLE),
+    "/admin/pprof/contention" -> new ProfileResourceHandler(Thread.State.BLOCKED),
+    "/admin/ping" -> new ReplyHandler("pong"),
+    "/admin/shutdown" -> new ShutdownHandler(app),
+    "/admin/tracing" -> new TracingHandler,
+    "/admin/logging" -> new LoggingHandler,
+    "/admin/metrics" -> new MetricQueryHandler,
+    Path.Clients -> new ClientRegistryHandler(Path.Clients),
+    Path.Servers -> new ServerRegistryHandler(Path.Servers),
+    "/admin/files/" -> ResourceHandler.fromJar(
+      baseRequestPath = "/admin/files/",
+      baseResourcePath = "twitter-server"
+    ),
+    "/admin/registry.json" -> new RegistryHandler,
+    "/favicon.ico" -> ResourceHandler.fromJar(
+      baseRequestPath = "/",
+      baseResourcePath = "twitter-server/img"
     )
-    HttpMuxer.addHandler("/delegator", DelegateHandler.ui(linker))
-    HttpMuxer.addHandler("/delegator.json", DelegateHandler.api)
-    HttpMuxer.addHandler("/routers.json", new RouterHandler(linker))
-    HttpMuxer.addHandler("/metrics", MetricsHandler)
+  ).map {
+      case (path, handler) =>
+        path -> (new IndexView(path, path, () => Nil) andThen handler)
+    }
+
+  private[this] def linkerdAdminRoutes: Seq[(String, Service[Request, Response])] = Seq(
+    "/" -> new SummaryHandler(linker),
+    "/files/" -> (StaticFilter andThen ResourceHandler.fromDirectoryOrJar(
+      baseRequestPath = "/files/",
+      baseResourcePath = "io/buoyant/linkerd/admin",
+      localFilePath = "linkerd/admin/src/main/resources/io/buoyant/linkerd/admin"
+    )),
+    "/delegator" -> DelegateHandler.ui(linker),
+    "/delegator.json" -> DelegateHandler.api,
+    "/routers.json" -> new RouterHandler(linker),
+    "/metrics" -> MetricsHandler
+  )
+
+  private[this] def metricsRoutes: Seq[(String, Service[Request, Response])] = Seq(
+    "/admin/metrics.json" -> HttpMuxer,
+    "/admin/per_host_metrics.json" -> HttpMuxer
+  )
+
+  def adminMuxer = {
+    (twitterServerRoutes ++ linkerdAdminRoutes ++ metricsRoutes).foldLeft(new HttpMuxer) {
+      case (muxer, (path, handler)) =>
+        log.info(s"$path => ${handler.getClass.getName}")
+        muxer.withHandler(path, handler)
+    }
   }
 }

--- a/linkerd/core/src/main/scala/io/buoyant/linkerd/Admin.scala
+++ b/linkerd/core/src/main/scala/io/buoyant/linkerd/Admin.scala
@@ -1,0 +1,22 @@
+package io.buoyant.linkerd
+
+import com.fasterxml.jackson.core.JsonParser
+import com.twitter.finagle.Stack
+
+case class Admin(params: Stack.Params = Stack.Params.empty) {
+
+  def read(json: JsonParser): Admin = {
+    copy(params = Admin.parser.readObject(json, params))
+  }
+}
+
+object Admin {
+  case class AdminPort(port: Int)
+  implicit object AdminPort extends Stack.Param[AdminPort] {
+    override def default: AdminPort = AdminPort(9990)
+  }
+
+  val port = Parsing.Param.Int("port")(AdminPort(_))
+
+  def parser = Parsing.Params(port)
+}

--- a/linkerd/core/src/test/scala/io/buoyant/linkerd/LinkerTest.scala
+++ b/linkerd/core/src/test/scala/io/buoyant/linkerd/LinkerTest.scala
@@ -4,6 +4,7 @@ import com.fasterxml.jackson.core.JsonToken
 import com.twitter.finagle.Dtab
 import com.twitter.finagle.buoyant.DstBindingFactory
 import com.twitter.finagle.naming.DefaultInterpreter
+import io.buoyant.linkerd.Admin.AdminPort
 import io.buoyant.router.RoutingFactory
 import java.net.{InetAddress, InetSocketAddress}
 import org.scalatest.FunSuite
@@ -189,5 +190,18 @@ routers:
     val linker = parse(yaml)
     val DstBindingFactory.Namer(namer) = linker.params[DstBindingFactory.Namer]
     assert(namer != DefaultInterpreter)
+  }
+
+  test("with admin") {
+    val yaml = """
+admin:
+  port: 9991
+routers:
+- protocol: plain
+  servers:
+  - port: 1
+"""
+    val linker = parse(yaml)
+    assert(linker.admin.params[AdminPort].port == 9991)
   }
 }

--- a/linkerd/main/src/main/scala/io/buoyant/App.scala
+++ b/linkerd/main/src/main/scala/io/buoyant/App.scala
@@ -1,0 +1,14 @@
+package io.buoyant
+
+import com.twitter.app.{App => TApp}
+import com.twitter.logging.Logging
+import com.twitter.server._
+
+trait App extends TApp
+  with Linters
+  with Logging
+  with EventSink
+  with LogFormat
+  with Hooks
+  with Lifecycle
+  with Stats


### PR DESCRIPTION
This breaks most of the TwitterServer admin page's nav.  Should be easy to port the nav stuff as well if we care about it, but I'm assuming we don't.
