### PR TITLE
Run ./sbt assembly in CI

### DIFF
--- a/circle.yml
+++ b/circle.yml
@@ -16,4 +16,4 @@ test:
   override:
   # unfortunately these have to be two separate sbt commands ¯\_(ツ)_/¯
   - ./sbt coverage test && ./sbt coverageAggregate
-  - ./sbt e2e:test
+  - ./sbt e2e:test assembly


### PR DESCRIPTION
We should make sure that our bundles are still buildable on every commit.  This branch also includes two scalariform fixes that were automatically applied when running tests.
