### PR TITLE
Some refactors/simplifications to recent config branch

### DIFF
--- a/circle.yml
+++ b/circle.yml
@@ -10,7 +10,7 @@ dependencies:
   cache_directories:
   - .sbt-launch.jar
   override:
-  - ./sbt update test:compile e2e:compile
+  - ./sbt update test:compile e2e:compile integration:compile
 
 test:
   override:

--- a/linkerd/admin/src/test/scala/io/buoyant/linkerd/admin/RouterHandlerTest.scala
+++ b/linkerd/admin/src/test/scala/io/buoyant/linkerd/admin/RouterHandlerTest.scala
@@ -16,7 +16,7 @@ routers:
 - protocol: fancy
   servers:
   - port: 2
-                       """, Seq(TestProtocol.Plain, TestProtocol.Fancy, TestNamer))
+                       """, Seq(TestProtocol.Plain, TestProtocol.Fancy, TestNamerInitializer))
     val handler = new RouterHandler(linker)
     val req = Request()
     val rsp = await(handler(req))

--- a/linkerd/admin/src/test/scala/io/buoyant/linkerd/admin/names/DelegatorTest.scala
+++ b/linkerd/admin/src/test/scala/io/buoyant/linkerd/admin/names/DelegatorTest.scala
@@ -20,7 +20,7 @@ routers:
 - protocol: fancy
   servers:
   - port: 2
-""", Seq(TestProtocol.Plain, TestProtocol.Fancy, TestNamer))
+""", Seq(TestProtocol.Plain, TestProtocol.Fancy, TestNamerInitializer))
 
   val dtab = Dtab.read("""
     /bah/humbug => /$/inet/127.1/8080 ;

--- a/linkerd/admin/src/test/scala/io/buoyant/linkerd/admin/names/WebDelegatorTest.scala
+++ b/linkerd/admin/src/test/scala/io/buoyant/linkerd/admin/names/WebDelegatorTest.scala
@@ -20,7 +20,7 @@ routers:
 - protocol: fancy
   servers:
   - port: 2
-""", Seq(TestProtocol.Plain, TestProtocol.Fancy, TestNamer))
+""", Seq(TestProtocol.Plain, TestProtocol.Fancy, TestNamerInitializer))
 
   val dtab = Dtab.read("""
     /bah/humbug => /$/inet/127.1/8080 ;

--- a/linkerd/config/src/main/scala/io/buoyant/linkerd/config/Parser.scala
+++ b/linkerd/config/src/main/scala/io/buoyant/linkerd/config/Parser.scala
@@ -11,9 +11,8 @@ import com.twitter.finagle.util.LoadService
 import scala.reflect.{ClassTag, classTag}
 
 abstract class ConfigDeserializer[T: ClassTag] extends StdDeserializer[T](Parser.jClass[T]) {
-  def register(module: SimpleModule): SimpleModule = {
-    module.addDeserializer(Parser.jClass[T], this)
-  }
+  def register(module: SimpleModule): SimpleModule = module.addDeserializer(Parser.jClass[T], this)
+
   protected def catchMappingException(ctxt: DeserializationContext)(t: => T): T =
     try t catch {
       case arg: IllegalArgumentException =>
@@ -22,7 +21,6 @@ abstract class ConfigDeserializer[T: ClassTag] extends StdDeserializer[T](Parser
 }
 
 object Parser {
-
   private[config] def jClass[T: ClassTag] = classTag[T].runtimeClass.asInstanceOf[Class[T]]
 
   private[this] def peekJsonObject(s: String): Boolean =

--- a/linkerd/config/src/main/scala/io/buoyant/linkerd/config/Parser.scala
+++ b/linkerd/config/src/main/scala/io/buoyant/linkerd/config/Parser.scala
@@ -11,7 +11,9 @@ import com.twitter.finagle.util.LoadService
 import scala.reflect.{ClassTag, classTag}
 
 abstract class ConfigDeserializer[T: ClassTag] extends StdDeserializer[T](Parser.jClass[T]) {
-  def register(module: SimpleModule): SimpleModule = module.addDeserializer(Parser.jClass[T], this)
+  def register(module: SimpleModule): SimpleModule = {
+    module.addDeserializer(Parser.jClass[T], this)
+  }
   protected def catchMappingException(ctxt: DeserializationContext)(t: => T): T =
     try t catch {
       case arg: IllegalArgumentException =>
@@ -20,8 +22,8 @@ abstract class ConfigDeserializer[T: ClassTag] extends StdDeserializer[T](Parser
 }
 
 object Parser {
-  // convert to java-compatible class, used for testing
-  def jClass[T: ClassTag]: Class[T] = classTag[T].runtimeClass.asInstanceOf[Class[T]]
+
+  private[config] def jClass[T: ClassTag] = classTag[T].runtimeClass.asInstanceOf[Class[T]]
 
   private[this] def peekJsonObject(s: String): Boolean =
     s.dropWhile(_.isWhitespace).startsWith("{")

--- a/linkerd/core/src/main/scala/io/buoyant/linkerd/ConfigInitializer.scala
+++ b/linkerd/core/src/main/scala/io/buoyant/linkerd/ConfigInitializer.scala
@@ -6,7 +6,7 @@ import com.fasterxml.jackson.databind.jsontype.NamedType
 trait ConfigInitializer {
 
   def configClass: Class[_]
-  def configId: String
+  def configId: String = configClass.getName
 
   lazy val namedType = new NamedType(configClass, configId)
 

--- a/linkerd/core/src/main/scala/io/buoyant/linkerd/NamerInitializer.scala
+++ b/linkerd/core/src/main/scala/io/buoyant/linkerd/NamerInitializer.scala
@@ -38,4 +38,4 @@ trait NamerConfig {
   def newNamer(params: Stack.Params): Namer
 }
 
-abstract class NamerInitializer extends ConfigInitializer
+trait NamerInitializer extends ConfigInitializer

--- a/linkerd/core/src/main/scala/io/buoyant/linkerd/ProtocolInitializer.scala
+++ b/linkerd/core/src/main/scala/io/buoyant/linkerd/ProtocolInitializer.scala
@@ -22,6 +22,7 @@ trait ProtocolInitializer extends ConfigInitializer {
 
   /** The protocol name, as read from configuration. */
   def name: String
+  override def configId = name
 
   /*
    * Router configuration & initialization

--- a/linkerd/core/src/test/scala/io/buoyant/linkerd/ConflictingNamer.scala
+++ b/linkerd/core/src/test/scala/io/buoyant/linkerd/ConflictingNamer.scala
@@ -4,14 +4,14 @@ import com.fasterxml.jackson.annotation.JsonIgnore
 import com.twitter.finagle._
 import io.buoyant.linkerd.config.Parser
 
-class ConflictingNamer extends NamerInitializer {
-  val configClass = classOf[ConflictingNamerConfig]
-  val configId = "io.buoyant.linkerd.TestNamer"
+class ConflictingNamerInitializer extends NamerInitializer {
+  val configClass = classOf[ConflictingNamer]
+  override val configId = "io.buoyant.linkerd.TestNamer"
 }
 
-object ConflictingNamer extends ConflictingNamer
+object ConflictingNamerInitializer extends ConflictingNamerInitializer
 
-class ConflictingNamerConfig extends NamerConfig {
+class ConflictingNamer extends NamerConfig {
   @JsonIgnore
   override def defaultPrefix: Path = ???
   @JsonIgnore

--- a/linkerd/core/src/test/scala/io/buoyant/linkerd/ConflictingNamer.scala
+++ b/linkerd/core/src/test/scala/io/buoyant/linkerd/ConflictingNamer.scala
@@ -5,7 +5,7 @@ import com.twitter.finagle._
 import io.buoyant.linkerd.config.Parser
 
 class ConflictingNamer extends NamerInitializer {
-  val configClass = Parser.jClass[ConflictingNamerConfig]
+  val configClass = classOf[ConflictingNamerConfig]
   val configId = "io.buoyant.linkerd.TestNamer"
 }
 

--- a/linkerd/core/src/test/scala/io/buoyant/linkerd/LinkerTest.scala
+++ b/linkerd/core/src/test/scala/io/buoyant/linkerd/LinkerTest.scala
@@ -13,8 +13,8 @@ class LinkerTest extends FunSuite {
   def parse(
     yaml: String,
     protos: Seq[ProtocolInitializer] = Seq(TestProtocol.Plain, TestProtocol.Fancy),
-    namers: Seq[NamerInitializer] = Seq(TestNamer),
-    tracers: Seq[TracerInitializer] = Seq(TestTracer)
+    namers: Seq[NamerInitializer] = Seq(TestNamerInitializer),
+    tracers: Seq[TracerInitializer] = Seq(TestTracerInitializer)
   ) = {
     Linker.load(yaml, protos ++ namers ++ tracers)
   }
@@ -211,6 +211,6 @@ routers:
   servers:
   - port: 1
     """
-    intercept[ConflictingSubtypes] { parse(yaml, namers = Seq(TestNamer, ConflictingNamer)) }
+    intercept[ConflictingSubtypes] { parse(yaml, namers = Seq(TestNamerInitializer, ConflictingNamerInitializer)) }
   }
 }

--- a/linkerd/core/src/test/scala/io/buoyant/linkerd/NamerInitializerTest.scala
+++ b/linkerd/core/src/test/scala/io/buoyant/linkerd/NamerInitializerTest.scala
@@ -9,7 +9,7 @@ class NamerInitializerTest extends FunSuite {
 
   def interpreter(config: String): NameInterpreter = {
     val mapper = Parser.objectMapper(config)
-    TestNamer.registerSubtypes(mapper)
+    TestNamerInitializer.registerSubtypes(mapper)
     val cfg = mapper.readValue[Seq[NamerConfig]](config)
     Linker.nameInterpreter(Stack.Params.empty)(cfg)
   }

--- a/linkerd/core/src/test/scala/io/buoyant/linkerd/NamerInitializersTest.scala
+++ b/linkerd/core/src/test/scala/io/buoyant/linkerd/NamerInitializersTest.scala
@@ -18,9 +18,9 @@ class NamerInitializersTest extends FunSuite {
 
   def interpreter(config: String): NameInterpreter = {
     val mapper = Parser.objectMapper(config)
-    mapper.registerSubtypes(new NamedType(Parser.jClass[booNamer], "io.buoyant.linkerd.booNamer"))
+    mapper.registerSubtypes(new NamedType(classOf[booNamer], "io.buoyant.linkerd.booNamer"))
     mapper.registerSubtypes(
-      new NamedType(Parser.jClass[booUrnsNamer], "io.buoyant.linkerd.booUrnsNamer")
+      new NamedType(classOf[booUrnsNamer], "io.buoyant.linkerd.booUrnsNamer")
     )
     val cfg = mapper.readValue[Seq[NamerConfig]](config)
     Linker.nameInterpreter(Stack.Params.empty)(cfg)

--- a/linkerd/core/src/test/scala/io/buoyant/linkerd/NamerInitializersTest.scala
+++ b/linkerd/core/src/test/scala/io/buoyant/linkerd/NamerInitializersTest.scala
@@ -6,11 +6,11 @@ import com.twitter.finagle._
 import io.buoyant.linkerd.config.Parser
 import org.scalatest.FunSuite
 
-class booNamer extends TestNamerConfig {
+class booNamer extends TestNamer {
   override def defaultPrefix = Path.read("/boo")
 }
 
-class booUrnsNamer extends TestNamerConfig {
+class booUrnsNamer extends TestNamer {
   override def defaultPrefix = Path.read("/boo/urns")
 }
 

--- a/linkerd/core/src/test/scala/io/buoyant/linkerd/TestNamer.scala
+++ b/linkerd/core/src/test/scala/io/buoyant/linkerd/TestNamer.scala
@@ -6,7 +6,7 @@ import com.twitter.util.{Activity, Var}
 import io.buoyant.linkerd.config.Parser
 
 class TestNamer extends NamerInitializer {
-  val configClass = Parser.jClass[TestNamerConfig]
+  val configClass = classOf[TestNamerConfig]
   val configId = "io.buoyant.linkerd.TestNamer"
 }
 

--- a/linkerd/core/src/test/scala/io/buoyant/linkerd/TestNamer.scala
+++ b/linkerd/core/src/test/scala/io/buoyant/linkerd/TestNamer.scala
@@ -5,14 +5,13 @@ import com.twitter.finagle._
 import com.twitter.util.{Activity, Var}
 import io.buoyant.linkerd.config.Parser
 
-class TestNamer extends NamerInitializer {
-  val configClass = classOf[TestNamerConfig]
-  val configId = "io.buoyant.linkerd.TestNamer"
+class TestNamerInitializer extends NamerInitializer {
+  val configClass = classOf[TestNamer]
 }
 
-object TestNamer extends TestNamer
+object TestNamerInitializer extends TestNamerInitializer
 
-class TestNamerConfig extends NamerConfig { config =>
+class TestNamer extends NamerConfig { config =>
   @JsonIgnore
   override def defaultPrefix: Path = Path.read("/foo")
 

--- a/linkerd/core/src/test/scala/io/buoyant/linkerd/TestProtocol.scala
+++ b/linkerd/core/src/test/scala/io/buoyant/linkerd/TestProtocol.scala
@@ -111,7 +111,7 @@ abstract class TestProtocol(val name: String) extends ProtocolInitializer.Simple
   val defaultServerPort = 13
 }
 
-class PlainConfig extends RouterConfig {
+class Plain extends RouterConfig {
 
   var servers: Seq[ServerConfig] = Nil
   var client: Option[ClientConfig] = None
@@ -120,7 +120,7 @@ class PlainConfig extends RouterConfig {
   override def protocol: ProtocolInitializer = TestProtocol.Plain
 }
 
-case class FancyConfig(fancy: Option[Boolean]) extends RouterConfig {
+case class Fancy(fancy: Option[Boolean]) extends RouterConfig {
 
   var servers: Seq[ServerConfig] = Nil
   var client: Option[ClientConfig] = None
@@ -141,12 +141,10 @@ object TestProtocol {
   }
 
   object Plain extends TestProtocol("plain") {
-    val configClass = classOf[PlainConfig]
-    val configId = "plain"
+    val configClass = classOf[Plain]
   }
 
   object Fancy extends TestProtocol("fancy") {
-    val configClass = classOf[FancyConfig]
-    val configId = "fancy"
+    val configClass = classOf[Fancy]
   }
 }

--- a/linkerd/core/src/test/scala/io/buoyant/linkerd/TestProtocol.scala
+++ b/linkerd/core/src/test/scala/io/buoyant/linkerd/TestProtocol.scala
@@ -141,12 +141,12 @@ object TestProtocol {
   }
 
   object Plain extends TestProtocol("plain") {
-    val configClass = Parser.jClass[PlainConfig]
+    val configClass = classOf[PlainConfig]
     val configId = "plain"
   }
 
   object Fancy extends TestProtocol("fancy") {
-    val configClass = Parser.jClass[FancyConfig]
+    val configClass = classOf[FancyConfig]
     val configId = "fancy"
   }
 }

--- a/linkerd/core/src/test/scala/io/buoyant/linkerd/TestTracer.scala
+++ b/linkerd/core/src/test/scala/io/buoyant/linkerd/TestTracer.scala
@@ -4,14 +4,13 @@ import com.fasterxml.jackson.annotation.JsonIgnore
 import com.twitter.finagle.tracing.{Record, TraceId, Tracer}
 import io.buoyant.linkerd.config.Parser
 
-class TestTracer extends TracerInitializer {
-  val configClass = Parser.jClass[TestTracerConfig]
-  val configId = "io.buoyant.linkerd.TestTracer"
+class TestTracerInitializer extends TracerInitializer {
+  val configClass = classOf[TestTracer]
 }
 
-object TestTracer extends TestTracer
+object TestTracerInitializer extends TestTracerInitializer
 
-class TestTracerConfig extends TracerConfig {
+class TestTracer extends TracerConfig {
   @JsonIgnore
   override def newTracer(): Tracer = new Tracer {
     def record(record: Record): Unit = {}

--- a/linkerd/namer/consul/src/main/resources/META-INF/services/io.buoyant.linkerd.NamerInitializer
+++ b/linkerd/namer/consul/src/main/resources/META-INF/services/io.buoyant.linkerd.NamerInitializer
@@ -1,1 +1,1 @@
-io.l5d.experimental.consul
+io.l5d.experimental.ConsulInitializer

--- a/linkerd/namer/consul/src/main/scala/io/l5d/consul.scala
+++ b/linkerd/namer/consul/src/main/scala/io/l5d/consul.scala
@@ -19,7 +19,7 @@ import io.buoyant.linkerd.{NamerConfig, NamerInitializer}
  * </pre>
  */
 class consul extends NamerInitializer {
-  val configClass = Parser.jClass[ConsulConfig]
+  val configClass = classOf[ConsulConfig]
   val configId = "io.l5d.experimental.consul"
 }
 

--- a/linkerd/namer/consul/src/main/scala/io/l5d/consul.scala
+++ b/linkerd/namer/consul/src/main/scala/io/l5d/consul.scala
@@ -18,12 +18,11 @@ import io.buoyant.linkerd.{NamerConfig, NamerInitializer}
  *   port: 8600
  * </pre>
  */
-class consul extends NamerInitializer {
-  val configClass = classOf[ConsulConfig]
-  val configId = "io.l5d.experimental.consul"
+class ConsulInitializer extends NamerInitializer {
+  val configClass = classOf[consul]
 }
 
-case class ConsulConfig(
+case class consul(
   host: Option[String],
   port: Option[Port]
 ) extends NamerConfig {

--- a/linkerd/namer/consul/src/test/scala/io/l5d/ConsulTest.scala
+++ b/linkerd/namer/consul/src/test/scala/io/l5d/ConsulTest.scala
@@ -5,14 +5,14 @@ import com.twitter.finagle.util.LoadService
 import io.buoyant.linkerd.NamerInitializer
 import org.scalatest.FunSuite
 
-class MarathonTest extends FunSuite {
+class ConsulTest extends FunSuite {
 
   test("sanity") {
     // ensure it doesn't totally blowup
-    marathon(None, None, None).newNamer(Stack.Params.empty)
+    consul(None, None).newNamer(Stack.Params.empty)
   }
 
   test("service registration") {
-    assert(LoadService[NamerInitializer]().exists(_.isInstanceOf[MarathonInitializer]))
+    assert(LoadService[NamerInitializer]().exists(_.isInstanceOf[ConsulInitializer]))
   }
 }

--- a/linkerd/namer/fs/src/main/resources/META-INF/services/io.buoyant.linkerd.NamerInitializer
+++ b/linkerd/namer/fs/src/main/resources/META-INF/services/io.buoyant.linkerd.NamerInitializer
@@ -1,1 +1,1 @@
-io.l5d.fs
+io.l5d.FsInitializer

--- a/linkerd/namer/fs/src/main/scala/io/l5d/fs.scala
+++ b/linkerd/namer/fs/src/main/scala/io/l5d/fs.scala
@@ -9,7 +9,7 @@ import io.buoyant.linkerd.{NamerConfig, NamerInitializer}
 import io.l5d.fs.FsConfig
 
 class fs extends NamerInitializer {
-  val configClass = Parser.jClass[FsConfig]
+  val configClass = classOf[FsConfig]
   val configId = "io.l5d.fs"
 }
 

--- a/linkerd/namer/fs/src/main/scala/io/l5d/fs.scala
+++ b/linkerd/namer/fs/src/main/scala/io/l5d/fs.scala
@@ -2,26 +2,23 @@ package io.l5d
 
 import com.fasterxml.jackson.annotation.JsonIgnore
 import com.twitter.finagle.{Stack, Path}
-import io.buoyant.linkerd.config.Parser
 import io.buoyant.linkerd.config.types.Directory
 import io.buoyant.linkerd.namer.fs.WatchingNamer
 import io.buoyant.linkerd.{NamerConfig, NamerInitializer}
-import io.l5d.fs.FsConfig
 
-class fs extends NamerInitializer {
-  val configClass = classOf[FsConfig]
-  val configId = "io.l5d.fs"
+class FsInitializer extends NamerInitializer {
+  val configClass = classOf[fs]
 }
 
-object fs {
-  case class FsConfig(rootDir: Directory) extends NamerConfig {
-    @JsonIgnore
-    override def defaultPrefix: Path = Path.read("/io.l5d.fs")
+object FsInitializer extends FsInitializer
 
-    /**
-     * Construct a namer.
-     */
-    @JsonIgnore
-    def newNamer(params: Stack.Params) = new WatchingNamer(rootDir.path, prefix)
-  }
+case class fs(rootDir: Directory) extends NamerConfig {
+  @JsonIgnore
+  override def defaultPrefix: Path = Path.read("/io.l5d.fs")
+
+  /**
+   * Construct a namer.
+   */
+  @JsonIgnore
+  def newNamer(params: Stack.Params) = new WatchingNamer(rootDir.path, prefix)
 }

--- a/linkerd/namer/fs/src/test/scala/io/l5d/FsTest.scala
+++ b/linkerd/namer/fs/src/test/scala/io/l5d/FsTest.scala
@@ -1,0 +1,20 @@
+package io.l5d
+
+import com.twitter.finagle.Stack
+import com.twitter.finagle.util.LoadService
+import io.buoyant.linkerd.NamerInitializer
+import io.buoyant.linkerd.config.types.Directory
+import java.nio.file.Paths
+import org.scalatest.FunSuite
+
+class FsTest extends FunSuite {
+
+  test("sanity") {
+    // ensure it doesn't totally blowup
+    fs(Directory(Paths.get("."))).newNamer(Stack.Params.empty)
+  }
+
+  test("service registration") {
+    assert(LoadService[NamerInitializer]().exists(_.isInstanceOf[FsInitializer]))
+  }
+}

--- a/linkerd/namer/k8s/src/main/resources/META-INF/services/io.buoyant.linkerd.NamerInitializer
+++ b/linkerd/namer/k8s/src/main/resources/META-INF/services/io.buoyant.linkerd.NamerInitializer
@@ -1,1 +1,1 @@
-io.l5d.experimental.k8s
+io.l5d.experimental.K8sInitializer

--- a/linkerd/namer/k8s/src/main/scala/io/l5d/k8s.scala
+++ b/linkerd/namer/k8s/src/main/scala/io/l5d/k8s.scala
@@ -23,7 +23,7 @@ import scala.io.Source
  * </pre>
  */
 class k8s extends NamerInitializer {
-  val configClass = Parser.jClass[k8sConfig]
+  val configClass = classOf[k8sConfig]
   val configId = "io.l5d.experimental.k8s"
 }
 

--- a/linkerd/namer/k8s/src/main/scala/io/l5d/k8s.scala
+++ b/linkerd/namer/k8s/src/main/scala/io/l5d/k8s.scala
@@ -22,14 +22,13 @@ import scala.io.Source
  *   authTokenFile: ../auth.token
  * </pre>
  */
-class k8s extends NamerInitializer {
-  val configClass = classOf[k8sConfig]
-  val configId = "io.l5d.experimental.k8s"
+class K8sInitializer extends NamerInitializer {
+  val configClass = classOf[k8s]
 }
 
-object k8s extends k8s
+object K8sInitializer extends K8sInitializer
 
-case class k8sConfig(
+case class k8s(
   host: Option[String],
   port: Option[Port],
   tls: Option[Boolean],

--- a/linkerd/namer/k8s/src/test/scala/io/l5d/K8sTest.scala
+++ b/linkerd/namer/k8s/src/test/scala/io/l5d/K8sTest.scala
@@ -1,12 +1,18 @@
 package io.l5d.experimental
 
 import com.twitter.finagle.Stack
+import com.twitter.finagle.util.LoadService
+import io.buoyant.linkerd.NamerInitializer
 import org.scalatest.FunSuite
 
 class K8sTest extends FunSuite {
 
   test("sanity") {
     // ensure it doesn't totally blowup
-    k8sConfig(None, None, None, None, None).newNamer(Stack.Params.empty)
+    k8s(None, None, None, None, None).newNamer(Stack.Params.empty)
+  }
+
+  test("service registration") {
+    assert(LoadService[NamerInitializer]().exists(_.isInstanceOf[K8sInitializer]))
   }
 }

--- a/linkerd/namer/marathon/src/main/resources/META-INF/services/io.buoyant.linkerd.NamerInitializer
+++ b/linkerd/namer/marathon/src/main/resources/META-INF/services/io.buoyant.linkerd.NamerInitializer
@@ -1,1 +1,1 @@
-io.l5d.experimental.marathon
+io.l5d.experimental.MarathonInitializer

--- a/linkerd/namer/marathon/src/main/scala/io/l5d/marathon.scala
+++ b/linkerd/namer/marathon/src/main/scala/io/l5d/marathon.scala
@@ -22,7 +22,7 @@ import io.buoyant.marathon.v2.{Api, AppIdNamer}
  * </pre>
  */
 class marathon extends NamerInitializer {
-  val configClass = Parser.jClass[MarathonConfig]
+  val configClass = classOf[MarathonConfig]
   val configId = "io.l5d.experimental.marathon"
 }
 

--- a/linkerd/namer/marathon/src/main/scala/io/l5d/marathon.scala
+++ b/linkerd/namer/marathon/src/main/scala/io/l5d/marathon.scala
@@ -21,12 +21,11 @@ import io.buoyant.marathon.v2.{Api, AppIdNamer}
  *   uriPrefix: /marathon
  * </pre>
  */
-class marathon extends NamerInitializer {
-  val configClass = classOf[MarathonConfig]
-  val configId = "io.l5d.experimental.marathon"
+class MarathonInitializer extends NamerInitializer {
+  val configClass = classOf[marathon]
 }
 
-case class MarathonConfig(
+case class marathon(
   host: Option[String],
   port: Option[Port],
   uriPrefix: Option[String]

--- a/linkerd/namer/serversets/src/main/resources/META-INF/services/io.buoyant.linkerd.NamerInitializer
+++ b/linkerd/namer/serversets/src/main/resources/META-INF/services/io.buoyant.linkerd.NamerInitializer
@@ -1,1 +1,1 @@
-io.l5d.serversets
+io.l5d.ServersetsInitializer

--- a/linkerd/namer/serversets/src/main/scala/io/l5d/serversets.scala
+++ b/linkerd/namer/serversets/src/main/scala/io/l5d/serversets.scala
@@ -8,7 +8,7 @@ import io.buoyant.linkerd.namer.serversets.ServersetNamer
 import io.buoyant.linkerd.{NamerConfig, NamerInitializer}
 
 class serversets extends NamerInitializer {
-  val configClass = Parser.jClass[ServersetsConfig]
+  val configClass = classOf[ServersetsConfig]
   val configId = "io.l5d.serversets"
 }
 

--- a/linkerd/namer/serversets/src/main/scala/io/l5d/serversets.scala
+++ b/linkerd/namer/serversets/src/main/scala/io/l5d/serversets.scala
@@ -7,14 +7,13 @@ import io.buoyant.linkerd.config.types.Port
 import io.buoyant.linkerd.namer.serversets.ServersetNamer
 import io.buoyant.linkerd.{NamerConfig, NamerInitializer}
 
-class serversets extends NamerInitializer {
-  val configClass = classOf[ServersetsConfig]
-  val configId = "io.l5d.serversets"
+class ServersetsInitializer extends NamerInitializer {
+  val configClass = classOf[serversets]
 }
 
-object serversets extends serversets
+object ServersetsInitializer extends ServersetsInitializer
 
-case class ServersetsConfig(zkAddrs: Seq[ZkAddr]) extends NamerConfig {
+case class serversets(zkAddrs: Seq[ZkAddr]) extends NamerConfig {
   @JsonIgnore
   override def defaultPrefix: Path = Path.read("/io.l5d.serversets")
 

--- a/linkerd/namer/serversets/src/test/scala/io/l5d/ServersetsTest.scala
+++ b/linkerd/namer/serversets/src/test/scala/io/l5d/ServersetsTest.scala
@@ -1,16 +1,17 @@
 package io.l5d
 
 import com.fasterxml.jackson.databind.JsonMappingException
-import io.buoyant.linkerd.NamerConfig
+import com.twitter.finagle.util.LoadService
+import io.buoyant.linkerd.{NamerInitializer, NamerConfig}
 import io.buoyant.linkerd.config.Parser
 import org.scalatest.FunSuite
 
 class ServersetsTest extends FunSuite {
 
-  def parse(yaml: String): ServersetsConfig = {
+  def parse(yaml: String): serversets = {
     val mapper = Parser.objectMapper(yaml)
-    serversets.registerSubtypes(mapper)
-    mapper.readValue[NamerConfig](yaml).asInstanceOf[ServersetsConfig]
+    ServersetsInitializer.registerSubtypes(mapper)
+    mapper.readValue[NamerConfig](yaml).asInstanceOf[serversets]
   }
 
   test("zkHost list") {
@@ -54,5 +55,9 @@ zkAddrs:
 - host: foo
 """
     assert(parse(yaml).connectString == "foo:2181")
+  }
+
+  test("service registration") {
+    assert(LoadService[NamerInitializer]().exists(_.isInstanceOf[ServersetsInitializer]))
   }
 }

--- a/linkerd/protocol/http/src/integration/scala/io/buoyant/linkerd/protocol/TlsBoundPathTest.scala
+++ b/linkerd/protocol/http/src/integration/scala/io/buoyant/linkerd/protocol/TlsBoundPathTest.scala
@@ -6,8 +6,8 @@ import com.twitter.finagle.http.{Request, Response}
 import com.twitter.finagle.{Failure, Service}
 import io.buoyant.linkerd.protocol.TlsUtils._
 import io.buoyant.test.Awaits
-import io.l5d.clientTls.boundPath
-import io.l5d.fs
+import io.l5d.FsInitializer
+import io.l5d.clientTls.BoundPathInitializer
 import java.io.File
 import org.scalatest.FunSuite
 import scala.sys.process._
@@ -276,7 +276,7 @@ class TlsBoundPathTest extends FunSuite with Awaits {
   }
 
   private[this] def withLinkerdClient(config: String)(f: Service[Request, Response] => Unit): Unit = {
-    val linker = Linker.load(config, Seq(new fs, HttpInitializer, new boundPath))
+    val linker = Linker.load(config, Seq(FsInitializer, HttpInitializer, BoundPathInitializer))
     val router = linker.routers.head.initialize()
     try {
       val server = router.servers.head.serve()

--- a/linkerd/protocol/http/src/integration/scala/io/buoyant/linkerd/protocol/TlsNoValidationTest.scala
+++ b/linkerd/protocol/http/src/integration/scala/io/buoyant/linkerd/protocol/TlsNoValidationTest.scala
@@ -5,7 +5,7 @@ import com.twitter.conversions.time._
 import com.twitter.finagle.http.Request
 import io.buoyant.linkerd.protocol.TlsUtils._
 import io.buoyant.test.Awaits
-import io.l5d.clientTls.noValidation
+import io.l5d.clientTls.NoValidationInitializer
 import org.scalatest.FunSuite
 
 class TlsNoValidationTest extends FunSuite with Awaits {
@@ -31,7 +31,7 @@ class TlsNoValidationTest extends FunSuite with Awaits {
              |      kind: io.l5d.clientTls.noValidation
              |""".
             stripMargin
-        val linker = Linker.load(linkerConfig, Seq(HttpInitializer, new noValidation))
+        val linker = Linker.load(linkerConfig, Seq(HttpInitializer, NoValidationInitializer))
         val router = linker.routers.head.initialize()
         try {
           val server = router.servers.head.serve()

--- a/linkerd/protocol/http/src/integration/scala/io/buoyant/linkerd/protocol/TlsStaticValidationTest.scala
+++ b/linkerd/protocol/http/src/integration/scala/io/buoyant/linkerd/protocol/TlsStaticValidationTest.scala
@@ -6,7 +6,7 @@ import com.twitter.finagle.Failure
 import com.twitter.finagle.http.Request
 import io.buoyant.linkerd.protocol.TlsUtils._
 import io.buoyant.test.Awaits
-import io.l5d.clientTls.static
+import io.l5d.clientTls.StaticInitializer
 import org.scalatest.FunSuite
 
 class TlsStaticValidationTest extends FunSuite with Awaits {
@@ -34,7 +34,7 @@ class TlsStaticValidationTest extends FunSuite with Awaits {
              |      caCertPath: ${certs.caCert.getPath}
              |""".
             stripMargin
-        val linker = Linker.load(linkerConfig, Seq(HttpInitializer, new static))
+        val linker = Linker.load(linkerConfig, Seq(HttpInitializer, StaticInitializer))
         val router = linker.routers.head.initialize()
         try {
           val server = router.servers.head.serve()
@@ -76,7 +76,7 @@ class TlsStaticValidationTest extends FunSuite with Awaits {
              |      caCertPath: ${certs.caCert.getPath}
              |""".
             stripMargin
-        val linker = Linker.load(linkerConfig, Seq(HttpInitializer, new static))
+        val linker = Linker.load(linkerConfig, Seq(HttpInitializer, StaticInitializer))
         val router = linker.routers.head.initialize()
         try {
           val server = router.servers.head.serve()

--- a/linkerd/protocol/http/src/main/scala/io/buoyant/linkerd/protocol/HttpInitializer.scala
+++ b/linkerd/protocol/http/src/main/scala/io/buoyant/linkerd/protocol/HttpInitializer.scala
@@ -36,7 +36,7 @@ class HttpInitializer extends ProtocolInitializer.Simple {
     Http.server.withStack(stk)
   }
 
-  val configClass = Parser.jClass[HttpConfig]
+  val configClass = classOf[HttpConfig]
   val configId = name
 
   override def defaultServerPort: Int = 4140

--- a/linkerd/protocol/http/src/main/scala/io/buoyant/linkerd/protocol/HttpInitializer.scala
+++ b/linkerd/protocol/http/src/main/scala/io/buoyant/linkerd/protocol/HttpInitializer.scala
@@ -37,7 +37,6 @@ class HttpInitializer extends ProtocolInitializer.Simple {
   }
 
   val configClass = classOf[HttpConfig]
-  val configId = name
 
   override def defaultServerPort: Int = 4140
 }

--- a/linkerd/protocol/mux/src/main/scala/io/buoyant/linkerd/protocol/MuxInitializer.scala
+++ b/linkerd/protocol/mux/src/main/scala/io/buoyant/linkerd/protocol/MuxInitializer.scala
@@ -20,7 +20,6 @@ class MuxInitializer extends ProtocolInitializer.Simple {
   override def defaultServerPort: Int = 4141
 
   val configClass = classOf[MuxConfig]
-  val configId = name
 }
 
 object MuxInitializer extends MuxInitializer

--- a/linkerd/protocol/mux/src/main/scala/io/buoyant/linkerd/protocol/MuxInitializer.scala
+++ b/linkerd/protocol/mux/src/main/scala/io/buoyant/linkerd/protocol/MuxInitializer.scala
@@ -19,7 +19,7 @@ class MuxInitializer extends ProtocolInitializer.Simple {
 
   override def defaultServerPort: Int = 4141
 
-  val configClass = Parser.jClass[MuxConfig]
+  val configClass = classOf[MuxConfig]
   val configId = name
 }
 

--- a/linkerd/protocol/thrift/src/main/scala/io/buoyant/linkerd/protocol/ThriftInitializer.scala
+++ b/linkerd/protocol/thrift/src/main/scala/io/buoyant/linkerd/protocol/ThriftInitializer.scala
@@ -26,7 +26,7 @@ class ThriftInitializer extends ProtocolInitializer {
 
   override def defaultServerPort: Int = 4114
 
-  val configClass = Parser.jClass[ThriftConfig]
+  val configClass = classOf[ThriftConfig]
   val configId = name
 }
 

--- a/linkerd/protocol/thrift/src/main/scala/io/buoyant/linkerd/protocol/ThriftInitializer.scala
+++ b/linkerd/protocol/thrift/src/main/scala/io/buoyant/linkerd/protocol/ThriftInitializer.scala
@@ -27,7 +27,6 @@ class ThriftInitializer extends ProtocolInitializer {
   override def defaultServerPort: Int = 4114
 
   val configClass = classOf[ThriftConfig]
-  val configId = name
 }
 
 object ThriftInitializer extends ThriftInitializer

--- a/linkerd/tls/src/main/resources/META-INF/services/io.buoyant.linkerd.TlsClientInitializer
+++ b/linkerd/tls/src/main/resources/META-INF/services/io.buoyant.linkerd.TlsClientInitializer
@@ -1,3 +1,3 @@
-io.l5d.clientTls.noValidation
-io.l5d.clientTls.static
-io.l5d.clientTls.boundPath
+io.l5d.clientTls.BoundPathInitializer
+io.l5d.clientTls.NoValidationInitializer
+io.l5d.clientTls.StaticInitializer

--- a/linkerd/tls/src/main/scala/io/l5d/clientTls/boundPath.scala
+++ b/linkerd/tls/src/main/scala/io/l5d/clientTls/boundPath.scala
@@ -14,7 +14,7 @@ import io.buoyant.linkerd.{TlsClientConfig, TlsClientInitializer}
 import java.net.SocketAddress
 
 class boundPath extends TlsClientInitializer {
-  val configClass = Parser.jClass[BoundPathConfig]
+  val configClass = classOf[BoundPathConfig]
   val configId = "io.l5d.clientTls.boundPath"
 }
 

--- a/linkerd/tls/src/main/scala/io/l5d/clientTls/boundPath.scala
+++ b/linkerd/tls/src/main/scala/io/l5d/clientTls/boundPath.scala
@@ -13,12 +13,13 @@ import io.buoyant.linkerd.util.PathMatcher
 import io.buoyant.linkerd.{TlsClientConfig, TlsClientInitializer}
 import java.net.SocketAddress
 
-class boundPath extends TlsClientInitializer {
-  val configClass = classOf[BoundPathConfig]
-  val configId = "io.l5d.clientTls.boundPath"
+class BoundPathInitializer extends TlsClientInitializer {
+  val configClass = classOf[boundPath]
 }
 
-case class BoundPathConfig(caCertPath: Option[String], names: Seq[NameMatcherConfig]) extends TlsClientConfig {
+object BoundPathInitializer extends BoundPathInitializer
+
+case class boundPath(caCertPath: Option[String], names: Seq[NameMatcherConfig]) extends TlsClientConfig {
   @JsonIgnore
   override def tlsClientPrep[Req, Rsp]: Module[Req, Rsp] = {
 

--- a/linkerd/tls/src/main/scala/io/l5d/clientTls/noValidation.scala
+++ b/linkerd/tls/src/main/scala/io/l5d/clientTls/noValidation.scala
@@ -7,7 +7,7 @@ import io.buoyant.linkerd.config.Parser
 import io.buoyant.linkerd.{TlsClientConfig, TlsClientInitializer}
 
 class noValidation extends TlsClientInitializer {
-  val configClass = Parser.jClass[NoValidationConfig]
+  val configClass = classOf[NoValidationConfig]
   val configId = "io.l5d.clientTls.noValidation"
 }
 

--- a/linkerd/tls/src/main/scala/io/l5d/clientTls/noValidation.scala
+++ b/linkerd/tls/src/main/scala/io/l5d/clientTls/noValidation.scala
@@ -6,12 +6,13 @@ import com.twitter.finagle.buoyant.TlsClientPrep.Module
 import io.buoyant.linkerd.config.Parser
 import io.buoyant.linkerd.{TlsClientConfig, TlsClientInitializer}
 
-class noValidation extends TlsClientInitializer {
-  val configClass = classOf[NoValidationConfig]
-  val configId = "io.l5d.clientTls.noValidation"
+class NoValidationInitializer extends TlsClientInitializer {
+  val configClass = classOf[noValidation]
 }
 
-class NoValidationConfig extends TlsClientConfig {
+object NoValidationInitializer extends NoValidationInitializer
+
+class noValidation extends TlsClientConfig {
   @JsonIgnore
   override def tlsClientPrep[Req, Rsp]: Module[Req, Rsp] =
     TlsClientPrep.withoutCertificateValidation[Req, Rsp]

--- a/linkerd/tls/src/main/scala/io/l5d/clientTls/static.scala
+++ b/linkerd/tls/src/main/scala/io/l5d/clientTls/static.scala
@@ -7,7 +7,7 @@ import io.buoyant.linkerd.config.Parser
 import io.buoyant.linkerd.{TlsClientConfig, TlsClientInitializer}
 
 class static extends TlsClientInitializer {
-  val configClass = Parser.jClass[StaticConfig]
+  val configClass = classOf[StaticConfig]
   val configId = "io.l5d.clientTls.static"
 }
 

--- a/linkerd/tls/src/main/scala/io/l5d/clientTls/static.scala
+++ b/linkerd/tls/src/main/scala/io/l5d/clientTls/static.scala
@@ -6,12 +6,13 @@ import com.twitter.finagle.buoyant.TlsClientPrep.Module
 import io.buoyant.linkerd.config.Parser
 import io.buoyant.linkerd.{TlsClientConfig, TlsClientInitializer}
 
-class static extends TlsClientInitializer {
-  val configClass = classOf[StaticConfig]
-  val configId = "io.l5d.clientTls.static"
+class StaticInitializer extends TlsClientInitializer {
+  val configClass = classOf[static]
 }
 
-case class StaticConfig(commonName: String, caCertPath: Option[String]) extends TlsClientConfig {
+object StaticInitializer extends StaticInitializer
+
+case class static(commonName: String, caCertPath: Option[String]) extends TlsClientConfig {
   @JsonIgnore
   override def tlsClientPrep[Req, Rsp]: Module[Req, Rsp] =
     TlsClientPrep.static[Req, Rsp](

--- a/linkerd/tls/src/test/scala/io/l5d/clientTls/boundPathTest.scala
+++ b/linkerd/tls/src/test/scala/io/l5d/clientTls/boundPathTest.scala
@@ -1,0 +1,15 @@
+package io.l5d.clientTls
+
+import com.twitter.finagle.util.LoadService
+import io.buoyant.linkerd.TlsClientInitializer
+import org.scalatest.FunSuite
+
+class boundPathTest extends FunSuite {
+  test("sanity") {
+    static("hello", None).tlsClientPrep
+  }
+
+  test("service registration") {
+    assert(LoadService[TlsClientInitializer].exists(_.isInstanceOf[BoundPathInitializer]))
+  }
+}

--- a/linkerd/tls/src/test/scala/io/l5d/clientTls/noValidationTest.scala
+++ b/linkerd/tls/src/test/scala/io/l5d/clientTls/noValidationTest.scala
@@ -1,0 +1,15 @@
+package io.l5d.clientTls
+
+import com.twitter.finagle.util.LoadService
+import io.buoyant.linkerd.TlsClientInitializer
+import org.scalatest.FunSuite
+
+class noValidationTest extends FunSuite {
+  test("sanity") {
+    new noValidation().tlsClientPrep
+  }
+
+  test("service registration") {
+    assert(LoadService[TlsClientInitializer].exists(_.isInstanceOf[NoValidationInitializer]))
+  }
+}

--- a/linkerd/tls/src/test/scala/io/l5d/clientTls/staticTest.scala
+++ b/linkerd/tls/src/test/scala/io/l5d/clientTls/staticTest.scala
@@ -1,0 +1,15 @@
+package io.l5d.clientTls
+
+import com.twitter.finagle.util.LoadService
+import io.buoyant.linkerd.TlsClientInitializer
+import org.scalatest.FunSuite
+
+class staticTest extends FunSuite {
+  test("sanity") {
+    static("hello", None).tlsClientPrep
+  }
+
+  test("service registration") {
+    assert(LoadService[TlsClientInitializer].exists(_.isInstanceOf[StaticInitializer]))
+  }
+}

--- a/project/LinkerdBuild.scala
+++ b/project/LinkerdBuild.scala
@@ -97,6 +97,7 @@ object LinkerdBuild extends Base {
 
       val fs = projectDir("linkerd/namer/fs")
         .dependsOn(core)
+        .withTests()
 
       val k8s = projectDir("linkerd/namer/k8s")
         .dependsOn(LinkerdBuild.k8s, core)
@@ -144,6 +145,7 @@ object LinkerdBuild extends Base {
 
     val tls = projectDir("linkerd/tls")
       .dependsOn(core)
+      .withTests()
 
     val all = projectDir("linkerd")
       .aggregate(admin, core, main, config, Namer.all, Protocol.all, tls)


### PR DESCRIPTION
There are two primary changes represented in this branch, broken into two commits:
* switch from using `Parser.jClass` to using `classOf` in most cases
* default the `configId` attribute for various initializers to reduce boilerplate
  * (this change required adjusting the naming so the `Config` subclasses now have the class name matching the value in the configuration YAML/JSON, rather than the `Initializer` subclasses)