### PR TITLE
Annotate traces with router label

### DIFF
--- a/router/core/src/main/scala/io/buoyant/router/Router.scala
+++ b/router/core/src/main/scala/io/buoyant/router/Router.scala
@@ -231,7 +231,7 @@ trait StdStackRouter[Req, Rsp, This <: StdStackRouter[Req, Rsp, This]]
           params[DstBindingFactory.Capacity]
         )
 
-        Stack.Leaf(role, new RoutingFactory(newIdentifier(), cache))
+        Stack.Leaf(role, new RoutingFactory(newIdentifier(), cache, label))
       }
     }
 


### PR DESCRIPTION
In looking at traces emitted from linkerd, it would be helpful to be able to distinguish traces by router in linkerd setups with multiple routers.  Am updating RoutingFactory to add a "router.label" trace annotation prior to routing requests.