### PR TITLE
Remove deprecated global flags.

### DIFF
--- a/consul/src/main/scala/io/buoyant/consul/CatalogNamer.scala
+++ b/consul/src/main/scala/io/buoyant/consul/CatalogNamer.scala
@@ -1,11 +1,7 @@
 package io.buoyant.consul
 
 import com.google.common.net.InetAddresses
-import com.twitter.app.{Flag, GlobalFlag}
 import com.twitter.finagle._
-import com.twitter.finagle.http.{Request, Response}
-import com.twitter.finagle.service.FailFastFactory.FailFast
-import com.twitter.logging.Level
 import com.twitter.util._
 import io.buoyant.consul.v1.ServiceNode
 import java.net.{InetSocketAddress, SocketAddress}

--- a/consul/src/test/scala/io/buoyant/consul/CatalogNamerTest.scala
+++ b/consul/src/test/scala/io/buoyant/consul/CatalogNamerTest.scala
@@ -1,13 +1,11 @@
 package io.buoyant.consul
 
-import java.net.{InetSocketAddress, SocketAddress}
-
-import com.twitter.app.{GlobalFlag, Flag}
 import com.twitter.finagle._
 import com.twitter.io.Buf
 import com.twitter.util.{Activity, Future, Promise}
 import io.buoyant.consul.v1.{CatalogApi, Indexed, ServiceNode}
 import io.buoyant.test.Awaits
+import java.net.SocketAddress
 import org.scalatest.FunSuite
 
 class CatalogNamerTest extends FunSuite with Awaits {

--- a/linkerd/namer/fs/src/main/scala/io/buoyant/linkerd/namer/fs/WatchingNamer.scala
+++ b/linkerd/namer/fs/src/main/scala/io/buoyant/linkerd/namer/fs/WatchingNamer.scala
@@ -1,15 +1,11 @@
 package io.buoyant.linkerd.namer.fs
 
-import com.twitter.app.GlobalFlag
-import com.twitter.conversions.storage._
 import com.twitter.finagle.{Addr, Name, NameTree, Namer, Path}
 import com.twitter.io.Buf
 import com.twitter.logging.Logger
 import com.twitter.util._
 import java.net.{InetSocketAddress, SocketAddress}
-import java.nio.file.{Path => NioPath, _}
-import java.nio.file.StandardWatchEventKinds._
-import scala.collection.JavaConverters._
+import java.nio.file.{Path => NioPath}
 
 object WatchingNamer {
   private val log = Logger.get(getClass.getName)


### PR DESCRIPTION
No need to keep these flags around since nameinitializers serve the
same purpose and our internal apps have migrated away from global
flags.