### PR TITLE
Release version 0.1.0, bump head to 0.1.1

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,3 +1,5 @@
+## 0.1.1
+
 ## 0.1.0
 
 * Introduce Marathon-backed service discovery, for routing traffic in Mesos.

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,3 +1,9 @@
+## 0.1.0
+
+* Introduce Marathon-backed service discovery, for routing traffic in Mesos.
+* Add new boundPath client TLS module for per-service TLS authentication.
+* Upgrade to Finagle 6.33, the latest and greatest in Finagle-based technology.
+
 ## 0.0.11
 
 * TLS, for real this time.

--- a/project/Base.scala
+++ b/project/Base.scala
@@ -14,7 +14,7 @@ import scalariform.formatter.preferences._
  * Base project configuration.
  */
 class Base extends Build {
-  val headVersion = "0.1.0"
+  val headVersion = "0.1.1"
 
   object Git {
     def git(arg: String, args: String*) = Process("git" +: arg +: args)


### PR DESCRIPTION
The 0.1.0 release is available here:

https://github.com/BuoyantIO/linkerd/releases/tag/0.1.0