### PR TITLE
domainToPath and domainToPathPfx rewrite namers

### DIFF
--- a/linkerd/admin/src/main/scala/io/buoyant/linkerd/admin/AdminInitializer.scala
+++ b/linkerd/admin/src/main/scala/io/buoyant/linkerd/admin/AdminInitializer.scala
@@ -10,6 +10,7 @@ import com.twitter.util.Monitor
 import io.buoyant.linkerd.Admin
 import io.buoyant.linkerd.Admin.AdminPort
 import java.net.InetSocketAddress
+import scala.util.Properties
 
 class AdminInitializer(admin: Admin, svc: Service[Request, Response]) {
 
@@ -22,6 +23,7 @@ class AdminInitializer(admin: Admin, svc: Service[Request, Response]) {
     val loggingMonitor = new Monitor {
       def handle(exc: Throwable): Boolean = {
         log.log(Level.ERROR, s"Caught exception in AdminInitializer: $exc", exc)
+        log.log(Level.ERROR, exc.getStackTrace().mkString("", Properties.lineSeparator, Properties.lineSeparator))
         false
       }
     }

--- a/router/http/src/main/scala/io/buoyant/http/namer.scala
+++ b/router/http/src/main/scala/io/buoyant/http/namer.scala
@@ -136,6 +136,40 @@ class subdomainOfPfx extends RewritingNamer {
 }
 
 /**
+ * A rewriting namer that accepts names in the form:
+ *
+ *   /foo.buoyant.io/resource/name
+ *
+ * and rewrites to:
+ *
+ *   /io/buoyant/foo/resource/name
+ */
+class domainToPath extends RewritingNamer {
+  protected[this] def rewrite(path: Path) = path.take(1) match {
+    case Path.Utf8(host@Match.host()) =>
+      Some(Path.Utf8(host.split("\\.").reverse: _*) ++ path.drop(1))
+    case _ => None
+  }
+}
+
+/**
+ * A rewriting namer that accepts names in the form:
+ *
+ *   /pfx/foo.buoyant.io/resource/name
+ *
+ * and rewrites to:
+ *
+ *   /pfx/io/buoyant/foo/resource/name
+ */
+class domainToPathPfx extends RewritingNamer {
+  protected[this] def rewrite(path: Path) = path.take(2) match {
+    case Path.Utf8(pfx, host@Match.host()) =>
+      Some(Path.Utf8(pfx +: host.split("\\.").reverse: _*) ++ path.drop(2))
+    case _ => None
+  }
+}
+
+/**
  * A service namer that accepts names in the form:
  *
  *   /400/resource/name

--- a/router/http/src/test/scala/io/buoyant/http/NamerTest.scala
+++ b/router/http/src/test/scala/io/buoyant/http/NamerTest.scala
@@ -61,6 +61,16 @@ class NamerTest extends FunSuite with Awaits {
     assert(lookup(path) == NameTree.Leaf(Name.Path(Path.Utf8("foo", "bar", "bah"))))
   }
 
+  test("domainToPath") {
+    val path = Path.read("/$/io.buoyant.http.domainToPath/foo.buoyant.io")
+    assert(lookup(path) == NameTree.Leaf(Name.Path(Path.Utf8("io", "buoyant", "foo"))))
+  }
+
+  test("domainToPathPfx") {
+    val path = Path.read("/$/io.buoyant.http.domainToPathPfx/pfx/foo.buoyant.io")
+    assert(lookup(path) == NameTree.Leaf(Name.Path(Path.Utf8("pfx", "io", "buoyant", "foo"))))
+  }
+
   test("status") {
     val client = Http.newService("/$/io.buoyant.http.status/401/foo/bar.a.b/bah")
     val rsp = await(client(Request()))


### PR DESCRIPTION
Fixes #68 

There's no external documentation yet for rewriting namers. I'm unsure whether to add docs now since they might be changing (#26)? 

Here's usage:

```
- protocol: http
  baseDtab: |
    /serverset/io/buoyant => /io.l5d.fs;
    /host => /$/io.buoyant.http.domainToPathPfx/serverset;
    /method => /$/io.buoyant.http.anyMethodPfx/host;
    /http/1.1 => /method;
```
