### PR TITLE
Add url paths and better error handling to dtab ui.

### DIFF
--- a/linkerd/admin/src/main/resources/io/buoyant/linkerd/admin/js/delegate.js
+++ b/linkerd/admin/src/main/resources/io/buoyant/linkerd/admin/js/delegate.js
@@ -5,10 +5,13 @@ var SINGLE_ROUTER_PAGES_ONLY = true;
 
 $.when(
   $.get("/files/template/dentry.template"),
-  $.get("/files/template/delegatenode.template")
-).done(function(dentryRsp, nodeRsp){
+  $.get("/files/template/delegatenode.template"),
+  $.get("/files/template/error_modal.template")
+).done(function(dentryRsp, nodeRsp, modalRsp){
   templates.dentry = Handlebars.compile(dentryRsp[0]);
   templates.node = Handlebars.compile(nodeRsp[0]);
+  templates.errorModal = Handlebars.compile(modalRsp[0]);
+
   var dtabMap = JSON.parse($("#data").html());
 
   var selectedRouter = getSelectedRouter();
@@ -25,11 +28,17 @@ $.when(
     $(".router-label-title").text("Router \"" + selectedRouter + "\"");
 
     var dtabViewer = new DtabViewer(dtab, templates.dentry);
+    $('#path-input').val(decodeURIComponent(window.location.hash).slice(1));
     $(function(){
       $('.go').click(function(e){
         e.preventDefault();
-        var path = $('.path input').val();
-        $.get("delegator.json?" + $.param({ n: path, d: dtabViewer.dtabStr() }), renderAll);
+        var path = $('#path-input').val();
+        window.location.hash = encodeURIComponent(path);
+        var request = $.get("delegator.json?" + $.param({ n: path, d: dtabViewer.dtabStr() }), renderAll);
+        request.fail(function( jqXHR ) {
+          $(".error-modal").html(templates.errorModal(jqXHR.statusText));
+          $('.error-modal').modal();
+        });
       });
     });
   }

--- a/linkerd/admin/src/main/resources/io/buoyant/linkerd/admin/template/error_modal.template
+++ b/linkerd/admin/src/main/resources/io/buoyant/linkerd/admin/template/error_modal.template
@@ -1,0 +1,12 @@
+<div class="modal-dialog modal-sm">
+  <div class="modal-content">
+    <div class="modal-header">
+      <button type="button" class="close" data-dismiss="modal" aria-label="Close"><span aria-hidden="true">&times;</span></button>
+      <h4 class="modal-title">Whoops!</h4>
+    </div>
+    <div class="modal-body">
+      <p>Looks like there was an issue completing your request.</p>
+      <pre>{{.}}</pre>
+    </div>
+  </div>
+</div>

--- a/linkerd/admin/src/main/scala/io/buoyant/linkerd/admin/DelegateHandler.scala
+++ b/linkerd/admin/src/main/scala/io/buoyant/linkerd/admin/DelegateHandler.scala
@@ -48,6 +48,8 @@ private object DelegateHandler {
         </div>
         <div class="result">
         </div>
+        <div class="modal fade error-modal" tabindex="-1" role="dialog">
+        </div>
       """,
       tailContent = s"""
         <script id="data" type="application/json">${WebDelegator.Codec.writeStr(dtab)}</script>


### PR DESCRIPTION
Now the dtab input field will stay filled in on page refresh.
Also adds an error modal that appears when there's an exception
(before this, nothing would happen, as if the page was
unresponsive)

<img width="1261" alt="screen shot 2016-02-08 at 12 19 34 pm" src="https://cloud.githubusercontent.com/assets/41829/12901325/d8d9cb66-ce6f-11e5-8e92-645a50cd8f80.png">
