### PR TITLE
Add config options for controlling connection pool size.

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -8,6 +8,10 @@
   specified and configured.  The load balancers that are currently supported are
   p2c, ewma, aperture, and heap.
 * Add a config.json admin endpoint which re-serializes the parsed linkerd config.
+* Add a `maxConcurrentRequests` config option to limit number of concurrent
+  requests accepted by a server.
+* Add a `hostConnectionPool` client config section to control the number of
+  connections maintained to destination hosts.
 
 ## 0.2.0
 

--- a/docs/config.md
+++ b/docs/config.md
@@ -156,14 +156,28 @@ local IPv4 interfaces.
   It must be an object containing keys:
   * *certPath* -- File path to the TLS certificate file
   * *keyPath* -- File path to the TLS key file
+* *maxConcurrentRequests* -- Optional.  The maximum number of concurrent
+requests the server will accept.  (default: unlimited)
 
 <a name="basic-client-params"></a>
 ### Basic client parameters
 
+* *hostConnectionPool* -- Optional.  Configure the number of connections to
+maintain to each destination host.  It must be an object containing keys:
+  * *minSize* -- Optional. The minimum number of connections to maintain to each
+  host.  (default: 0)
+  * *maxSize* -- Optional.  The maximum number of connections to maintain to
+  each host.  (default: Int.MaxValue)
+  * *idleTimeMs* -- Optional.  The amount of idle time for which a connection is
+  cached in milliseconds.  (default: forever)
+  * *maxWaiters* -- Optional.  The maximum number of connection requests that
+  are queued when the connection concurrency exceeds maxSize.  (default:
+  Int.MaxValue)
+
 #### TLS
 
-* *tls* -- The router will make requests using TLS if this parameter is
-provided.  It must be an object containing keys:
+* *tls* -- Optional.  The router will make requests using TLS if this parameter
+is provided.  It must be an object containing keys:
   * *kind* -- One of the supported TlsClientInitializer plugins, by
   fully-qualified class name.
   * Any options specific to the plugin
@@ -211,8 +225,8 @@ names:
 
 #### Load Balancer
 
-* *loadBalancer* -- Specifies a load balancer to use.  It must be an object
-containing keys:
+* *loadBalancer* -- Optional.  Specifies a load balancer to use.  It must be an
+object containing keys:
   * *kind* -- One of the supported load balancers.
   * Any options specific to the load balancer.
 

--- a/linkerd/core/src/main/scala/io/buoyant/linkerd/Server.scala
+++ b/linkerd/core/src/main/scala/io/buoyant/linkerd/Server.scala
@@ -1,7 +1,9 @@
 package io.buoyant.linkerd
 
 import com.fasterxml.jackson.annotation.JsonIgnore
+import com.twitter.concurrent.AsyncSemaphore
 import com.twitter.finagle.Stack.{Param, Params}
+import com.twitter.finagle.filter.RequestSemaphoreFilter
 import com.twitter.finagle.ssl.Ssl
 import com.twitter.finagle.transport.Transport
 import com.twitter.finagle.{ListeningServer, Stack}
@@ -77,12 +79,15 @@ class ServerConfig { config =>
   var ip: Option[InetAddress] = None
   var tls: Option[TlsServerConfig] = None
   var label: Option[String] = None
+  var maxConcurrentRequests: Option[Int] = None
+
+  private[this] def requestSemaphore = maxConcurrentRequests.map(new AsyncSemaphore(_, 0))
 
   @JsonIgnore
   protected def serverParams: Stack.Params = Stack.Params.empty
     .maybeWith(tls.map {
       case TlsServerConfig(certPath, keyPath) => tlsParam(certPath, keyPath)
-    })
+    }) + RequestSemaphoreFilter.Param(requestSemaphore)
 
   @JsonIgnore
   private[this] def tlsParam(certificatePath: String, keyPath: String) =

--- a/linkerd/core/src/test/scala/io/buoyant/linkerd/HostConnectionPoolTest.scala
+++ b/linkerd/core/src/test/scala/io/buoyant/linkerd/HostConnectionPoolTest.scala
@@ -1,0 +1,31 @@
+package io.buoyant.linkerd
+
+import com.twitter.conversions.time._
+import com.twitter.finagle.client.DefaultPool
+import io.buoyant.linkerd.Linker.Initializers
+import org.scalatest.FunSuite
+
+class HostConnectionPoolTest extends FunSuite {
+
+  test("pool size") {
+    val config = """
+                   |routers:
+                   |- protocol: plain
+                   |  client:
+                   |    hostConnectionPool:
+                   |      minSize: 5
+                   |      maxSize: 100
+                   |      idleTimeMs: 5000
+                   |      maxWaiters: 10
+                   |  servers:
+                   |  - {}
+                   |""".stripMargin
+
+    val linker = Linker.load(config, Initializers(protocol = Seq(TestProtocol.Plain)))
+    val pool = linker.routers.head.params[DefaultPool.Param]
+    assert(pool.low == 5)
+    assert(pool.high == 100)
+    assert(pool.idleTime == 5.seconds)
+    assert(pool.maxWaiters == 10)
+  }
+}

--- a/linkerd/core/src/test/scala/io/buoyant/linkerd/ServerTest.scala
+++ b/linkerd/core/src/test/scala/io/buoyant/linkerd/ServerTest.scala
@@ -1,5 +1,6 @@
 package io.buoyant.linkerd
 
+import com.twitter.finagle.filter.RequestSemaphoreFilter
 import com.twitter.finagle.transport.Transport
 import com.twitter.util.{Return, Try}
 import io.buoyant.linkerd.config.Parser
@@ -91,5 +92,13 @@ fancyRouter: true
         |port: 1234
       """.stripMargin
     assert(parse(TestProtocol.Plain, yaml).get.params.apply[Transport.TLSServerEngine].e.isEmpty)
+  }
+
+  test("maxConcurrentRequests") {
+    val yaml =
+      """
+        |maxConcurrentRequests: 1000
+      """.stripMargin
+    assert(parse(TestProtocol.Plain, yaml).get.params[RequestSemaphoreFilter.Param].sem.get.numInitialPermits == 1000)
   }
 }


### PR DESCRIPTION
Add a `maxConcurrentRequests` config option to limit number of concurrent
requests accepted by a server and a `hostConnectionPool` client config section
to control the number of connections maintained to destination hosts.

Fixes #24