### PR TITLE
Force resampling when L5D-Sample header is present

### DIFF
--- a/linkerd/protocol/http/src/main/scala/com/twitter/finagle/buoyant/linkerd/HttpTraceInitializer.scala
+++ b/linkerd/protocol/http/src/main/scala/com/twitter/finagle/buoyant/linkerd/HttpTraceInitializer.scala
@@ -57,10 +57,7 @@ object HttpTraceInitializer {
         sampler match {
           case Some(sampler) =>
             val id = Trace.id
-            val sampled = id._sampled match {
-              case None => id.copy(_sampled = Some(sampler(id.traceId.toLong)))
-              case _ => id
-            }
+            val sampled = id.copy(_sampled = Some(sampler(id.traceId.toLong)))
             Trace.letId(sampled)(f)
           case _ => f
         }


### PR DESCRIPTION
I made a last-minute change in #89 that inadvertently broke the behavior of the L5D-Sample header.  It turns out we _always_ want to resample the current request ID if the L5D-Sample header is present with the request.
