### PR TITLE
TracerConfig and TracerInitializer

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,5 +1,8 @@
 ## 0.2.1
 
+* Configs may now include a `tracers` section with pluggable tracers (although
+  we don't provide any out of the box just yet)
+
 ## 0.2.0
 
 * This release contains **breaking changes** to the configuration file format.

--- a/linkerd/core/src/main/scala/io/buoyant/linkerd/NamerInitializer.scala
+++ b/linkerd/core/src/main/scala/io/buoyant/linkerd/NamerInitializer.scala
@@ -2,7 +2,7 @@ package io.buoyant.linkerd
 
 import com.fasterxml.jackson.annotation.JsonAutoDetect.Visibility
 import com.fasterxml.jackson.annotation.{JsonAutoDetect, JsonIgnore, JsonProperty, JsonTypeInfo}
-import com.twitter.finagle.{Namer, Path}
+import com.twitter.finagle.{Stack, Namer, Path}
 
 /**
  * Read a single namer configuration in the form:
@@ -35,7 +35,7 @@ trait NamerConfig {
    * Construct a namer.
    */
   @JsonIgnore
-  def newNamer(): Namer
+  def newNamer(params: Stack.Params): Namer
 }
 
 abstract class NamerInitializer extends ConfigInitializer

--- a/linkerd/core/src/main/scala/io/buoyant/linkerd/TracerInitializer.scala
+++ b/linkerd/core/src/main/scala/io/buoyant/linkerd/TracerInitializer.scala
@@ -1,0 +1,17 @@
+package io.buoyant.linkerd
+
+import com.fasterxml.jackson.annotation.JsonAutoDetect.Visibility
+import com.fasterxml.jackson.annotation.{JsonAutoDetect, JsonIgnore, JsonTypeInfo}
+import com.twitter.finagle.tracing.Tracer
+
+@JsonTypeInfo(use = JsonTypeInfo.Id.NAME, include = JsonTypeInfo.As.PROPERTY, property = "kind")
+@JsonAutoDetect(fieldVisibility = Visibility.ANY)
+trait TracerConfig {
+  /**
+   * Construct a tracer.
+   */
+  @JsonIgnore
+  def newTracer(): Tracer
+}
+
+abstract class TracerInitializer extends ConfigInitializer

--- a/linkerd/core/src/test/scala/io/buoyant/linkerd/ConflictingNamer.scala
+++ b/linkerd/core/src/test/scala/io/buoyant/linkerd/ConflictingNamer.scala
@@ -15,5 +15,5 @@ class ConflictingNamerConfig extends NamerConfig {
   @JsonIgnore
   override def defaultPrefix: Path = ???
   @JsonIgnore
-  override def newNamer(): Namer = ???
+  override def newNamer(params: Stack.Params): Namer = ???
 }

--- a/linkerd/core/src/test/scala/io/buoyant/linkerd/NamerInitializerTest.scala
+++ b/linkerd/core/src/test/scala/io/buoyant/linkerd/NamerInitializerTest.scala
@@ -1,7 +1,7 @@
 package io.buoyant.linkerd
 
 import com.twitter.finagle.naming.NameInterpreter
-import com.twitter.finagle.{Dtab, NameTree, Path}
+import com.twitter.finagle.{Stack, Dtab, NameTree, Path}
 import io.buoyant.linkerd.config.Parser
 import org.scalatest.FunSuite
 
@@ -11,7 +11,7 @@ class NamerInitializerTest extends FunSuite {
     val mapper = Parser.objectMapper(config)
     TestNamer.registerSubtypes(mapper)
     val cfg = mapper.readValue[Seq[NamerConfig]](config)
-    Linker.nameInterpreter(cfg)
+    Linker.nameInterpreter(Stack.Params.empty)(cfg)
   }
 
   val kind = "io.buoyant.linkerd.TestNamer"

--- a/linkerd/core/src/test/scala/io/buoyant/linkerd/NamerInitializersTest.scala
+++ b/linkerd/core/src/test/scala/io/buoyant/linkerd/NamerInitializersTest.scala
@@ -2,7 +2,7 @@ package io.buoyant.linkerd
 
 import com.fasterxml.jackson.databind.jsontype.NamedType
 import com.twitter.finagle.naming.NameInterpreter
-import com.twitter.finagle.{Dtab, Name, NameTree, Path}
+import com.twitter.finagle._
 import io.buoyant.linkerd.config.Parser
 import org.scalatest.FunSuite
 
@@ -23,7 +23,7 @@ class NamerInitializersTest extends FunSuite {
       new NamedType(Parser.jClass[booUrnsNamer], "io.buoyant.linkerd.booUrnsNamer")
     )
     val cfg = mapper.readValue[Seq[NamerConfig]](config)
-    Linker.nameInterpreter(cfg)
+    Linker.nameInterpreter(Stack.Params.empty)(cfg)
   }
 
   test("namers evaluated bottom-up") {

--- a/linkerd/core/src/test/scala/io/buoyant/linkerd/TestNamer.scala
+++ b/linkerd/core/src/test/scala/io/buoyant/linkerd/TestNamer.scala
@@ -1,7 +1,7 @@
 package io.buoyant.linkerd
 
 import com.fasterxml.jackson.annotation.JsonIgnore
-import com.twitter.finagle.{Addr, Name, NameTree, Namer, Path}
+import com.twitter.finagle._
 import com.twitter.util.{Activity, Var}
 import io.buoyant.linkerd.config.Parser
 
@@ -19,7 +19,7 @@ class TestNamerConfig extends NamerConfig { config =>
   var buh: Option[Boolean] = None
 
   @JsonIgnore
-  override def newNamer(): Namer = new Namer {
+  override def newNamer(params: Stack.Params): Namer = new Namer {
 
     val buh = config.buh.getOrElse(false)
 

--- a/linkerd/core/src/test/scala/io/buoyant/linkerd/TestTracer.scala
+++ b/linkerd/core/src/test/scala/io/buoyant/linkerd/TestTracer.scala
@@ -1,0 +1,20 @@
+package io.buoyant.linkerd
+
+import com.fasterxml.jackson.annotation.JsonIgnore
+import com.twitter.finagle.tracing.{Record, TraceId, Tracer}
+import io.buoyant.linkerd.config.Parser
+
+class TestTracer extends TracerInitializer {
+  val configClass = Parser.jClass[TestTracerConfig]
+  val configId = "io.buoyant.linkerd.TestTracer"
+}
+
+object TestTracer extends TestTracer
+
+class TestTracerConfig extends TracerConfig {
+  @JsonIgnore
+  override def newTracer(): Tracer = new Tracer {
+    def record(record: Record): Unit = {}
+    def sampleTrace(traceId: TraceId): Option[Boolean] = Some(true)
+  }
+}

--- a/linkerd/namer/consul/src/main/scala/io/l5d/consul.scala
+++ b/linkerd/namer/consul/src/main/scala/io/l5d/consul.scala
@@ -2,7 +2,7 @@ package io.l5d.experimental
 
 import com.fasterxml.jackson.annotation.JsonIgnore
 import com.twitter.finagle.param.Label
-import com.twitter.finagle.{Http, Path}
+import com.twitter.finagle.{Http, Path, Stack}
 import io.buoyant.consul.{CatalogNamer, SetHostFilter, v1}
 import io.buoyant.linkerd.config.Parser
 import io.buoyant.linkerd.config.types.Port
@@ -41,8 +41,9 @@ case class ConsulConfig(
    * Build a Namer backed by Consul.
    */
   @JsonIgnore
-  def newNamer(): CatalogNamer = {
+  def newNamer(params: Stack.Params): CatalogNamer = {
     val service = Http.client
+      .withParams(Http.client.params ++ params)
       .configured(Label("namer" + prefix))
       .filtered(new SetHostFilter(getHost, getPort))
       .newService(s"/$$/inet/$getHost/$getPort")

--- a/linkerd/namer/fs/src/main/scala/io/l5d/fs.scala
+++ b/linkerd/namer/fs/src/main/scala/io/l5d/fs.scala
@@ -1,7 +1,7 @@
 package io.l5d
 
 import com.fasterxml.jackson.annotation.JsonIgnore
-import com.twitter.finagle.Path
+import com.twitter.finagle.{Stack, Path}
 import io.buoyant.linkerd.config.Parser
 import io.buoyant.linkerd.config.types.Directory
 import io.buoyant.linkerd.namer.fs.WatchingNamer
@@ -22,6 +22,6 @@ object fs {
      * Construct a namer.
      */
     @JsonIgnore
-    def newNamer() = new WatchingNamer(rootDir.path, prefix)
+    def newNamer(params: Stack.Params) = new WatchingNamer(rootDir.path, prefix)
   }
 }

--- a/linkerd/namer/k8s/src/main/scala/io/l5d/k8s.scala
+++ b/linkerd/namer/k8s/src/main/scala/io/l5d/k8s.scala
@@ -61,7 +61,7 @@ case class k8sConfig(
    * Construct a namer.
    */
   @JsonIgnore
-  override def newNamer(): Namer = {
+  override def newNamer(params: Stack.Params): Namer = {
     val setHost = new SetHostFilter(getHost, getPort)
 
     val client = (tls, tlsWithoutValidation) match {
@@ -73,6 +73,7 @@ case class k8sConfig(
     // namer path -- should we just support a `label`?
     val path = prefix.show
     val service = client
+      .withParams(client.params ++ params)
       .configured(Label("namer" + path))
       .filtered(setHost)
       .filtered(authFilter)

--- a/linkerd/namer/k8s/src/test/scala/io/l5d/K8sTest.scala
+++ b/linkerd/namer/k8s/src/test/scala/io/l5d/K8sTest.scala
@@ -1,11 +1,12 @@
 package io.l5d.experimental
 
+import com.twitter.finagle.Stack
 import org.scalatest.FunSuite
 
 class K8sTest extends FunSuite {
 
   test("sanity") {
     // ensure it doesn't totally blowup
-    k8sConfig(None, None, None, None, None).newNamer()
+    k8sConfig(None, None, None, None, None).newNamer(Stack.Params.empty)
   }
 }

--- a/linkerd/namer/marathon/src/main/scala/io/l5d/marathon.scala
+++ b/linkerd/namer/marathon/src/main/scala/io/l5d/marathon.scala
@@ -3,7 +3,7 @@ package io.l5d.experimental
 import com.fasterxml.jackson.annotation.JsonIgnore
 import com.twitter.conversions.time._
 import com.twitter.finagle.param.Label
-import com.twitter.finagle.{Http, Path}
+import com.twitter.finagle.{Stack, Http, Path}
 import io.buoyant.linkerd.config.Parser
 import io.buoyant.linkerd.config.types.Port
 import io.buoyant.linkerd.{NamerConfig, NamerInitializer}
@@ -44,8 +44,9 @@ case class MarathonConfig(
   /**
    * Construct a namer.
    */
-  def newNamer() = {
+  def newNamer(params: Stack.Params) = {
     val service = Http.client
+      .withParams(params)
       .configured(Label("namer" + prefix.show))
       .newService(s"/$$/inet/$getHost/$getPort")
 

--- a/linkerd/namer/marathon/src/test/scala/io/l5d/MarathonTest.scala
+++ b/linkerd/namer/marathon/src/test/scala/io/l5d/MarathonTest.scala
@@ -1,11 +1,12 @@
 package io.l5d.experimental
 
+import com.twitter.finagle.Stack
 import org.scalatest.FunSuite
 
 class MarathonTest extends FunSuite {
 
   test("sanity") {
     // ensure it doesn't totally blowup
-    MarathonConfig(None, None, None).newNamer()
+    MarathonConfig(None, None, None).newNamer(Stack.Params.empty)
   }
 }

--- a/linkerd/namer/serversets/src/main/scala/io/l5d/serversets.scala
+++ b/linkerd/namer/serversets/src/main/scala/io/l5d/serversets.scala
@@ -1,7 +1,7 @@
 package io.l5d
 
 import com.fasterxml.jackson.annotation.JsonIgnore
-import com.twitter.finagle.Path
+import com.twitter.finagle.{Stack, Path}
 import io.buoyant.linkerd.config.Parser
 import io.buoyant.linkerd.config.types.Port
 import io.buoyant.linkerd.namer.serversets.ServersetNamer
@@ -24,7 +24,7 @@ case class ServersetsConfig(zkAddrs: Seq[ZkAddr]) extends NamerConfig {
   /**
    * Construct a namer.
    */
-  def newNamer() = new ServersetNamer(connectString)
+  def newNamer(params: Stack.Params) = new ServersetNamer(connectString)
 }
 
 case class ZkAddr(host: String, port: Option[Port]) {


### PR DESCRIPTION
I want to use my own tracer for linkerd routers and configure it
similar to how namers are configured.

My proposed solution is to add a top level `tracers` section to
the config. Each tracer requires a kind to be specified. See
TestTracer for an example on how I plan to use it