### PR TITLE
Establish a new client for each Kubernetes namespace.

### DIFF
--- a/linkerd/namer/k8s/src/main/scala/io/l5d/k8s.scala
+++ b/linkerd/namer/k8s/src/main/scala/io/l5d/k8s.scala
@@ -3,7 +3,6 @@ package io.l5d.experimental
 import com.fasterxml.jackson.annotation.JsonIgnore
 import com.twitter.finagle._
 import com.twitter.finagle.http.{Request, Response}
-import com.twitter.finagle.param.Label
 import io.buoyant.k8s.v1.Api
 import io.buoyant.k8s.{AuthFilter, EndpointsNamer, SetHostFilter}
 import io.buoyant.linkerd.config.Parser
@@ -28,15 +27,7 @@ class k8s extends NamerInitializer {
   val configId = "io.l5d.experimental.k8s"
 }
 
-object k8s extends k8s {
-  def authTokenFilter(authTokenFile: String): Filter[Request, Response, Request, Response] = {
-    val token = Source.fromFile(authTokenFile).mkString
-    if (token.isEmpty)
-      Filter.identity
-    else
-      new AuthFilter(token)
-  }
-}
+object k8s extends k8s
 
 case class k8sConfig(
   host: Option[String],
@@ -45,42 +36,48 @@ case class k8sConfig(
   tlsWithoutValidation: Option[Boolean],
   authTokenFile: Option[String]
 ) extends NamerConfig {
+
   @JsonIgnore
   override def defaultPrefix: Path = Path.read("/io.l5d.k8s")
 
   private[this] def getHost = host.getOrElse("kubernetes.default.cluster.local")
+
   private[this] def getPort = port match {
     case Some(p) => p.port
     case None => 443
   }
-  private[this] def authFilter: Filter[Request, Response, Request, Response] = authTokenFile match {
-    case Some(path) => k8s.authTokenFilter(path)
-    case None => Filter.identity
+
+  private[this] def authFilter = authTokenFile match {
+    case Some(path) =>
+      val token = Source.fromFile(path).mkString
+      if (token.nonEmpty) new AuthFilter(token)
+      else Filter.identity[Request, Response]
+    case None => Filter.identity[Request, Response]
   }
+
   /**
    * Construct a namer.
    */
   @JsonIgnore
   override def newNamer(params: Stack.Params): Namer = {
-    val setHost = new SetHostFilter(getHost, getPort)
-
-    val client = (tls, tlsWithoutValidation) match {
-      case (Some(false), _) => Http.client
-      case (_, Some(true)) => Http.client.withTlsWithoutValidation
-      case _ => Http.client.withTls(setHost.host)
+    val (host, port) = (getHost, getPort)
+    val client = {
+      val setHost = new SetHostFilter(host, port)
+      val client = (tls, tlsWithoutValidation) match {
+        case (Some(false), _) => Http.client
+        case (_, Some(true)) => Http.client.withTlsWithoutValidation
+        case _ => Http.client.withTls(setHost.host)
+      }
+      client.withParams(client.params ++ params)
+        .withStreaming(true)
+        .filtered(setHost)
+        .filtered(authFilter)
     }
-
-    // namer path -- should we just support a `label`?
-    val path = prefix.show
-    val service = client
-      .withParams(client.params ++ params)
-      .configured(Label("namer" + path))
-      .filtered(setHost)
-      .filtered(authFilter)
-      .withStreaming(true)
-      .newService(s"/$$/inet/$getHost/$getPort")
-
-    def mkNs(ns: String) = Api(service).namespace(ns)
+    val dst = s"/$$/inet/$host/$port"
+    def mkNs(ns: String) = {
+      val label = param.Label(s"namer${prefix.show}/$ns")
+      Api(client.configured(label).newService(dst)).namespace(ns)
+    }
     new EndpointsNamer(prefix, mkNs)
   }
 }


### PR DESCRIPTION
Currently, the k8s namer builds a single client at configuration-time.  In
theory, this is fine, but we have observed odd hanging behavior, as
described by #83.

Anecdotally, establishing a new client for each namespace has resolved this
issue in the past.  This does not provide a real _fix_ for the issue, though it
may offer some relief for the issue while we establish a more robust fix.