### PR TITLE
Add loadBalancer client config.

### DIFF
--- a/docs/config.md
+++ b/docs/config.md
@@ -49,6 +49,8 @@ routers:
       kind: io.l5d.clientTls.static
       commonName: foo
       caCertPath: /foo/caCert.pem
+    loadBalancer:
+      kind: ewma
   timeoutMs: 1000
 
 - protocol: thrift
@@ -150,6 +152,8 @@ local IPv4 interfaces.
 <a name="basic-client-params"></a>
 ### Basic client parameters
 
+#### TLS
+
 * *tls* -- The router will make requests using TLS if this parameter is
 provided.  It must be an object containing keys:
   * *kind* -- One of the supported TlsClientInitializer plugins, by
@@ -158,11 +162,11 @@ provided.  It must be an object containing keys:
 
 Current TLS plugins include:
 
-#### io.l5d.clientTls.noValidation
+##### io.l5d.clientTls.noValidation
 
 Skip hostname validation.  This is unsafe.
 
-#### io.l5d.clientTls.static
+##### io.l5d.clientTls.static
 
 Use a single common name for all TLS requests.  This assumes that all servers
 that the router connects to all use the same TLS cert (or all use certs
@@ -172,7 +176,7 @@ options:
 * *commonName* -- Required.  The common name to use for all TLS requests.
 * *caCertPath* -- Optional.  Use the given CA cert for common name validation.
 
-#### io.l5d.clientTls.boundPath
+##### io.l5d.clientTls.boundPath
 
 Determine the common name based on the destination bound path.  This plugin
 supports the following options:
@@ -196,6 +200,49 @@ names:
 - prefix: "/io.l5d.fs/{host}"
   commonNamePattern: "{host}.buoyant.io"
 ```
+
+#### Load Balancer
+
+* *loadBalancer* -- Specifies a load balancer to use.  It must be an object
+containing keys:
+  * *kind* -- One of the supported load balancers.
+  * Any options specific to the load balancer.
+
+If unspecified, p2c is used.
+
+Current load balancers include:
+
+[p2c]: https://twitter.github.io/finagle/guide/Clients.html#power-of-two-choices-p2c-least-loaded
+[ewma]: https://twitter.github.io/finagle/guide/Clients.html#power-of-two-choices-p2c-peak-ewma
+[aperture]: https://twitter.github.io/finagle/guide/Clients.html#aperture-least-loaded
+[heap]: https://twitter.github.io/finagle/guide/Clients.html#heap-least-loaded
+
+##### [p2c][p2c]
+
+p2c supports the following options (see [here][p2c] for option semantics and defaults):
+
+* *maxEffort* -- Optional.
+
+##### [ewma][ewma]
+
+ewma supports the following options (see [here][ewma] for option semantics and defaults):
+
+* *maxEffort* -- Optional.
+* *decayTimeMs* -- Optional.
+
+##### [aperture][aperture]
+
+aperture supports the following options (see [here][aperture] for option semantics and defaults):
+
+* *maxEffort* -- Optional.
+* *smoothWindowMs* -- Optional.
+* *lowLoad* -- Optional.
+* *highLoad* -- Optional.
+* *minAperture* -- Optional.
+
+##### [heap][heap]
+
+heap does not support any options.
 
 <a name="protocol-http"></a>
 ### HTTP/1.1 protocol parameters

--- a/linkerd/core/src/main/scala/io/buoyant/linkerd/LoadBalancerConfig.scala
+++ b/linkerd/core/src/main/scala/io/buoyant/linkerd/LoadBalancerConfig.scala
@@ -1,0 +1,56 @@
+package io.buoyant.linkerd
+
+import com.fasterxml.jackson.annotation.JsonSubTypes.Type
+import com.fasterxml.jackson.annotation.{JsonIgnore, JsonSubTypes, JsonTypeInfo}
+import com.twitter.conversions.time._
+import com.twitter.finagle.Stack
+import com.twitter.finagle.loadbalancer.{Balancers, LoadBalancerFactory}
+
+@JsonTypeInfo(use = JsonTypeInfo.Id.NAME, include = JsonTypeInfo.As.PROPERTY, property = "kind")
+@JsonSubTypes(Array(
+  new Type(value = classOf[P2C], name = "p2c"),
+  new Type(value = classOf[P2CEwma], name = "ewma"),
+  new Type(value = classOf[Aperture], name = "aperture"),
+  new Type(value = classOf[Heap], name = "heap")
+))
+trait LoadBalancerConfig {
+  val factory: LoadBalancerFactory
+
+  @JsonIgnore
+  def clientParams = Stack.Params.empty + LoadBalancerFactory.Param(factory)
+}
+
+case class P2C(maxEffort: Option[Int]) extends LoadBalancerConfig {
+  @JsonIgnore
+  val factory = Balancers.p2c(maxEffort.getOrElse(Balancers.MaxEffort))
+}
+
+case class P2CEwma(decayTimeMs: Option[Int], maxEffort: Option[Int]) extends LoadBalancerConfig {
+  @JsonIgnore
+  val factory = Balancers.p2cPeakEwma(
+    decayTime = decayTimeMs.map(_.millis).getOrElse(10.seconds),
+    maxEffort = maxEffort.getOrElse(Balancers.MaxEffort)
+  )
+}
+
+case class Aperture(
+  smoothWindowMs: Option[Int],
+  maxEffort: Option[Int],
+  lowLoad: Option[Double],
+  highLoad: Option[Double],
+  minAperture: Option[Int]
+) extends LoadBalancerConfig {
+  @JsonIgnore
+  val factory = Balancers.aperture(
+    smoothWin = smoothWindowMs.map(_.millis).getOrElse(5.seconds),
+    maxEffort = maxEffort.getOrElse(Balancers.MaxEffort),
+    lowLoad = lowLoad.getOrElse(0.5),
+    highLoad = highLoad.getOrElse(2.0),
+    minAperture = minAperture.getOrElse(1)
+  )
+}
+
+class Heap extends LoadBalancerConfig {
+  @JsonIgnore
+  val factory = Balancers.heap()
+}

--- a/linkerd/core/src/main/scala/io/buoyant/linkerd/Router.scala
+++ b/linkerd/core/src/main/scala/io/buoyant/linkerd/Router.scala
@@ -130,7 +130,9 @@ trait RouterConfig {
 class ClientConfig {
 
   var tls: Option[TlsClientConfig] = None
+  var loadBalancer: Option[LoadBalancerConfig] = None
 
   @JsonIgnore
   def clientParams: Stack.Params = Stack.Params.empty
+    .maybeWith(loadBalancer.map(_.clientParams))
 }

--- a/linkerd/core/src/test/scala/io/buoyant/linkerd/LoadBalancerTest.scala
+++ b/linkerd/core/src/test/scala/io/buoyant/linkerd/LoadBalancerTest.scala
@@ -1,0 +1,27 @@
+package io.buoyant.linkerd
+
+import com.twitter.finagle.loadbalancer.{DefaultBalancerFactory, LoadBalancerFactory}
+import org.scalatest.FunSuite
+
+class LoadBalancerTest extends FunSuite {
+
+  val balancers = Seq("p2c", "ewma", "aperture", "heap")
+
+  for (balancer <- balancers) {
+    test(balancer) {
+      val config = s"""
+      |routers:
+      |- protocol: plain
+      |  client:
+      |    loadBalancer:
+      |      kind: $balancer
+      |  servers:
+      |  - {}
+      |""".stripMargin
+
+      val linker = Linker.load(config, Seq(TestProtocol.Plain))
+      val factory = linker.routers.head.params[LoadBalancerFactory.Param]
+      assert(factory.loadBalancerFactory != DefaultBalancerFactory)
+    }
+  }
+}


### PR DESCRIPTION
Fixes #147 

Add a loadBalancer section to the client config where a load balancer can be
specified and configured.  The load balancers that are currently supported are
p2c, ewma, aperture, and heap.