### PR TITLE
Upgrade Finagle to 6.33.0

### DIFF
--- a/k8s/src/main/scala/io/buoyant/k8s/EndpointsNamer.scala
+++ b/k8s/src/main/scala/io/buoyant/k8s/EndpointsNamer.scala
@@ -48,7 +48,7 @@ object master {
     log.debug("building %s client to %s", label, name)
     val client = (masterTls(), masterUnsafe()) match {
       case (false, _) => Http.client
-      case (true, true) => Http.client.withTlsWithoutValidation()
+      case (true, true) => Http.client.withTlsWithoutValidation
       case (true, _) => Http.client.withTls(setHost.host)
     }
     val service = client

--- a/linkerd/namer/k8s/src/main/scala/io/l5d/k8s.scala
+++ b/linkerd/namer/k8s/src/main/scala/io/l5d/k8s.scala
@@ -110,7 +110,7 @@ class k8s(val params: Stack.Params) extends NamerInitializer {
 
     val client = (params[k8s.Tls], params[k8s.Tls.WithoutValidation]) match {
       case (k8s.Tls(false), _) => Http.client
-      case (_, k8s.Tls.WithoutValidation(true)) => Http.client.withTlsWithoutValidation()
+      case (_, k8s.Tls.WithoutValidation(true)) => Http.client.withTlsWithoutValidation
       case _ => Http.client.withTls(setHost.host)
     }
 

--- a/linkerd/protocol/thrift/src/main/scala/io/buoyant/linkerd/protocol/ThriftInitializer.scala
+++ b/linkerd/protocol/thrift/src/main/scala/io/buoyant/linkerd/protocol/ThriftInitializer.scala
@@ -2,6 +2,7 @@ package io.buoyant.linkerd
 package protocol
 
 import com.twitter.finagle.Path
+import com.twitter.finagle.Thrift.param
 import io.buoyant.router.{Thrift, RoutingFactory}
 
 class ThriftInitializer extends ProtocolInitializer {
@@ -20,7 +21,7 @@ class ThriftInitializer extends ProtocolInitializer {
     .configured(Server.Port(4114))
 
   val Framed = Parsing.Param.Boolean("thriftFramed") { framed =>
-    Thrift.param.Framed(framed)
+    param.Framed(framed)
   }
 
   val MethodInDst = Parsing.Param.Boolean("thriftMethodInDst") { methodInDst =>

--- a/project/Deps.scala
+++ b/project/Deps.scala
@@ -4,15 +4,15 @@ object Deps {
 
   // process lifecycle
   val twitterServer =
-    ("com.twitter" %% "twitter-server" % "1.16.0").
+    ("com.twitter" %% "twitter-server" % "1.18.0").
       exclude("com.twitter", "finagle-zipkin_2.11")
 
   def twitterUtil(mod: String) =
-    "com.twitter" %% s"util-$mod" % "6.30.0"
+    "com.twitter" %% s"util-$mod" %  "6.32.0"
 
   // networking
   def finagle(mod: String) =
-    "com.twitter" %% s"finagle-$mod" % "6.31.0"
+    "com.twitter" %% s"finagle-$mod" % "6.33.0"
 
   // Jackson (parsing)
   val jacksonVersion = "2.4.4"

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -14,4 +14,4 @@ addSbtPlugin("com.eed3si9n"      % "sbt-assembly"  % "0.14.1")
 addSbtPlugin("se.marcuslonnberg" % "sbt-docker"    % "1.2.0")
 
 // scrooge
-addSbtPlugin("com.twitter" %% "scrooge-sbt-plugin" % "4.1.0")
+addSbtPlugin("com.twitter" %% "scrooge-sbt-plugin" % "4.5.0")


### PR DESCRIPTION
Fixes #86 

Notably, framed is now in Thrift.param.Framed, so we can clean our code up.

https://github.com/twitter/finagle/blob/develop/CHANGES
http://finagle.github.io/blog/2016/02/05/release-notes-6-33/
Breaking changes: framed is no longer on Thrift.Client - instead it is controlled by Thrift.param.Framed

I tested this by running the ruby calc app with both buffered and framed, and by running the linkerd tests.  I'll run this in more places for more tests.
