### PR TITLE
fix metrics scrollIntoView not being in view

### DIFF
--- a/linkerd/admin/src/main/resources/io/buoyant/linkerd/admin/css/metrics.css
+++ b/linkerd/admin/src/main/resources/io/buoyant/linkerd/admin/css/metrics.css
@@ -1,5 +1,7 @@
-body {
-  padding-top: 64px;
+.metrics {
+  position: fixed;
+  width: 100%;
+  top: 64px;
 }
 
 .metrics-names {
@@ -9,7 +11,7 @@ body {
 .metrics-list {
   margin-bottom: 0;
   overflow-y: auto;
-  overflow-x: hidden;
+  max-height: calc(100vh - 100px);
 }
 
 .metrics-list li {

--- a/linkerd/admin/src/main/resources/io/buoyant/linkerd/admin/js/metrics.js
+++ b/linkerd/admin/src/main/resources/io/buoyant/linkerd/admin/js/metrics.js
@@ -12,6 +12,21 @@ $.when(
 
 function init(template, json) {
 
+  var metricRe = /.*\.(avg|count|max|min|p50|p90|p95|p99|p9990|p9999|sum)$/;
+
+  // init metrics browser
+  var metrics = _(json)
+    .map(function(value, name){
+      if (!name.match(metricRe)) {
+        return name;
+      }
+    })
+    .compact()
+    .sort()
+    .value();
+
+  $('.metrics').html(template({ 'metrics': metrics }));
+
   var canvas = document.getElementById("metrics-canvas");
 
   // init chart
@@ -47,20 +62,6 @@ function init(template, json) {
     chart.setMetric(li.attr("id"));
   }
 
-  var metricRe = /.*\.(avg|count|max|min|p50|p90|p95|p99|p9990|p9999|sum)$/
-
-  // init metrics browser
-  var metrics = _(json)
-    .map(function(value, name){
-      if (!name.match(metricRe)) {
-        return name;
-      }
-    })
-    .compact()
-    .sort()
-    .value();
-
-  $('.metrics-names').html(template({ 'metrics': metrics }));
   $('.metrics-list li').on('click', function(e) {
     var li = $(e.target);
     var selector = "#"+li.attr("id");

--- a/linkerd/admin/src/main/resources/io/buoyant/linkerd/admin/template/metrics.template
+++ b/linkerd/admin/src/main/resources/io/buoyant/linkerd/admin/template/metrics.template
@@ -1,7 +1,22 @@
-<ul class="metrics-list list-unstyled">
-  {{#each metrics}}
-    <li id={{.}}>
-      {{.}}
-    </li>
-  {{/each}}
-</ul>
+<div class="row">
+  <div class="metrics-names col-sm-3">
+    <ul class="metrics-list list-unstyled">
+      {{#each metrics}}
+        <li id={{.}}>
+          {{.}}
+        </li>
+      {{/each}}
+    </ul>
+  </div>
+  <div class="metrics-graph col-sm-9">
+    <div id="metrics-title">
+      <div class="metrics-json">
+        <span>Raw data: </span>
+        <a href="/admin/metrics.json">/admin/metrics.json</a>
+      </div>
+      <span class="name">&nbsp;</span>
+      <span class="value stat">&nbsp;</span>
+    </div>
+    <canvas id="metrics-canvas" height="300"></canvas>
+  </div>
+</div>

--- a/linkerd/admin/src/main/scala/io/buoyant/linkerd/admin/MetricsHandler.scala
+++ b/linkerd/admin/src/main/scala/io/buoyant/linkerd/admin/MetricsHandler.scala
@@ -14,21 +14,6 @@ private object MetricsHandler extends Service[Request, Response] {
     AdminHandler.adminHtml(
       content = s"""
         <div class="metrics">
-          <div class="row">
-            <div class="metrics-names col-sm-3"></div>
-            <div class="metrics-graph col-sm-9">
-              <div id="metrics-title">
-                <div class="metrics-json">
-                  <span>Raw data: </span>
-                  <a href="/admin/metrics.json">/admin/metrics.json</a>
-                </div>
-                <span class="name">&nbsp;</span>
-                <span class="value stat">&nbsp;</span>
-              </div>
-              <canvas id="metrics-canvas" height="300"></canvas>
-            </div>
-          </div>
-
         </div>
       """,
       javaScripts = Seq("lib/smoothie.js", "utils.js", "metrics.js"),


### PR DESCRIPTION
this fixes the currently selected metric not scrolling into view on page load. also moved more of the metrics page out of scala into a template.

for example, http://localhost:9990/metrics#jvm/classes/total_loaded:

before:
![before](https://cloud.githubusercontent.com/assets/236915/12800096/8e581976-ca87-11e5-9aab-bf010da36d6d.png)

after:
![after](https://cloud.githubusercontent.com/assets/236915/12800103/9491ee3e-ca87-11e5-99cd-26de0fbb2cca.png)
