### PR TITLE
Add router dropdown for dtab ui

### DIFF
--- a/linkerd/admin/src/main/resources/io/buoyant/linkerd/admin/css/admin.css
+++ b/linkerd/admin/src/main/resources/io/buoyant/linkerd/admin/css/admin.css
@@ -14,3 +14,15 @@ h1 {
 .container {
   width: 500px;
 }
+
+.open > a.dropdown-toggle, .open > a.dropdown-toggle:focus {
+  background-color: inherit !important;
+}
+
+.dropdown li {
+  margin: 0;
+}
+
+.dropdown li a {
+  padding: 10px 5px;
+}

--- a/linkerd/admin/src/main/resources/io/buoyant/linkerd/admin/js/admin.js
+++ b/linkerd/admin/src/main/resources/io/buoyant/linkerd/admin/js/admin.js
@@ -4,4 +4,36 @@ $(function() {
   // highlight current page in navbar
   var path = window.location.pathname;
   $('a[href="' + path + '"]').parent().addClass("current");
+
+  var matches = window.location.search.match(/router=(.+)(?:&|$)/)
+  if (matches && matches.length > 1) {
+    var label = decodeURIComponent(matches[1]);
+    $(".dropdown-toggle .router-label").text(label)
+  }
 });
+
+$.when(
+  $.get("/files/template/router_option.template"),
+  $.get("/routers.json")
+).done(function(templateRsp, routers) {
+  var template = Handlebars.compile(templateRsp[0])
+  var routerHtml = routers[0].map(template);
+
+  $(".dropdown-menu").html(routerHtml.join(""));
+
+  $(".router-menu-option").click(function() {
+    selectRouter($(this).text());
+  });
+});
+
+function selectRouter(label) {
+  var uriComponent = "router=" + encodeURIComponent(label);
+  var re = /router=(.+)(?:&|$)/
+  if (window.location.search == "") {
+    window.location.search = uriComponent;
+  } else if (window.location.search.match(re)) {
+    window.location.search = window.location.search.replace(re, uriComponent);
+  } else {
+    window.location.search = window.location.search + "&" + uriComponent;
+  }
+}

--- a/linkerd/admin/src/main/resources/io/buoyant/linkerd/admin/js/delegate.js
+++ b/linkerd/admin/src/main/resources/io/buoyant/linkerd/admin/js/delegate.js
@@ -8,15 +8,33 @@ $.when(
 ).done(function(dentryRsp, nodeRsp){
   templates.dentry = Handlebars.compile(dentryRsp[0]);
   templates.node = Handlebars.compile(nodeRsp[0]);
-  var dtab = JSON.parse($("#data").html());
-  var dtabViewer = new DtabViewer(dtab, templates.dentry);
-  $(function(){
-    $('.go').click(function(e){
-      e.preventDefault();
-      var path = $('.path input').val();
-      $.get("delegator.json?" + $.param({ n: path, d: dtabViewer.dtabStr() }), renderAll);
+  var dtabMap = JSON.parse($("#data").html());
+
+  var selectedRouter = $(".dropdown-toggle .router-label").text();
+  var dtab = dtabMap[selectedRouter];
+
+  if (!dtab) {
+    var defaultRouter = $(".router-menu-option:first").text();
+    if (dtabMap[defaultRouter]) {
+      selectRouter(defaultRouter);
+    } else {
+      console.warn("undefined router:", selectedRouter);
+    }
+  } else {
+    //TODO: remove this once dropdown is site-wide
+    $(".nav .dropdown").removeClass("hide");
+
+    $(".router-label-title").text("Router \"" + selectedRouter + "\"");
+
+    var dtabViewer = new DtabViewer(dtab, templates.dentry);
+    $(function(){
+      $('.go').click(function(e){
+        e.preventDefault();
+        var path = $('.path input').val();
+        $.get("delegator.json?" + $.param({ n: path, d: dtabViewer.dtabStr() }), renderAll);
+      });
     });
-  });
+  }
 });
 
 $(function() {

--- a/linkerd/admin/src/main/resources/io/buoyant/linkerd/admin/template/router_option.template
+++ b/linkerd/admin/src/main/resources/io/buoyant/linkerd/admin/template/router_option.template
@@ -1,0 +1,1 @@
+<li><a href='#' class='router-menu-option'>{{label}}</a></li>

--- a/linkerd/admin/src/main/scala/io/buoyant/linkerd/admin/AdminHandler.scala
+++ b/linkerd/admin/src/main/scala/io/buoyant/linkerd/admin/AdminHandler.scala
@@ -2,7 +2,6 @@ package io.buoyant.linkerd.admin
 
 import com.twitter.finagle.http.{MediaType, Request, Response}
 import com.twitter.finagle.{Service, SimpleFilter}
-import com.twitter.server.TwitterServer
 import com.twitter.util.Future
 
 object AdminHandler {
@@ -44,21 +43,30 @@ object AdminHandler {
         </head>
         <body>
           <nav class="navbar navbar-inverse navbar-fixed-top">
-          <div class="container">
-            <div class="navbar-header">
-              <a class="navbar-brand-img" href="/">
-                <img alt="Logo" src="/files/images/logo.svg">
-              </a>
-            </div>
-            <div id="navbar" class="collapse navbar-collapse">
-              <ul class="nav navbar-nav">
-                <li><a href="/delegator">dtab</a></li>
-                <li><a href="/metrics">metrics</a></li>
-                <li><a href="/admin">admin</a></li>
-                <li><a href="/admin/logging">logging</a></li>
-                <li><a href="https://linkerd.io/help/">help</a></li>
-              </ul>
-            </div>
+            <ul class="nav navbar-nav navbar-right">
+              <li class="dropdown hide">
+                <a href="#" class="dropdown-toggle" data-toggle="dropdown" role="button" aria-haspopup="true" aria-expanded="false">
+                  <span class="router-label">All</span> <span class="caret"></span>
+                </a>
+                <ul class="dropdown-menu">
+                </ul>
+              </li>
+            </ul>
+            <div class="container">
+              <div class="navbar-header">
+                <a class="navbar-brand-img" href="/">
+                  <img alt="Logo" src="/files/images/logo.svg">
+                </a>
+              </div>
+              <div id="navbar" class="collapse navbar-collapse">
+                <ul class="nav navbar-nav">
+                  <li><a href="/delegator">dtab</a></li>
+                  <li><a href="/metrics">metrics</a></li>
+                  <li><a href="/admin">admin</a></li>
+                  <li><a href="/admin/logging">logging</a></li>
+                  <li><a href="https://linkerd.io/help/">help</a></li>
+                </ul>
+              </div>
             </div>
           </nav>
 
@@ -71,6 +79,7 @@ object AdminHandler {
           <script src="/files/js/lib/jquery.min.js"></script>
           <script src="/files/js/lib/bootstrap.min.js"></script>
           <script src="/files/js/lib/lodash.min.js"></script>
+          <script src="/files/js/lib/handlebars-v4.0.5.js"></script>
           <script src="/files/js/admin.js"></script>
           $javaScriptsHtml
         </body>

--- a/linkerd/admin/src/main/scala/io/buoyant/linkerd/admin/MetricsHandler.scala
+++ b/linkerd/admin/src/main/scala/io/buoyant/linkerd/admin/MetricsHandler.scala
@@ -30,7 +30,7 @@ private object MetricsHandler extends Service[Request, Response] {
           </div>
         </div>
       """,
-      javaScripts = Seq("lib/handlebars-v4.0.5.js", "lib/smoothie.js", "utils.js", "metrics.js"),
+      javaScripts = Seq("lib/smoothie.js", "utils.js", "metrics.js"),
       csses = Seq("metrics.css")
     )
 }

--- a/linkerd/admin/src/main/scala/io/buoyant/linkerd/admin/SummaryHandler.scala
+++ b/linkerd/admin/src/main/scala/io/buoyant/linkerd/admin/SummaryHandler.scala
@@ -73,7 +73,7 @@ private object SummaryHandler {
         <div id="server-info" class="interfaces"></div>
       """,
       csses = Seq("summary.css"),
-      javaScripts = Seq("lib/handlebars-v4.0.5.js", "lib/smoothie.js", "utils.js", "routers.js", "summary.js")
+      javaScripts = Seq("lib/smoothie.js", "utils.js", "routers.js", "summary.js")
     )
   }
 }


### PR DESCRIPTION
![screen shot 2016-01-26 at 1 42 56 pm](https://cloud.githubusercontent.com/assets/41829/12596743/49c98ecc-c436-11e5-922e-73c3d429b608.png)
My hope is the dropdown can be used across all pages eventually to filter metrics based on router label. For now the dropdown is hidden on all pages except the dtab ui.
