### PR TITLE
Include tls as part of the sbt bundle

### DIFF
--- a/project/LinkerdBuild.scala
+++ b/project/LinkerdBuild.scala
@@ -130,7 +130,8 @@ object LinkerdBuild extends Base {
       // Bundle is includes all of the supported features:
       .configDependsOn(Bundle)(
         Namer.consul, Namer.k8s, Namer.serversets,
-        Protocol.mux, Protocol.thrift)
+        Protocol.mux, Protocol.thrift,
+        tls)
       .settings(inConfig(Bundle)(BundleSettings))
       .settings(
         assembly <<= assembly in Bundle,


### PR DESCRIPTION
fixes error

```
io.buoyant.linkerd.Parsing$Error: unknown tls kind: 'io.l5d.clientTls.noValidation'
```

when using example config 

```
routers:
- protocol: http
  baseDtab: |
    /host     => /io.l5d.fs;
    /host     => /io.l5d.consul/dc1;
    /method   => /$/io.buoyant.http.anyMethodPfx/host;
    /http/1.1 => /method;
  httpAccessLog: logs/access.log
  label: int
  dstPrefix: /http
  client:
    tls:
      kind: io.l5d.clientTls.noValidation
  servers:
  - port: 4140
    ip: 0.0.0.0
```

TODO: add tls as part of acceptance testing
