### PR TITLE
Fix thriftMethodInDst for Thrift compact protocol

### DIFF
--- a/router/thrift/src/main/scala/io/buoyant/router/Thrift.scala
+++ b/router/thrift/src/main/scala/io/buoyant/router/Thrift.scala
@@ -62,7 +62,8 @@ object Thrift extends Router[ThriftClientRequest, Array[Byte]]
       val RoutingFactory.DstPrefix(pfx) = params[RoutingFactory.DstPrefix]
       val param.MethodInDst(methodInDst) = params[param.MethodInDst]
       val RoutingFactory.BaseDtab(baseDtab) = params[RoutingFactory.BaseDtab]
-      Identifier(pfx, methodInDst, baseDtab)
+      val FinagleThrift.param.ProtocolFactory(protocol) = params[FinagleThrift.param.ProtocolFactory]
+      Identifier(pfx, methodInDst, baseDtab, protocol)
     }
   }
 

--- a/router/thrift/src/main/scala/io/buoyant/router/thrift/Identifier.scala
+++ b/router/thrift/src/main/scala/io/buoyant/router/thrift/Identifier.scala
@@ -5,17 +5,19 @@ import com.twitter.finagle.thrift.{Protocols, ThriftClientRequest}
 import com.twitter.finagle.{Dtab, Path}
 import com.twitter.util.Future
 import io.buoyant.router.RoutingFactory
+import org.apache.thrift.protocol.TProtocolFactory
 import org.apache.thrift.transport.TMemoryInputTransport
 
 case class Identifier(
   name: Path = Path.empty,
   methodInDst: Boolean = false,
-  dtab: () => Dtab = () => Dtab.base
+  dtab: () => Dtab = () => Dtab.base,
+  protocol: TProtocolFactory = Protocols.binaryFactory()
 ) extends RoutingFactory.Identifier[ThriftClientRequest] {
 
   private[this] def suffix(req: ThriftClientRequest): Path = {
     if (methodInDst) {
-      val messageName = Protocols.binaryFactory().getProtocol(
+      val messageName = protocol.getProtocol(
         new TMemoryInputTransport(req.message)
       ).readMessageBegin().name
       Path.read(s"/$messageName")


### PR DESCRIPTION
Problem:

The Thrift Identifier assumed the binary protocol when inspecting
requests for the Thrift method.

Solution:

Pass the actual protocol configured for the Router into the Identifier.

Fixes #124.

Note: I verified this fix manually, but any suggestions on appropriate
automated tests to add to this repo would be appreciated.