### PR TITLE
CSS tweaks for the summary and metrics page

### DIFF
--- a/linkerd/admin/src/main/resources/io/buoyant/linkerd/admin/css/metrics.css
+++ b/linkerd/admin/src/main/resources/io/buoyant/linkerd/admin/css/metrics.css
@@ -1,17 +1,13 @@
-.metrics {
-  padding: 0 20px 0 20px;
+body {
+  padding-top: 64px;
 }
 
 .metrics-names {
-  padding: 0;
+  padding: 15px;
 }
 
 .metrics-list {
-  border-left: 1px solid lightgray;
-  border-top: 1px solid lightgray;
-  border-bottom: 1px solid lightgray;
   margin-bottom: 0;
-  height: 350px;
   overflow-y: auto;
   overflow-x: hidden;
 }
@@ -32,6 +28,7 @@
 
 .metrics-list li.selected {
   background-color: #dfdfdf;
+  border-radius: 5px;
 }
 
 #metrics-title {
@@ -46,13 +43,14 @@
 .metrics-graph {
   text-align: center;
   height: 350px;
-  border: 1px solid lightgray;
   padding: 0 10px 0 10px;
+  position: fixed;
+  right: 10px;
+  top: 100px;
 }
 
 .metrics-json {
-  margin-top: 10px;
-  font-size: 20px;
+  float:left;
 }
 
 .metrics-json a {

--- a/linkerd/admin/src/main/resources/io/buoyant/linkerd/admin/css/summary.css
+++ b/linkerd/admin/src/main/resources/io/buoyant/linkerd/admin/css/summary.css
@@ -82,6 +82,7 @@
   overflow: hidden;
   text-decoration: none;
   text-overflow: ellipsis;
+  white-space: nowrap;
 }
 
 .interface hr {

--- a/linkerd/admin/src/main/resources/io/buoyant/linkerd/admin/template/interfaces.template
+++ b/linkerd/admin/src/main/resources/io/buoyant/linkerd/admin/template/interfaces.template
@@ -8,7 +8,7 @@
         <h6 class="sr-header col-sm-5">success rate</h6>
       </div>
       <hr>
-      <div class="row name">
+      <div class="row name" title="{{name}}">
         <a href="/metrics#{{requestsKey}}">{{name}}</a>
       </div>
       <div class="row connections">

--- a/linkerd/admin/src/main/scala/io/buoyant/linkerd/admin/MetricsHandler.scala
+++ b/linkerd/admin/src/main/scala/io/buoyant/linkerd/admin/MetricsHandler.scala
@@ -18,16 +18,17 @@ private object MetricsHandler extends Service[Request, Response] {
             <div class="metrics-names col-sm-3"></div>
             <div class="metrics-graph col-sm-9">
               <div id="metrics-title">
+                <div class="metrics-json">
+                  <span>Raw data: </span>
+                  <a href="/admin/metrics.json">/admin/metrics.json</a>
+                </div>
                 <span class="name">&nbsp;</span>
                 <span class="value stat">&nbsp;</span>
               </div>
               <canvas id="metrics-canvas" height="300"></canvas>
             </div>
           </div>
-          <div class="row metrics-json">
-            <span>Raw data: </span>
-            <a href="/admin/metrics.json">/admin/metrics.json</a>
-          </div>
+
         </div>
       """,
       javaScripts = Seq("lib/handlebars-v4.0.5.js", "lib/smoothie.js", "utils.js", "metrics.js"),


### PR DESCRIPTION
I moved metrics out of its little box so it's easier to scroll through the metrics:

![screen shot 2016-01-27 at 1 51 51 pm](https://cloud.githubusercontent.com/assets/41829/12629724/f8419464-c4fd-11e5-882c-36cb45d60a5c.png)

Also added white-space: nowrap because the summary interface names were in some cases (mostly if there's a dash in the name) wrapping and causing layout issues.

Also added a summary title so that hovering over a name will show the non-ellipses'd name
