### PR TITLE
0.0.9 release take 2

### DIFF
--- a/project/Base.scala
+++ b/project/Base.scala
@@ -13,7 +13,7 @@ class Base extends Build {
 
   val orgSettings = Seq(
     organization := "io.buoyant",
-    version := "0.0.9",
+    version := "0.0.10-SNAPSHOT",
     homepage := Some(url("https://linkerd.io"))
   )
 


### PR DESCRIPTION
These commits must not be squashed, or the 0.0.9-release tag will not correlate with a real commit.
