### PR TITLE
release 0.0.9

### DIFF
--- a/project/Base.scala
+++ b/project/Base.scala
@@ -12,7 +12,7 @@ class Base extends Build {
 
   val orgSettings = Seq(
     organization := "io.buoyant",
-    version := "0.0.9",
+    version := "0.0.10-SNAPSHOT",
     homepage := Some(url("https://linkerd.io"))
   )
 


### PR DESCRIPTION
These commits must not be squashed, or the release-0.0.9 tag will not correlate with a real commit.
