### PR TITLE
Move Delegator off global Namers and onto linkerd NameInterpreters

### DIFF
--- a/linkerd/admin/src/main/scala/io/buoyant/linkerd/admin/DelegateHandler.scala
+++ b/linkerd/admin/src/main/scala/io/buoyant/linkerd/admin/DelegateHandler.scala
@@ -17,7 +17,7 @@ private object DelegateHandler {
     new DelegateHandler(dtabs)
   }
 
-  def api = new WebDelegator
+  def api(linker: Linker) = new WebDelegator(linker)
 
   def render(dtab: Map[String, Dtab]) =
     AdminHandler.adminHtml(

--- a/linkerd/admin/src/main/scala/io/buoyant/linkerd/admin/LinkerdAdmin.scala
+++ b/linkerd/admin/src/main/scala/io/buoyant/linkerd/admin/LinkerdAdmin.scala
@@ -55,7 +55,7 @@ class LinkerdAdmin(app: App, linker: Linker) {
       localFilePath = "linkerd/admin/src/main/resources/io/buoyant/linkerd/admin"
     )),
     "/delegator" -> DelegateHandler.ui(linker),
-    "/delegator.json" -> DelegateHandler.api,
+    "/delegator.json" -> DelegateHandler.api(linker),
     "/routers.json" -> new RouterHandler(linker),
     "/metrics" -> MetricsHandler
   )

--- a/linkerd/core/src/main/scala/io/buoyant/linkerd/NamerInitializers.scala
+++ b/linkerd/core/src/main/scala/io/buoyant/linkerd/NamerInitializers.scala
@@ -76,7 +76,7 @@ object NamerInitializers {
 
   val empty: NamerInitializers = _NamerInitializers(Map.empty)
 
-  private case class Interpreter(namers: Seq[(Path, Namer)] = Seq.empty)
+  case class Interpreter(namers: Seq[(Path, Namer)] = Seq.empty)
     extends NameInterpreter {
     private[NamerInitializers] def naming(p: Path, n: Namer) =
       copy(namers = namers :+ (p -> n))
@@ -109,5 +109,8 @@ object NamerInitializers {
         // Not a match, keep looking through namers.
         case Seq(_, namers@_*) => lookup(namers, path)
       }
+
+    def lookup(path: Path): Activity[NameTree[Name]] =
+      lookup(namers, path)
   }
 }


### PR DESCRIPTION
This is a big review for what is ostensibly a one-line change. We now pass in the linker namer instead of relying on Namer.global
