### PR TITLE
Add TlsClientInitializer.

### DIFF
--- a/docs/config.md
+++ b/docs/config.md
@@ -106,6 +106,21 @@ destinations. Protocols may set defaults.
 * *failFast* -- If `true`, connection failures are punished more
 aggressively. Should not be used with small destination pools.
 * *timeoutMs* -- Per-request timeout in milliseconds.
+* *tls* -- The router will make requests using TLS if this parameter is
+provided.  It must be an object containing keys:
+  * *kind* -- One of the supported TlsClientInitializer plugins, by
+  fully-qualified class name.
+  * Any options specific to the plugin
+  Current plugins include:
+  * *io.l5d.clientTls.noValidation*: Skip hostname validation.  This is unsafe.
+  * *io.l5d.clietnTls.static*: Use a single common name for all TLS
+  requests.  This assumes that all servers that the router connects to all use
+  the same TLS cert (or all use certs generated with the same common name).
+  This plugin supports the following options:
+    * *commonName* -- Required.  The common name to use for all TLS requests.
+    * *caCertPath* -- Optional.  Use the given CA cert for common name
+    validation.
+
 
 <!-- TODO router capacity  -->
 

--- a/linkerd/admin/src/test/scala/io/buoyant/linkerd/admin/RouterHandlerTest.scala
+++ b/linkerd/admin/src/test/scala/io/buoyant/linkerd/admin/RouterHandlerTest.scala
@@ -12,7 +12,8 @@ class RouterHandlerTest extends FunSuite with Awaits {
     yaml: String
   ) = Linker.mk(
     TestProtocol.DefaultInitializers,
-    NamerInitializers(new TestNamer)
+    NamerInitializers(new TestNamer),
+    TlsClientInitializers.empty
   ).read(Yaml(yaml))
 
   test("returns the names of defined routers") {

--- a/linkerd/admin/src/test/scala/io/buoyant/linkerd/admin/SummaryHandlerTest.scala
+++ b/linkerd/admin/src/test/scala/io/buoyant/linkerd/admin/SummaryHandlerTest.scala
@@ -3,7 +3,7 @@ package io.buoyant.linkerd.admin
 import com.twitter.finagle.Service
 import com.twitter.finagle.http.{MediaType, Request, Response, Status}
 import com.twitter.util.Future
-import io.buoyant.linkerd.{Build, Linker, NamerInitializers, TestNamer, TestProtocol, Yaml}
+import io.buoyant.linkerd._
 import io.buoyant.test.Awaits
 import org.scalatest.FunSuite
 
@@ -14,7 +14,8 @@ class SummaryHandlerTest extends FunSuite with Awaits {
     yaml: String
   ) = Linker.mk(
     TestProtocol.DefaultInitializers,
-    NamerInitializers(new TestNamer)
+    NamerInitializers(new TestNamer),
+    TlsClientInitializers.empty
   ).read(Yaml(yaml))
 
   val linker = parse("""

--- a/linkerd/admin/src/test/scala/io/buoyant/linkerd/admin/names/DelegatorTest.scala
+++ b/linkerd/admin/src/test/scala/io/buoyant/linkerd/admin/names/DelegatorTest.scala
@@ -13,9 +13,9 @@ class DelegatorTest extends FunSuite with Awaits {
     yaml: String,
     protos: ProtocolInitializers = TestProtocol.DefaultInitializers,
     namers: NamerInitializers = NamerInitializers(new TestNamer)
-  ) = Linker.mk(protos, namers).read(Yaml(yaml))
+  ) = Linker.mk(protos, namers, TlsClientInitializers.empty).read(Yaml(yaml))
 
-    val linker = parse("""
+  val linker = parse("""
 namers:
 - kind: io.buoyant.linkerd.TestNamer
   prefix: /namer
@@ -46,7 +46,8 @@ routers:
       Return(DelegateTree.Delegate(path, Dentry.nop, DelegateTree.Leaf(
         Path.read("/namer/bro"),
         Dentry.read("/nah=>/namer"),
-        Name.Bound(Var.value(Addr.Pending), Path.read("/namer"), Path.Utf8("bro"))))))
+        Name.Bound(Var.value(Addr.Pending), Path.read("/namer"), Path.Utf8("bro"))
+      ))))
   }
 
   test("explain neg delegation") {

--- a/linkerd/admin/src/test/scala/io/buoyant/linkerd/admin/names/WebDelegatorTest.scala
+++ b/linkerd/admin/src/test/scala/io/buoyant/linkerd/admin/names/WebDelegatorTest.scala
@@ -14,7 +14,7 @@ class WebDelegatorTest extends FunSuite with Awaits {
     yaml: String,
     protos: ProtocolInitializers = TestProtocol.DefaultInitializers,
     namers: NamerInitializers = NamerInitializers(new TestNamer)
-  ) = Linker.mk(protos, namers).read(Yaml(yaml))
+  ) = Linker.mk(protos, namers, TlsClientInitializers.empty).read(Yaml(yaml))
 
   val linker = parse("""
 namers:

--- a/linkerd/core/src/main/scala/io/buoyant/linkerd/Parsing.scala
+++ b/linkerd/core/src/main/scala/io/buoyant/linkerd/Parsing.scala
@@ -63,7 +63,7 @@ object Parsing {
 
   def skipValue(json: JsonParser): Unit =
     json.getCurrentToken match {
-      case JsonToken.START_ARRAY =>
+      case JsonToken.START_ARRAY | JsonToken.START_OBJECT =>
         json.skipChildren()
         json.nextToken()
       case tok =>

--- a/linkerd/core/src/main/scala/io/buoyant/linkerd/ProtocolInitializer.scala
+++ b/linkerd/core/src/main/scala/io/buoyant/linkerd/ProtocolInitializer.scala
@@ -67,6 +67,12 @@ trait ProtocolInitializer {
       }
       InitializedRouter(protocol, params, factory, servable)
     }
+
+    override def tlsFrom(tls: TlsClientInitializers, p: JsonParser): Router = {
+      val tlsPrep = tls.read[RouterReq, RouterRsp](p)
+      val clientStack = router.clientStack.replace(Stack.Role("TlsClientPrep"), tlsPrep)
+      copy(router = router.withClientStack(clientStack))
+    }
   }
 
   def router: Router = ProtocolRouter(defaultRouter)

--- a/linkerd/core/src/main/scala/io/buoyant/linkerd/TlsClientInitializer.scala
+++ b/linkerd/core/src/main/scala/io/buoyant/linkerd/TlsClientInitializer.scala
@@ -1,0 +1,90 @@
+package io.buoyant.linkerd
+
+import com.fasterxml.jackson.core.{JsonParser, JsonToken, TreeNode}
+import com.twitter.finagle.Stack
+import com.twitter.finagle.buoyant.TlsClientPrep
+
+/**
+ * Loadable TLS client configuration module.
+ *
+ * Implementers may read params from the config file and must produce a
+ * TlsClientPrep module which will control how this router makes TLS requests.
+ */
+trait TlsClientInitializer {
+
+  /** Configuration state. */
+  def params: Stack.Params
+
+  /** Create a new TlsClientInitializer with a new configuration */
+  def withParams(ps: Stack.Params): TlsClientInitializer
+
+  /** Append the given param to the configuration */
+  def configured[P: Stack.Param](p: P): TlsClientInitializer = withParams(params + p)
+
+  /** List of param names that are readable by this namer. */
+  def paramKeys: Set[String]
+
+  /**
+   * Read the value for parameter named `key`.  An error is thrown if
+   * `key` is not in `paramKeys`.
+   */
+  def readParam(key: String, p: JsonParser): TlsClientInitializer
+
+  /** The TslClientPrep module that will be used to make TLS requests */
+  def tlsClientPrep[Req, Rsp]: TlsClientPrep.Module[Req, Rsp]
+}
+
+object TlsClientInitializer {
+
+  /**
+   * Read a single TlsClientInitializer configuration in the form:
+   *
+   * <pre>
+   *   kind: io.l5d.FooTlsClient
+   *   foo: bar
+   * </pre>
+   */
+  private[linkerd] def read(getTls: String => Option[TlsClientInitializer], p: JsonParser): TlsClientInitializer = {
+    val obj = Parsing.ensureTok(p, JsonToken.START_OBJECT) { p =>
+      p.readValueAsTree(): TreeNode
+    }
+    p.nextToken()
+
+    val tlsClientInitializer: TlsClientInitializer = {
+      val t = obj.traverse()
+      t.setCodec(p.getCodec)
+      t.nextToken()
+      t.overrideCurrentName("tls")
+      Parsing.findInObject(t) {
+        case ("kind", p) =>
+          Parsing.ensureTok(p, JsonToken.VALUE_STRING) { p =>
+            val kind = p.getText()
+            p.nextToken()
+            getTls(kind) match {
+              case None => throw Parsing.error(s"unknown tls kind: '$kind'", p)
+              case Some(tls) => tls
+            }
+          }
+      } match {
+        case None => throw Parsing.error(s"tls requires a 'kind' attribute", p)
+        case Some(tls) => tls
+      }
+    }
+
+    val t = obj.traverse()
+    t.setCodec(p.getCodec)
+    t.nextToken()
+    t.overrideCurrentName("tls")
+    Parsing.foldObject(t, tlsClientInitializer) {
+      case (tls, "kind", p) =>
+        Parsing.skipValue(p)
+        tls
+
+      case (tls, key, p) if tls.paramKeys(key) =>
+        tls.readParam(key, p)
+
+      case (_, key, p) =>
+        throw Parsing.error(s"unexpected tls attribute: '$key'", p)
+    }
+  }
+}

--- a/linkerd/core/src/main/scala/io/buoyant/linkerd/TlsClientInitializers.scala
+++ b/linkerd/core/src/main/scala/io/buoyant/linkerd/TlsClientInitializers.scala
@@ -1,0 +1,59 @@
+package io.buoyant.linkerd
+
+import com.fasterxml.jackson.core.{JsonToken, JsonParser}
+import com.twitter.finagle.buoyant.TlsClientPrep
+import com.twitter.finagle.util.LoadService
+
+/**
+ * A collection of TlsClientInitializer modules that are available to be used
+ * to configure the way that TLS requests are sent.  Note that while several
+ * TlsClientInitializer modules can be loaded, each router can only use at most
+ * one of them.
+ */
+trait TlsClientInitializers {
+  def kinds: Set[String]
+  def get(k: String): Option[TlsClientInitializer]
+
+  /**
+   * Reads a tls section of a router config, finds the appropriate
+   * TlsClientInitializer based on the kind field, configures the
+   * TlsClientInitializer, and then produces a TlsClientPrep module.
+   */
+  def read[Req, Rsp](p: JsonParser): TlsClientPrep.Module[Req, Rsp]
+}
+
+object TlsClientInitializers {
+
+  def apply(initializers: TlsClientInitializer*): TlsClientInitializers = {
+    val byKind = initializers.groupBy(_.getClass.getName).map {
+      case (kind, Seq(tci)) => kind -> tci
+      case (kind, _) => throw new IllegalArgumentException(s"TlsClientInitializer kind conflict: '$kind'")
+    }
+    _TlsClientInitializers(byKind)
+  }
+
+  private case class _TlsClientInitializers(initializers: Map[String, TlsClientInitializer])
+    extends TlsClientInitializers {
+
+    def kinds = initializers.keySet
+    def get(k: String) = initializers.get(k)
+
+    def read[Req, Rsp](p: JsonParser): TlsClientPrep.Module[Req, Rsp] =
+      Parsing.ensureTok(p, JsonToken.START_OBJECT) { p =>
+        TlsClientInitializer.read(this.get, p).tlsClientPrep
+      }
+  }
+
+  /**
+   * Runtime-loaded TlsClientInitializer modules.
+   *
+   * Uses finagle's `LoadService` facility to discover protocol
+   * support at runtime by searching the class path for
+   * TlsClientInitializer subclasses.
+   */
+  def load(): TlsClientInitializers = {
+    apply(LoadService[TlsClientInitializer]: _*)
+  }
+
+  def empty: TlsClientInitializers = _TlsClientInitializers(Map.empty)
+}

--- a/linkerd/core/src/test/scala/io/buoyant/linkerd/LinkerTest.scala
+++ b/linkerd/core/src/test/scala/io/buoyant/linkerd/LinkerTest.scala
@@ -15,7 +15,7 @@ class LinkerTest extends FunSuite {
     yaml: String,
     protos: ProtocolInitializers = TestProtocol.DefaultInitializers,
     namers: NamerInitializers = NamerInitializers(new TestNamer)
-  ) = Linker.mk(protos, namers).read(Yaml(yaml))
+  ) = Linker.mk(protos, namers, TlsClientInitializers.empty).read(Yaml(yaml))
 
   test("basic") {
     val linker = parse("""

--- a/linkerd/core/src/test/scala/io/buoyant/linkerd/RouterTest.scala
+++ b/linkerd/core/src/test/scala/io/buoyant/linkerd/RouterTest.scala
@@ -11,7 +11,7 @@ class RouterTest extends FunSuite {
     yaml: String,
     params: Stack.Params = Stack.Params.empty,
     protos: ProtocolInitializers = TestProtocol.DefaultInitializers
-  ) = Router.read(Yaml(yaml), params, protos)
+  ) = Router.read(Yaml(yaml), params, protos, TlsClientInitializers.empty)
 
   test("with label") {
     val yaml = """

--- a/linkerd/protocol/http/src/e2e/scala/io/buoyant/linkerd/protocol/HttpEndToEndTest.scala
+++ b/linkerd/protocol/http/src/e2e/scala/io/buoyant/linkerd/protocol/HttpEndToEndTest.scala
@@ -81,7 +81,7 @@ routers:
 """
 
     val protocols = ProtocolInitializers(new HttpInitializer)
-    val linker = Linker.mk(protocols, NamerInitializers.empty)
+    val linker = Linker.mk(protocols, NamerInitializers.empty, TlsClientInitializers.empty)
       .configured(param.Stats(stats))
       .configured(param.Tracer(tracer))
       .read(Yaml(yaml))

--- a/linkerd/protocol/http/src/integration/scala/io/buoyant/linkerd/protocol/HttpsIntegrationTest.scala
+++ b/linkerd/protocol/http/src/integration/scala/io/buoyant/linkerd/protocol/HttpsIntegrationTest.scala
@@ -2,6 +2,7 @@ package io.buoyant.linkerd
 package protocol
 
 import com.twitter.conversions.time._
+import com.twitter.finagle.transport.Transport
 import com.twitter.finagle.{Http => FinagleHttp, _}
 import com.twitter.finagle.http._
 import com.twitter.finagle.netty3.Netty3TransporterTLSConfig
@@ -11,6 +12,7 @@ import com.twitter.finagle.tracing.{BufferingTracer, NullTracer}
 import com.twitter.util._
 import io.buoyant.router.Http
 import io.buoyant.test.Awaits
+import io.l5d.clientTls.{noValidation, static}
 import java.io.{File, FileInputStream}
 import java.net.{InetAddress, InetSocketAddress, SocketAddress}
 import java.security.KeyStore
@@ -25,46 +27,32 @@ class HttpsIntegrationTest extends FunSuite with Awaits {
   override val defaultWait = 2.seconds
 
   test("tls server + plain backend") {
-    // First, we create a CA and get a cert/key for linker
-    val tmpdir = new File("mktemp -d -t linkerd-tls".!!.stripLineEnd)
-    try {
-      val configFile = mkCaDirs(tmpdir)
-
-      val caCert = new File(tmpdir, "cacert.pem")
-      val caKey = new File(tmpdir, "private/cakey.pem")
-      assert(run(newKeyAndCert("/C=US/CN=Test CA", configFile, caKey, caCert)) == 0)
-
-      val routerReq = new File(tmpdir, "routerreq.pem")
-      val routerCert = new File(tmpdir, "routercert.pem")
-      val routerKey = new File(tmpdir, "private/routerkey.pem")
-      assert(run(newReq("/C=US/CN=linkerd", configFile, routerReq, routerKey)) == 0)
-
-      assert(run(signReq(configFile, caKey, caCert, routerReq, routerCert)) == 0)
-      // routerCert has the server's cert, signed by caCert
-
+    withCerts { certs =>
       val dog = Downstream.const("dogs", "woof")
       try {
-        val linkerConfig = s"""
-        |routers:
-        |- protocol: http
-        |  baseDtab: |
-        |    /p/dog => /$$/inet/127.1/${dog.port} ;
-        |    /http/1.1/GET/clifford => /p/dog ;
-        |  servers:
-        |  - port: 0
-        |    tls:
-        |      certPath: ${routerCert.getPath}
-        |      keyPath: ${routerKey.getPath}
-        |""".stripMargin
+        val linkerConfig =
+          s"""
+             |routers:
+             |- protocol: http
+             |  baseDtab: |
+             |    /p/dog => /$$/inet/127.1/${dog.port} ;
+             |    /http/1.1/GET/clifford => /p/dog ;
+             |  servers:
+             |  - port: 0
+             |    tls:
+             |      certPath: ${certs.routerCert.getPath}
+             |      keyPath: ${certs.routerKey.getPath}
+             |""".
+            stripMargin
         val protocols = ProtocolInitializers(new HttpInitializer)
-        val linker = Linker.mk(protocols, NamerInitializers.empty)
+        val linker = Linker.mk(protocols, NamerInitializers.empty, TlsClientInitializers.empty)
           .read(Yaml(linkerConfig))
 
         val router = linker.routers.head.initialize()
         try {
           val server = router.servers.head.serve()
           try {
-            val client = upstream(server, "linkerd", caCert)
+            val client = upstreamTls(server, "linkerd", certs.caCert)
             try {
               val rsp = {
                 val req = Request()
@@ -73,12 +61,138 @@ class HttpsIntegrationTest extends FunSuite with Awaits {
               }
               assert(rsp.contentString == "woof")
 
-            } finally(await(client.close()))
-          } finally(await(server.close()))
-        } finally(await(router.close()))
-      } finally(await(dog.server.close()))
-    } finally(Seq("echo", "rm", "-rf", tmpdir.getPath).!)
+            } finally (await(client.close()))
+          } finally (await(server.close()))
+        } finally (await(router.close()))
+      } finally (await(dog.server.close()))
+    }
   }
+
+  test("tls router + plain upstream without validation") {
+    withCerts { certs =>
+      val dog = Downstream.constTls("dogs", "woof", certs.routerCert, certs.routerKey)
+      try {
+        val linkerConfig =
+          s"""
+             |routers:
+             |- protocol: http
+             |  baseDtab: |
+             |    /p/dog => /$$/inet/127.1/${dog.port} ;
+             |    /http/1.1/GET/clifford => /p/dog ;
+             |  servers:
+             |  - port: 0
+             |  tls:
+             |    kind: io.l5d.clientTls.noValidation
+             |""".
+            stripMargin
+        val protocols = ProtocolInitializers(new HttpInitializer)
+        val tls = TlsClientInitializers(new noValidation)
+        val linker = Linker.mk(protocols, NamerInitializers.empty, tls)
+          .read(Yaml(linkerConfig))
+        val router = linker.routers.head.initialize()
+        try {
+          val server = router.servers.head.serve()
+          try {
+            val client = upstream(server)
+            try {
+              val rsp = {
+                val req = Request()
+                req.host = "clifford"
+                await(client(req))
+              }
+              assert(rsp.contentString == "woof")
+
+            } finally (await(client.close()))
+          } finally (await(server.close()))
+        } finally (await(router.close()))
+      } finally (await(dog.server.close()))
+    }
+  }
+
+  test("tls router + plain upstream with static validation") {
+    withCerts { certs =>
+      val dog = Downstream.constTls("dogs", "woof", certs.routerCert, certs.routerKey)
+      try {
+        val linkerConfig =
+          s"""
+             |routers:
+             |- protocol: http
+             |  baseDtab: |
+             |    /p/dog => /$$/inet/127.1/${dog.port} ;
+             |    /http/1.1/GET/clifford => /p/dog ;
+             |  servers:
+             |  - port: 0
+             |  tls:
+             |    kind: io.l5d.clientTls.static
+             |    commonName: linkerd
+             |    caCertPath: ${certs.caCert.getPath}
+             |""".
+            stripMargin
+        val protocols = ProtocolInitializers(new HttpInitializer)
+        val tls = TlsClientInitializers(new static)
+        val linker = Linker.mk(protocols, NamerInitializers.empty, tls)
+          .read(Yaml(linkerConfig))
+        val router = linker.routers.head.initialize()
+        try {
+          val server = router.servers.head.serve()
+          try {
+            val client = upstream(server)
+            try {
+              val rsp = {
+                val req = Request()
+                req.host = "clifford"
+                await(client(req))
+              }
+              assert(rsp.contentString == "woof")
+
+            } finally (await(client.close()))
+          } finally (await(server.close()))
+        } finally (await(router.close()))
+      } finally (await(dog.server.close()))
+    }
+  }
+
+  test("tls router + plain upstream with static validation and incorrect common name") {
+    withCerts { certs =>
+      val dog = Downstream.constTls("dogs", "woof", certs.routerCert, certs.routerKey)
+      try {
+        val linkerConfig =
+          s"""
+             |routers:
+             |- protocol: http
+             |  baseDtab: |
+             |    /p/dog => /$$/inet/127.1/${dog.port} ;
+             |    /http/1.1/GET/clifford => /p/dog ;
+             |  servers:
+             |  - port: 0
+             |  tls:
+             |    kind: io.l5d.clientTls.static
+             |    commonName: wrong
+             |    caCertPath: ${certs.caCert.getPath}
+             |""".
+            stripMargin
+        val protocols = ProtocolInitializers(new HttpInitializer)
+        val tls = TlsClientInitializers(new static)
+        val linker = Linker.mk(protocols, NamerInitializers.empty, tls)
+          .read(Yaml(linkerConfig))
+        val router = linker.routers.head.initialize()
+        try {
+          val server = router.servers.head.serve()
+          try {
+            val client = upstream(server)
+            try {
+              val rsp = {
+                val req = Request()
+                req.host = "clifford"
+                intercept[Failure](await(client(req)))
+              }
+            } finally (await(client.close()))
+          } finally (await(server.close()))
+        } finally (await(router.close()))
+      } finally (await(dog.server.close()))
+    }
+  }
+
 
   /*
    * helpers
@@ -90,7 +204,30 @@ class HttpsIntegrationTest extends FunSuite with Awaits {
     p
   }
 
-  def upstream(server: ListeningServer, tlsName: String, caCert: File) = {
+  case class Certs(caCert: File, routerCert: File, routerKey: File)
+  def withCerts(f: Certs => Unit): Unit = {
+    // First, we create a CA and get a cert/key for linker
+    val tmpdir = new File("mktemp -d -t linkerd-tls".!!.stripLineEnd)
+    try {
+      val configFile = mkCaDirs (tmpdir)
+
+      val caCert = new File (tmpdir, "cacert.pem")
+      val caKey = new File (tmpdir, "private/cakey.pem")
+      assert (run (newKeyAndCert ("/C=US/CN=Test CA", configFile, caKey, caCert) ) == 0)
+
+      val routerReq = new File (tmpdir, "routerreq.pem")
+      val routerCert = new File (tmpdir, "routercert.pem")
+      val routerKey = new File (tmpdir, "private/routerkey.pem")
+      assert (run (newReq ("/C=US/CN=linkerd", configFile, routerReq, routerKey) ) == 0)
+
+      assert (run (signReq (configFile, caKey, caCert, routerReq, routerCert) ) == 0)
+      // routerCert has the server's cert, signed by caCert
+
+      f (Certs (caCert, routerCert, routerKey) )
+    } finally(Seq("echo", "rm", "-rf", tmpdir.getPath).!)
+  }
+
+  def upstreamTls(server: ListeningServer, tlsName: String, caCert: File) = {
     val address = server.boundAddress.asInstanceOf[InetSocketAddress]
 
     // Establish an SSL context that uses our generated certificate.
@@ -117,6 +254,17 @@ class HttpsIntegrationTest extends FunSuite with Awaits {
       .newClient(name, "upstream").toService
   }
 
+  def upstream(server: ListeningServer) = {
+    val address = server.boundAddress.asInstanceOf[InetSocketAddress]
+
+    val name = Name.Bound(Var.value(Addr.Bound(address)), address)
+    FinagleHttp.client
+      .configured(param.Stats(NullStatsReceiver))
+      .configured(param.Tracer(NullTracer))
+      .transformed(_.remove(TlsFilter.role)) // do NOT rewrite Host headers using tlsName
+      .newClient(name, "upstream").toService
+  }
+
   case class Downstream(name: String, server: ListeningServer) {
     val address = server.boundAddress.asInstanceOf[InetSocketAddress]
     val port = address.getPort
@@ -136,8 +284,29 @@ class HttpsIntegrationTest extends FunSuite with Awaits {
       Downstream(name, server)
     }
 
+    def mkTls(name: String, cert: File, key: File)(f: Request=>Response): Downstream = {
+      val service = Service.mk { req: Request => Future(f(req)) }
+      val server = FinagleHttp.server
+        .configured(param.Label(name))
+        .configured(param.Tracer(NullTracer))
+        .configured(
+          Transport.TLSServerEngine(
+            Some(() => Ssl.server(cert.getPath, key.getPath, null, null, null))
+          )
+        )
+        .serve(":*", service)
+      Downstream(name, server)
+    }
+
     def const(name: String, value: String): Downstream =
       mk(name) { _ =>
+        val rsp = Response()
+        rsp.contentString = value
+        rsp
+      }
+
+    def constTls(name: String, value: String, cert: File, key: File): Downstream =
+      mkTls(name, cert, key) { _ =>
         val rsp = Response()
         rsp.contentString = value
         rsp

--- a/linkerd/tls/src/main/resources/META-INF/services/io.buoyant.linkerd.TlsClientInitializer
+++ b/linkerd/tls/src/main/resources/META-INF/services/io.buoyant.linkerd.TlsClientInitializer
@@ -1,0 +1,2 @@
+io.l5d.clientTls.noValidation
+io.l5d.clientTls.static

--- a/linkerd/tls/src/main/scala/io/l5d/clientTls/noValidation.scala
+++ b/linkerd/tls/src/main/scala/io/l5d/clientTls/noValidation.scala
@@ -1,0 +1,23 @@
+package io.l5d.clientTls
+
+import com.fasterxml.jackson.core.JsonParser
+import com.twitter.finagle.Stack
+import com.twitter.finagle.Stack.Params
+import com.twitter.finagle.buoyant.TlsClientPrep
+import io.buoyant.linkerd.TlsClientInitializer
+
+object noValidation {
+  val defaultParams = Stack.Params.empty
+}
+
+class noValidation(val params: Stack.Params) extends TlsClientInitializer {
+  def this() = this(noValidation.defaultParams)
+
+  override def withParams(ps: Params) = new noValidation(ps)
+
+  override def paramKeys: Set[String] = Set.empty
+
+  override def tlsClientPrep[Req, Rsp] = TlsClientPrep.withoutCertificateValidation[Req, Rsp]
+
+  override def readParam(key: String, p: JsonParser): TlsClientInitializer = this
+}

--- a/linkerd/tls/src/main/scala/io/l5d/clientTls/static.scala
+++ b/linkerd/tls/src/main/scala/io/l5d/clientTls/static.scala
@@ -1,0 +1,49 @@
+package io.l5d.clientTls
+
+import com.fasterxml.jackson.core.JsonParser
+import com.twitter.finagle.Stack
+import com.twitter.finagle.Stack.Params
+import com.twitter.finagle.buoyant.TlsClientPrep
+import io.buoyant.linkerd.{Parsing, TlsClientInitializer}
+import io.l5d.clientTls.static.{CaCert, CommonName}
+
+object static {
+  val defaultParams = Stack.Params.empty
+
+  case class CommonName(name: String)
+  implicit object CommonName extends Stack.Param[CommonName] {
+    override def default = CommonName("")
+  }
+
+  case class CaCert(path: Option[String])
+  implicit object CaCert extends Stack.Param[CaCert] {
+    override def default = CaCert(None)
+  }
+
+  val commonName = Parsing.Param.Text("commonName") { name =>
+    CommonName(name)
+  }
+
+  val caCert = Parsing.Param.Text("caCertPath") { path =>
+    CaCert(Some(path))
+  }
+
+  val parser = Parsing.Params(commonName, caCert)
+}
+
+class static(val params: Stack.Params) extends TlsClientInitializer {
+  def this() = this(static.defaultParams)
+
+  override def withParams(ps: Params) = new static(ps)
+
+  override def paramKeys: Set[String] = static.parser.keys
+
+  override def tlsClientPrep[Req, Rsp] = {
+    val CommonName(name) = params[CommonName]
+    val CaCert(caCert) = params[CaCert]
+    TlsClientPrep.static[Req, Rsp](name, caCert)
+  }
+
+  override def readParam(key: String, p: JsonParser): TlsClientInitializer =
+    withParams(static.parser.read(key, p, params))
+}

--- a/project/LinkerdBuild.scala
+++ b/project/LinkerdBuild.scala
@@ -104,6 +104,7 @@ object LinkerdBuild extends Base {
         .withTests().withE2e().withIntegration()
         .dependsOn(
           core % "compile->compile;e2e->test;integration->test",
+          tls % "test",
           Router.http)
 
       val mux = projectDir("linkerd/protocol/mux")
@@ -116,8 +117,11 @@ object LinkerdBuild extends Base {
         .aggregate(http, mux, thrift)
     }
 
+    val tls = projectDir("linkerd/tls")
+      .dependsOn(core)
+
     val all = projectDir("linkerd")
-      .aggregate(admin, core, main, Namer.all, Protocol.all)
+      .aggregate(admin, core, main, Namer.all, Protocol.all, tls)
       .configs(Minimal, Bundle)
       // Minimal cofiguration includes a runtime, HTTP routing and the
       // fs service discovery.
@@ -183,6 +187,7 @@ object LinkerdBuild extends Base {
   val linkerdProtocolHttp = Linkerd.Protocol.http
   val linkerdProtocolMux = Linkerd.Protocol.mux
   val linkerdProtocolThrift = Linkerd.Protocol.thrift
+  val linkerdTls = Linkerd.tls
   val router = Router.all
   val routerCore = Router.core
   val routerHttp = Router.http

--- a/router/http/src/main/scala/io/buoyant/router/Http.scala
+++ b/router/http/src/main/scala/io/buoyant/router/Http.scala
@@ -30,6 +30,7 @@ object Http extends Router[Request, Response] with FinagleServer[Request, Respon
      * Install better http tracing and prevent TLS/Host-header interference.
      */
     val client: StackClient[Request, Response] = FinagleHttp.client
+      .transformed(StackRouter.Client.mkStack(_))
       .transformed(_.replace(StackClient.Role.protoTracing, http.TracingFilter))
       .transformed(_.remove(TlsFilter.role))
 


### PR DESCRIPTION
Fixes #63 

A TlsClientInitializer will read configuration from the tls key in the router
config and provide a TlsClientPrep module which is used to configure TLS in
the client.  Two TlsClientInitializers are provided: NoValidationTlsClient
which skips hostname validation and StaticTlsClient which uses a fixed
hostname and optional CA cert for all clients.
