### PR TITLE
Pluggable HTTP request identifiers

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,3 +1,8 @@
+## 0.3.0
+
+* Breaking change to configs: `httpUriInDst` is now specified under the
+  `identifier` header (see docs for add'l info)
+
 ## 0.2.1
 
 * Configs may now include a `tracers` section with pluggable tracers (although

--- a/docs/config.md
+++ b/docs/config.md
@@ -269,26 +269,14 @@ heap does not support any options.
 <a name="protocol-http"></a>
 ### HTTP/1.1 protocol parameters
 
-HTTP requests are routed by a combination of Host header, method, and URI.
-Specifically, HTTP/1.0 logical names are of the form:
-```
-  dstPrefix / "1.0" / method [/ uri* ]
-```
-and HTTP/1.1 logical names are of the form:
-```
-  dstPrefix / "1.1" / method / host [/ uri* ]
-```
-
-The default _dstPrefix_ is `/http`. In both cases, `uri` is only considered a part
-of the logical name if the config option `httpUriInDst` is true.
-
 Router configuration options include:
 * *httpAccessLog* -- Sets the access log path.  If not specified, no
 access log is written.
-* *httpUriInDst* -- If `true` http paths are appended to destinations. This allows
- path-prefix routing. (default: false)
+* *identifier* -- [Http-specific identifier](#protocol-http-identifiers) (default:
+default)
 
-The default server _port_ is 4140.
+The default _dstPrefix_ is `/http`
+The default server _port_ is 4140
 
 As an example, here's an http router config that routes all `GET` requests to
 8081 and all `POST` requests to 8091
@@ -304,6 +292,33 @@ routers:
   servers:
     port: 5000
 ```
+<a name="protocol-http-identifiers"></a>
+#### HTTP/1.1 Identifiers
+
+Identifiers are objects responsible for creating logical names from an incoming
+request with the following parameters:
+
+* *kind* -- One of the supported identifier plugins, by fully-qualified class
+ name. Current plugins include:
+  * *default*
+* *httpUriInDst* -- If `true` http paths are appended to destinations. This allows
+ path-prefix routing. (default: false)
+* any other identifier-specific parameters
+
+##### default
+
+HTTP requests are routed by a combination of Host header, method, and URI.
+Specifically, HTTP/1.0 logical names are of the form:
+```
+  dstPrefix / "1.0" / method [/ uri* ]
+```
+and HTTP/1.1 logical names are of the form:
+```
+  dstPrefix / "1.1" / method / host [/ uri* ]
+```
+
+In both cases, `uri` is only considered a part
+of the logical name if the config option `httpUriInDst` is true.
 
 <a name="protocol-thrift"></a>
 ### Thrift protocol parameters

--- a/examples/http.l5d
+++ b/examples/http.l5d
@@ -8,6 +8,9 @@ namers:
 # A simple HTTP router that looks up host header values in io.l5d.fs.
 routers:
 - protocol: http
+  identifier:
+    kind: default
+    httpUriInDst: true
   baseDtab: |
     /host => /io.l5d.fs;
     /host/127.0.0.1:4140 => /host/default;

--- a/linkerd/core/src/main/scala/io/buoyant/linkerd/IdentifierInitializer.scala
+++ b/linkerd/core/src/main/scala/io/buoyant/linkerd/IdentifierInitializer.scala
@@ -1,0 +1,5 @@
+package io.buoyant.linkerd
+
+import io.buoyant.linkerd.config.ConfigInitializer
+
+trait IdentifierInitializer extends ConfigInitializer

--- a/linkerd/core/src/main/scala/io/buoyant/linkerd/Linker.scala
+++ b/linkerd/core/src/main/scala/io/buoyant/linkerd/Linker.scala
@@ -25,10 +25,11 @@ object Linker {
     namer: Seq[NamerInitializer] = Nil,
     interpreter: Seq[InterpreterInitializer] = Nil,
     tlsClient: Seq[TlsClientInitializer] = Nil,
-    tracer: Seq[TracerInitializer] = Nil
+    tracer: Seq[TracerInitializer] = Nil,
+    identifier: Seq[IdentifierInitializer] = Nil
   ) {
     def iter: Iterable[Seq[ConfigInitializer]] =
-      Seq(protocol, namer, interpreter, tlsClient, tracer)
+      Seq(protocol, namer, interpreter, tlsClient, tracer, identifier)
 
     def parse(config: String): LinkerConfig =
       Linker.parse(config, this)
@@ -42,7 +43,8 @@ object Linker {
     LoadService[NamerInitializer],
     LoadService[InterpreterInitializer] :+ DefaultInterpreterInitializer,
     LoadService[TlsClientInitializer],
-    LoadService[TracerInitializer]
+    LoadService[TracerInitializer],
+    LoadService[IdentifierInitializer]
   )
 
   def parse(

--- a/linkerd/identifier/http/src/main/resources/META-INF/services/io.buoyant.linkerd.IdentifierInitializer
+++ b/linkerd/identifier/http/src/main/resources/META-INF/services/io.buoyant.linkerd.IdentifierInitializer
@@ -1,0 +1,1 @@
+io.l5d.identifier.DefaultHttpIdentifierInitializer

--- a/linkerd/identifier/http/src/main/scala/io/l5d/DefaultHttpIdentifierInitializer.scala
+++ b/linkerd/identifier/http/src/main/scala/io/l5d/DefaultHttpIdentifierInitializer.scala
@@ -1,0 +1,26 @@
+package io.l5d.identifier
+
+import com.fasterxml.jackson.annotation.JsonIgnore
+import com.twitter.finagle.{Dtab, Path}
+import io.buoyant.linkerd.IdentifierInitializer
+import io.buoyant.router.http.DefaultIdentifier
+import io.l5d.HttpIdentifierConfig
+
+class DefaultHttpIdentifierInitializer extends IdentifierInitializer {
+  val configClass = classOf[DefaultHttpIdentifierConfig]
+  override val configId = DefaultHttpIdentifierConfig.kind
+}
+
+object DefaultHttpIdentifierInitializer extends DefaultHttpIdentifierInitializer
+
+object DefaultHttpIdentifierConfig {
+  val kind = "default"
+}
+
+class DefaultHttpIdentifierConfig extends HttpIdentifierConfig {
+  @JsonIgnore
+  override def newIdentifier(
+    prefix: Path,
+    baseDtab: () => Dtab = () => Dtab.base
+  ) = DefaultIdentifier(prefix, httpUriInDst.getOrElse(false), baseDtab)
+}

--- a/linkerd/identifier/http/src/main/scala/io/l5d/HttpIdentifierConfig.scala
+++ b/linkerd/identifier/http/src/main/scala/io/l5d/HttpIdentifierConfig.scala
@@ -1,0 +1,19 @@
+package io.l5d
+
+import com.fasterxml.jackson.annotation.JsonAutoDetect.Visibility
+import com.fasterxml.jackson.annotation.{JsonAutoDetect, JsonIgnore, JsonTypeInfo}
+import com.twitter.finagle.{Dtab, Path, http}
+import io.buoyant.router.RoutingFactory.Identifier
+
+@JsonTypeInfo(use = JsonTypeInfo.Id.NAME, include = JsonTypeInfo.As.PROPERTY, property = "kind")
+@JsonAutoDetect(fieldVisibility = Visibility.ANY)
+trait HttpIdentifierConfig {
+  var httpUriInDst: Option[Boolean] = None
+
+  @JsonIgnore
+  def newIdentifier(
+    prefix: Path,
+    baseDtab: () => Dtab = () => Dtab.base
+  ): Identifier[http.Request]
+}
+

--- a/linkerd/identifier/http/src/test/scala/basicHttpTest.scala
+++ b/linkerd/identifier/http/src/test/scala/basicHttpTest.scala
@@ -1,0 +1,15 @@
+import com.twitter.finagle.Path
+import com.twitter.finagle.util.LoadService
+import io.buoyant.linkerd.IdentifierInitializer
+import io.l5d.identifier.{DefaultHttpIdentifierInitializer, DefaultHttpIdentifierConfig}
+import org.scalatest.FunSuite
+
+class basicHttpTest extends FunSuite {
+  test("sanity") {
+    new DefaultHttpIdentifierConfig().newIdentifier(Path.empty)
+  }
+
+  test("service registration") {
+    assert(LoadService[IdentifierInitializer].exists(_.isInstanceOf[DefaultHttpIdentifierInitializer]))
+  }
+}

--- a/linkerd/protocol/http/src/e2e/scala/io/buoyant/linkerd/protocol/HttpEndToEndTest.scala
+++ b/linkerd/protocol/http/src/e2e/scala/io/buoyant/linkerd/protocol/HttpEndToEndTest.scala
@@ -8,6 +8,8 @@ import com.twitter.finagle.stats.NullStatsReceiver
 import com.twitter.finagle.tracing.{Annotation, BufferingTracer, NullTracer}
 import com.twitter.finagle.{Http => FinagleHttp, Status => _, http => _, _}
 import com.twitter.util._
+import io.buoyant.router.Http
+import io.buoyant.router.http.DefaultIdentifier
 import io.buoyant.test.Awaits
 import java.net.InetSocketAddress
 import org.scalatest.FunSuite
@@ -73,7 +75,6 @@ class HttpEndToEndTest extends FunSuite with Awaits {
 routers:
 - protocol: http
   baseDtab: ${dtab.show}
-  httpUriInDst: true
   servers:
   - port: 0
 """
@@ -81,6 +82,7 @@ routers:
     val linker = Linker.Initializers(Seq(HttpInitializer)).load(yaml)
       .configured(param.Stats(stats))
       .configured(param.Tracer(tracer))
+      .configured(Http.param.HttpIdentifier((path, dtab) => DefaultIdentifier(path, true, dtab)))
     val router = linker.routers.head.initialize()
     val server = router.servers.head.serve()
 

--- a/linkerd/protocol/http/src/main/scala/io/buoyant/linkerd/protocol/HttpInitializer.scala
+++ b/linkerd/protocol/http/src/main/scala/io/buoyant/linkerd/protocol/HttpInitializer.scala
@@ -4,9 +4,9 @@ package protocol
 import com.fasterxml.jackson.annotation.JsonIgnore
 import com.twitter.finagle.buoyant.linkerd.{Headers, HttpTraceInitializer}
 import com.twitter.finagle.{Path, Stack, StackBuilder}
-import io.buoyant.linkerd.config.Parser
 import io.buoyant.linkerd.protocol.http.AccessLogger
 import io.buoyant.router.{Http, RoutingFactory}
+import io.l5d.HttpIdentifierConfig
 
 class HttpInitializer extends ProtocolInitializer.Simple {
   val name = "http"
@@ -45,7 +45,7 @@ object HttpInitializer extends HttpInitializer
 
 case class HttpConfig(
   httpAccessLog: Option[String],
-  httpUriInDst: Option[Boolean]
+  identifier: Option[HttpIdentifierConfig]
 ) extends RouterConfig {
 
   var client: Option[ClientConfig] = None
@@ -57,5 +57,5 @@ case class HttpConfig(
   @JsonIgnore
   override def routerParams: Stack.Params = super.routerParams
     .maybeWith(httpAccessLog.map(AccessLogger.param.File(_)))
-    .maybeWith(httpUriInDst.map(Http.param.UriInDst(_)))
+    .maybeWith(identifier.map(id => Http.param.HttpIdentifier(id.newIdentifier)))
 }

--- a/project/LinkerdBuild.scala
+++ b/project/LinkerdBuild.scala
@@ -83,6 +83,16 @@ object LinkerdBuild extends Base {
       .dependsOn(core)
       .withTests()
 
+
+    object Identifier {
+      val http = projectDir("linkerd/identifier/http")
+        .dependsOn(core, Router.http)
+        .withTests()
+
+      val all = projectDir("linkerd/identifier")
+        .aggregate(http)
+    }
+
     object Namer {
       val consul = projectDir("linkerd/namer/consul")
         .dependsOn(LinkerdBuild.consul, core)
@@ -117,6 +127,7 @@ object LinkerdBuild extends Base {
           core % "compile->compile;e2e->test;integration->test",
           tls % "integration",
           Namer.fs % "integration",
+          Identifier.http,
           Router.http)
 
       val mux = projectDir("linkerd/protocol/mux")
@@ -149,7 +160,7 @@ object LinkerdBuild extends Base {
       .withBuildProperties()
 
     val all = projectDir("linkerd")
-      .aggregate(admin, core, main, config, Namer.all, Protocol.all, tls)
+      .aggregate(admin, core, main, config, Identifier.all, Namer.all, Protocol.all, tls)
       .configs(Minimal, Bundle)
       // Minimal cofiguration includes a runtime, HTTP routing and the
       // fs service discovery.
@@ -158,6 +169,7 @@ object LinkerdBuild extends Base {
       .withLib(Deps.finagle("stats") % Minimal)
       // Bundle is includes all of the supported features:
       .configDependsOn(Bundle)(
+        Identifier.http,
         Namer.consul, Namer.k8s, Namer.marathon, Namer.serversets,
         Protocol.mux, Protocol.thrift,
         tls)
@@ -226,6 +238,8 @@ object LinkerdBuild extends Base {
   val linkerdAdmin = Linkerd.admin
   val linkerdConfig = Linkerd.config
   val linkerdCore = Linkerd.core
+  val linkerdIdentifier = Linkerd.Identifier.all
+  val linkerdIdentifierHttp = Linkerd.Identifier.http
   val linkerdMain = Linkerd.main
   val linkerdNamer = Linkerd.Namer.all
   val linkerdNamerConsul = Linkerd.Namer.consul

--- a/router/core/src/e2e/scala/io/buoyant/router/EchoEndToEndTest.scala
+++ b/router/core/src/e2e/scala/io/buoyant/router/EchoEndToEndTest.scala
@@ -58,15 +58,15 @@ class EchoEndToEndTest extends FunSuite with Awaits {
     }
 
     val echo = Downstream.identity("echo")
-    val oche = Downstream.reversed("oche")
+    val ohce = Downstream.reversed("ohce")
     val router = {
       val dtab = Dtab.read(s"""
         /p/echo => /$$/inet/127.1/${echo.port} ;
-        /p/oche => /$$/inet/127.1/${oche.port} ;
+        /p/ohce => /$$/inet/127.1/${ohce.port} ;
 
         /s => /p/echo ;
         /s/idk => /$$/fail ;
-        /s/dog => /p/oche ;
+        /s/dog => /p/ohce ;
       """)
 
       val factory = Echo.router
@@ -94,7 +94,7 @@ class EchoEndToEndTest extends FunSuite with Awaits {
     assert(await(client("dog/bark")) == "krab/god")
     withAnnotations { anns =>
       assert(anns.exists(_ == Annotation.BinaryAnnotation("namer.path", "/s/dog/bark")))
-      assert(anns.exists(_ == Annotation.BinaryAnnotation("dst.id", s"/$$/inet/127.1/${oche.port}")))
+      assert(anns.exists(_ == Annotation.BinaryAnnotation("dst.id", s"/$$/inet/127.1/${ohce.port}")))
       assert(anns.exists(_ == Annotation.BinaryAnnotation("dst.path", "/bark")))
     }
 
@@ -119,7 +119,7 @@ class EchoEndToEndTest extends FunSuite with Awaits {
     // todo check stats
 
     await(echo.server.close())
-    await(oche.server.close())
+    await(ohce.server.close())
     await(router.close())
   }
 

--- a/router/http/src/e2e/scala/io/buoyant/router/HttpEndToEndTest.scala
+++ b/router/http/src/e2e/scala/io/buoyant/router/HttpEndToEndTest.scala
@@ -72,7 +72,7 @@ class HttpEndToEndTest extends FunSuite with Awaits {
       val factory = Http.router
         .configured(RoutingFactory.BaseDtab(() => dtab))
         .configured(RoutingFactory.DstPrefix(Path.Utf8("http")))
-        .configured(Http.param.UriInDst(true))
+        .configured(Http.param.HttpIdentifier((path, dtab) => http.DefaultIdentifier(path, true, dtab)))
         .factory()
 
       Http.server

--- a/router/http/src/main/scala/io/buoyant/router/http/DefaultIdentifier.scala
+++ b/router/http/src/main/scala/io/buoyant/router/http/DefaultIdentifier.scala
@@ -5,7 +5,14 @@ import com.twitter.finagle.buoyant.Dst
 import com.twitter.util.Future
 import io.buoyant.router.RoutingFactory
 
-case class Identifier(
+object DefaultIdentifier {
+  def mk(
+    prefix: Path,
+    baseDtab: () => Dtab = () => Dtab.base
+  ): RoutingFactory.Identifier[http.Request] = DefaultIdentifier(prefix, false, baseDtab)
+}
+
+case class DefaultIdentifier(
   prefix: Path,
   uris: Boolean = false,
   baseDtab: () => Dtab = () => Dtab.base

--- a/router/http/src/test/scala/io/buoyant/router/http/IdentifierTest.scala
+++ b/router/http/src/test/scala/io/buoyant/router/http/IdentifierTest.scala
@@ -11,7 +11,7 @@ import org.scalatest.FunSuite
 class IdentifierTest extends FunSuite with Awaits {
 
   test("http/1.1 request without a host header") {
-    val identifier = Identifier(Path.Utf8("https"), false)
+    val identifier = DefaultIdentifier(Path.Utf8("https"), false)
     val req = Request()
     req.uri = "/some/path?other=stuff"
     intercept[IllegalArgumentException] {
@@ -20,7 +20,7 @@ class IdentifierTest extends FunSuite with Awaits {
   }
 
   test("http/1.1 request with a host header") {
-    val identifier = Identifier(Path.Utf8("https"), false)
+    val identifier = DefaultIdentifier(Path.Utf8("https"), false)
     val req = Request()
     req.uri = "/some/path?other=stuff"
     req.host = "domain"
@@ -28,7 +28,7 @@ class IdentifierTest extends FunSuite with Awaits {
   }
 
   test("http/1.1 with URIs") {
-    val identifier = Identifier(Path.Utf8("https"), true)
+    val identifier = DefaultIdentifier(Path.Utf8("https"), true)
     val req = Request()
     req.uri = "/some/path?other=stuff"
     req.host = "domain"
@@ -36,14 +36,14 @@ class IdentifierTest extends FunSuite with Awaits {
   }
 
   test("http/1.0") {
-    val identifier = Identifier(Path.Utf8("prefix"), false)
+    val identifier = DefaultIdentifier(Path.Utf8("prefix"), false)
     val req = Request(Method.Post, "/drum/bass")
     req.version = Version.Http10
     assert(await(identifier(req)) == Dst.Path(Path.read("/prefix/1.0/POST")))
   }
 
   test("http/1.0 with uri") {
-    val identifier = Identifier(Path.Utf8("prefix"), true)
+    val identifier = DefaultIdentifier(Path.Utf8("prefix"), true)
     val req = Request(Method.Post, "/drum/bass")
     req.version = Version.Http10
     assert(await(identifier(req)) == Dst.Path(Path.read("/prefix/1.0/POST/drum/bass")))


### PR DESCRIPTION
Adds a linkerd-identifer-http module, and uses the current http.Identifier for the BasicHttpIdentifierInitializer.

I'm not very happy about adding a finagle http dependency to linkerd-core, but I needed `HttpIdentifierInitializer` in core in order to call `LoadService[HttpIdentifierInitializer]()` ... while at the same time wanting it typed to `Identifier[http.Request]`. Not sure if anyone has suggestions there.

(also...the reverse of echo is ohce)

Fixes #120 