### PR TITLE
Allow control over thrift protocol upgrade

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -12,6 +12,8 @@
   requests accepted by a server.
 * Add a `hostConnectionPool` client config section to control the number of
   connections maintained to destination hosts.
+* Add a `attemptTTwitterUpgrade` thrift client config option to control whether
+  thrift protocol upgrade should be attempted.
 
 ## 0.2.0
 

--- a/docs/config.md
+++ b/docs/config.md
@@ -340,6 +340,8 @@ Thrift also supports additional *client* parameters:
    currently supports `binary` for `TBinaryProtocol` (default) and
    `compact` for `TCompactProtocol`. Typically this setting matches
    the router's servers' `thriftProtocol` param.
+* *attemptTTwitterUpgrade* -- controls whether thrift protocol upgrade should be
+   attempted.  (default: true)
 
 As an example: Here's a thrift router configuration that routes thrift--via
 buffered transport using the TCompactProtocol --from port 4004 to port 5005

--- a/linkerd/protocol/thrift/src/main/scala/io/buoyant/linkerd/protocol/ThriftInitializer.scala
+++ b/linkerd/protocol/thrift/src/main/scala/io/buoyant/linkerd/protocol/ThriftInitializer.scala
@@ -5,7 +5,7 @@ import com.fasterxml.jackson.annotation.JsonIgnore
 import com.twitter.finagle.Path
 import com.twitter.finagle.Stack.Params
 import com.twitter.finagle.Thrift.param
-import com.twitter.finagle.Thrift.param.ProtocolFactory
+import com.twitter.finagle.Thrift.param.{AttemptTTwitterUpgrade, ProtocolFactory}
 import io.buoyant.linkerd.config.Parser
 import io.buoyant.linkerd.config.types.ThriftProtocol
 import io.buoyant.router.{RoutingFactory, Thrift}
@@ -58,10 +58,12 @@ case class ThriftServerConfig(
 
 case class ThriftClientConfig(
   thriftFramed: Option[Boolean],
-  thriftProtocol: Option[ThriftProtocol]
+  thriftProtocol: Option[ThriftProtocol],
+  attemptTTwitterUpgrade: Option[Boolean]
 ) extends ClientConfig {
   @JsonIgnore
   override def clientParams: Params = super.clientParams
     .maybeWith(thriftFramed.map(param.Framed(_)))
     .maybeWith(thriftProtocol.map(proto => param.ProtocolFactory(proto.factory)))
+    .maybeWith(attemptTTwitterUpgrade.map(AttemptTTwitterUpgrade(_)))
 }

--- a/linkerd/protocol/thrift/src/test/scala/io/buoyant/linkerd/protocol/ThriftInitializerTest.scala
+++ b/linkerd/protocol/thrift/src/test/scala/io/buoyant/linkerd/protocol/ThriftInitializerTest.scala
@@ -2,6 +2,7 @@ package io.buoyant.linkerd.protocol
 
 import com.fasterxml.jackson.databind.JsonMappingException
 import com.twitter.finagle.Thrift.param
+import com.twitter.finagle.Thrift.param.AttemptTTwitterUpgrade
 import io.buoyant.linkerd.Linker
 import io.buoyant.router.Thrift.param.MethodInDst
 import org.apache.thrift.protocol.TCompactProtocol
@@ -17,6 +18,7 @@ class ThriftInitializerTest extends FunSuite {
       |  client:
       |    thriftFramed: false
       |    thriftProtocol: binary
+      |    attemptTTwitterUpgrade: false
       |  servers:
       |  - thriftFramed: true
       |    thriftProtocol: compact
@@ -29,6 +31,7 @@ class ThriftInitializerTest extends FunSuite {
     assert(!router.params[param.ProtocolFactory].protocolFactory.isInstanceOf[TCompactProtocol.Factory])
     assert(router.servers.head.params[param.Framed].enabled)
     assert(router.servers.head.params[param.ProtocolFactory].protocolFactory.isInstanceOf[TCompactProtocol.Factory])
+    assert(!router.params[AttemptTTwitterUpgrade].upgrade)
   }
 
   test("unsupported thrift protocol") {


### PR DESCRIPTION
Add a `attemptTTwitterUpgrade` thrift client config option to control whether
thrift protocol upgrade should be attempted.

Fixes #154 