### PR TITLE
Enable filtering summary and metrics pages by router

### DIFF
--- a/linkerd/admin/src/main/resources/io/buoyant/linkerd/admin/css/admin.css
+++ b/linkerd/admin/src/main/resources/io/buoyant/linkerd/admin/css/admin.css
@@ -11,12 +11,6 @@ h1 {
   margin-top: 20px;
 }
 
-@media (min-width: 992px) {
-  .container {
-    width: 500px;
-  }
-}
-
 .open > a.dropdown-toggle, .open > a.dropdown-toggle:focus {
   background-color: inherit !important;
 }

--- a/linkerd/admin/src/main/resources/io/buoyant/linkerd/admin/js/admin.js
+++ b/linkerd/admin/src/main/resources/io/buoyant/linkerd/admin/js/admin.js
@@ -1,5 +1,7 @@
 "use strict";
 
+var SINGLE_ROUTER_PAGES_ONLY = SINGLE_ROUTER_PAGES_ONLY || false;
+
 $(function() {
   // highlight current page in navbar
   var path = window.location.pathname;
@@ -15,9 +17,16 @@ $(function() {
 $.when(
   $.get("/files/template/router_option.template"),
   $.get("/routers.json")
-).done(function(templateRsp, routers) {
-  var template = Handlebars.compile(templateRsp[0])
-  var routerHtml = routers[0].map(template);
+).done(function(templateRsp, routersRsp) {
+  var template = Handlebars.compile(templateRsp[0]);
+  var routers = routersRsp[0];
+
+  //Not every page supports a mult-router view!
+  if(!SINGLE_ROUTER_PAGES_ONLY) {
+    routers.unshift({label: "all"});
+  }
+
+  var routerHtml = routers.map(template);
 
   $(".dropdown-menu").html(routerHtml.join(""));
 
@@ -27,6 +36,11 @@ $.when(
 });
 
 function selectRouter(label) {
+  if (label === "all") {
+    unselectRouter();
+    return;
+  }
+
   var uriComponent = "router=" + encodeURIComponent(label);
   var re = /router=(.+)(?:&|$)/
   if (window.location.search == "") {
@@ -36,4 +50,13 @@ function selectRouter(label) {
   } else {
     window.location.search = window.location.search + "&" + uriComponent;
   }
+}
+
+function unselectRouter() {
+  var re = /router=(.+)(?:&|$)/
+  window.location.search = window.location.search.replace(re, "");
+}
+
+function getSelectedRouter() {
+  return $(".dropdown-toggle .router-label").text();
 }

--- a/linkerd/admin/src/main/resources/io/buoyant/linkerd/admin/js/delegate.js
+++ b/linkerd/admin/src/main/resources/io/buoyant/linkerd/admin/js/delegate.js
@@ -1,6 +1,7 @@
 "use strict";
 
 var templates = {};
+var SINGLE_ROUTER_PAGES_ONLY = true;
 
 $.when(
   $.get("/files/template/dentry.template"),
@@ -10,7 +11,7 @@ $.when(
   templates.node = Handlebars.compile(nodeRsp[0]);
   var dtabMap = JSON.parse($("#data").html());
 
-  var selectedRouter = $(".dropdown-toggle .router-label").text();
+  var selectedRouter = getSelectedRouter();
   var dtab = dtabMap[selectedRouter];
 
   if (!dtab) {
@@ -21,9 +22,6 @@ $.when(
       console.warn("undefined router:", selectedRouter);
     }
   } else {
-    //TODO: remove this once dropdown is site-wide
-    $(".nav .dropdown").removeClass("hide");
-
     $(".router-label-title").text("Router \"" + selectedRouter + "\"");
 
     var dtabViewer = new DtabViewer(dtab, templates.dentry);

--- a/linkerd/admin/src/main/resources/io/buoyant/linkerd/admin/js/metrics.js
+++ b/linkerd/admin/src/main/resources/io/buoyant/linkerd/admin/js/metrics.js
@@ -13,12 +13,20 @@ $.when(
 function init(template, json) {
 
   var metricRe = /.*\.(avg|count|max|min|p50|p90|p95|p99|p9990|p9999|sum)$/;
+  var routers = Routers(json);
+  var selectedRouter = getSelectedRouter();
+  var router = routers.data[selectedRouter];
 
   // init metrics browser
   var metrics = _(json)
     .map(function(value, name){
       if (!name.match(metricRe)) {
-        return name;
+        if (router) { //filter on router if it exists
+          var matchingRouter = routers.findMatchingRouter(name);
+          return matchingRouter && matchingRouter.label == router.label ? name : null;
+        } else {
+          return name;
+        }
       }
     })
     .compact()

--- a/linkerd/admin/src/main/resources/io/buoyant/linkerd/admin/js/routers.js
+++ b/linkerd/admin/src/main/resources/io/buoyant/linkerd/admin/js/routers.js
@@ -147,7 +147,10 @@ var Routers = (function() {
       update: function(metrics) { update(this.data, metrics); },
 
       /** Finds a scope (router, dst, or server) associated with a scoped metric name. */
-      findByMetricKey: function(key) { return findByMetricKey(this.data, key); }
+      findByMetricKey: function(key) { return findByMetricKey(this.data, key); },
+
+      /** Finds a router associated with a scoped metric name. */
+      findMatchingRouter: function(key) { return findMatchingRouter(this.data, key); }
     };
   };
 })();

--- a/linkerd/admin/src/main/scala/io/buoyant/linkerd/admin/AdminHandler.scala
+++ b/linkerd/admin/src/main/scala/io/buoyant/linkerd/admin/AdminHandler.scala
@@ -66,7 +66,7 @@ object AdminHandler {
                 </ul>
 
                 <ul class="nav navbar-nav navbar-right">
-                  <li class="dropdown hide">
+                  <li class="dropdown">
                     <a href="#" class="dropdown-toggle" data-toggle="dropdown" role="button" aria-haspopup="true" aria-expanded="false">
                       <span class="router-label">All</span> <span class="caret"></span>
                     </a>

--- a/linkerd/admin/src/main/scala/io/buoyant/linkerd/admin/MetricsHandler.scala
+++ b/linkerd/admin/src/main/scala/io/buoyant/linkerd/admin/MetricsHandler.scala
@@ -16,7 +16,7 @@ private object MetricsHandler extends Service[Request, Response] {
         <div class="metrics">
         </div>
       """,
-      javaScripts = Seq("lib/smoothie.js", "utils.js", "metrics.js"),
+      javaScripts = Seq("lib/smoothie.js", "utils.js", "routers.js", "metrics.js"),
       csses = Seq("metrics.css")
     )
 }


### PR DESCRIPTION
The router dropdown now affects all admin pages by filtering metrics not relevant to the selected router.

![screen shot 2016-02-03 at 4 46 48 pm](https://cloud.githubusercontent.com/assets/41829/12801980/ce3d0516-ca95-11e5-803f-08b87e0b10d2.png)
