### PR TITLE
Chart individual clients on admin index page

### DIFF
--- a/linkerd/admin/src/main/resources/io/buoyant/linkerd/admin/js/routers.js
+++ b/linkerd/admin/src/main/resources/io/buoyant/linkerd/admin/js/routers.js
@@ -36,12 +36,33 @@ var Routers = (function() {
   var clientRE = /^rt\/(.+)\/dst\/id\/(.*)\/requests$/,
       serverRE = /^rt\/(.+)\/srv\/([^/]+)\/(\d+)\/requests$/;
 
+  var mkColor = function() {
+    var colors = [
+      "224,243,219",
+      "204,235,197",
+      "168,221,181",
+      "123,204,196",
+      "78,179,211",
+      "43,140,190",
+      "8,104,172",
+      "8,64,129"
+    ];
+
+    //returns a color based on summed ascii values
+    return function(label) {
+      var idx = _.sumBy(label.split(""), function(char) { return char.charCodeAt(0); });
+      var color = colors[idx % colors.length];
+      return color;
+    }
+  }();
+
   function mk(router, label, prefix) {
     return {
       router: router,
       label: label,
       prefix: prefix,
-      metrics: {requests: -1}
+      metrics: {requests: -1},
+      color: mkColor(label)
     };
   }
 

--- a/linkerd/admin/src/main/resources/io/buoyant/linkerd/admin/js/summary.js
+++ b/linkerd/admin/src/main/resources/io/buoyant/linkerd/admin/js/summary.js
@@ -31,12 +31,12 @@ $.when(
     var selectedRouter = getSelectedRouter();
     var router = routers.data[selectedRouter];
     if (router)
-      var servers = router.servers;
+      var clients = _.values(router.dstIds);
     else
-      var servers = _(routers.data).values().flatMap('servers').value();
+      var clients = _(routers.data).values().flatMap(function(r){return _.values(r.dstIds);}).value();
 
     var procInfo = ProcInfo(),
-        bigBoard = BigBoard(servers, summaryTemplate),
+        bigBoard = BigBoard(clients, summaryTemplate),
         interfaces = Interfaces(selectedRouter, routers, namers, ifacesTemplate);
 
     procInfo.start(UPDATE_INTERVAL);
@@ -116,7 +116,9 @@ var BigBoard = (function() {
    */
   var init = function(servers, template) {
     // set up requests chart
-    chart.setMetrics(_.map(servers, function(server) { return server.prefix + "requests"; }));
+    chart.setMetrics(_.map(servers, function(server) {
+      return {name: server.prefix + "requests", color: server.color};
+    }));
 
     // set up metrics
     $('#request-stats').html(template({keys: summaryKeys}));
@@ -214,6 +216,7 @@ var Interfaces = (function() {
     var iface = prepInterface(client);
     iface.lbSize = client.metrics["loadbalancer/size"] || 0;
     iface.lbAvail = client.metrics["loadbalancer/available"] || 0;
+    iface.color = "rgb(" + client.color + ")";
     return iface;
   }
 

--- a/linkerd/admin/src/main/resources/io/buoyant/linkerd/admin/js/summary.js
+++ b/linkerd/admin/src/main/resources/io/buoyant/linkerd/admin/js/summary.js
@@ -29,14 +29,8 @@ $.when(
 
   $(function() {
     var selectedRouter = getSelectedRouter();
-    var router = routers.data[selectedRouter];
-    if (router)
-      var clients = _.values(router.dstIds);
-    else
-      var clients = _(routers.data).values().flatMap(function(r){return _.values(r.dstIds);}).value();
-
     var procInfo = ProcInfo(),
-        bigBoard = BigBoard(clients, summaryTemplate),
+        bigBoard = BigBoard(selectedRouter, routers, summaryTemplate),
         interfaces = Interfaces(selectedRouter, routers, namers, ifacesTemplate);
 
     procInfo.start(UPDATE_INTERVAL);
@@ -102,23 +96,45 @@ var ProcInfo = (function() {
  * Big summary board of server requests
  */
 var BigBoard = (function() {
-  var summaryKeys = ['load', 'failures', 'success', 'requests'],
-      chart = new UpdateableChart(
-        {minValue: 0},
-        document.getElementById("request-canvas"),
-        function() {
-          return window.innerWidth * 0.75;
-        }
-      );
+  var summaryKeys = ['load', 'failures', 'success', 'requests'];
+  var chart = new UpdateableChart(
+    {minValue: 0},
+    document.getElementById("request-canvas"),
+    function() {
+      return window.innerWidth * 0.75;
+    }
+  );
+  var metricsParams = [];
+
+  function url() {
+    return "/admin/metrics?" + $.param({m: metricsParams}, true);
+  }
+
+  function clientToMetric(client) {
+    return {name: client.prefix + "requests", color: client.color};
+  }
+
+  function clientsToMetricParam(clients) {
+    return _(clients).map(function(client) {
+      return _.map(summaryKeys, function(key) {
+        return client.prefix + key;
+      });
+    }).flatten().value();
+  }
+
+  function addClients(clients) {
+    chart.addMetrics(_.map(clients, clientToMetric));
+    metricsParams = metricsParams.concat(clientsToMetricParam(clients));
+  }
 
   /**
    * Returns a function that may be called to trigger an update.
    */
-  var init = function(servers, template) {
+  var init = function(selectedRouter, routers, template) {
     // set up requests chart
-    chart.setMetrics(_.map(servers, function(server) {
-      return {name: server.prefix + "requests", color: server.color};
-    }));
+    chart.setMetrics(_.map(routers.clients(selectedRouter), clientToMetric));
+
+    routers.onAddedClients(addClients);
 
     // set up metrics
     $('#request-stats').html(template({keys: summaryKeys}));
@@ -132,16 +148,11 @@ var BigBoard = (function() {
       }
     });
 
-    var metricsParams = _(servers).map(function(server) {
-      return _.map(summaryKeys, function(key) {
-        return server.prefix + key;
-      });
-    }).flatten().value();
+    metricsParams = clientsToMetricParam(routers.clients(selectedRouter));
 
-    var url = "/admin/metrics?" + $.param({m: metricsParams}, true);
     function update() {
       $.ajax({
-        url: url,
+        url: url(),
         dataType: "json",
         cache: false,
         success: function(data) {
@@ -228,22 +239,23 @@ var Interfaces = (function() {
     return sortBySuccess(servers.map(prepInterface));
   }
 
-  function renderInterfaces(routers, namers, template) {
-    var servers = _(routers)
-      .map('servers')
-      .flatten()
-      .value();
-
-    var clients = _(routers)
-      .map(function(router) { return _.values(router.dstIds); })
-      .flatten()
-      .value();
-
+  function renderInterfaces(selectedRouter, routers, namers, template) {
     var namerIfaces = _.map(namers, prepInterface);
 
-    $('#client-info').html(template({name:'router clients', interfaces: prepClients(clients)}));
-    $('#server-info').html(template({name:'router servers', interfaces: prepServers(servers)}));
-    $('#namer-info').html(template({name:'namer clients', interfaces: sortBySuccess(namerIfaces)}));
+    $('#client-info').html(template({
+      name:'router clients',
+      interfaces: prepClients(routers.clients(selectedRouter))
+    }));
+
+    $('#server-info').html(template({
+      name:'router servers',
+      interfaces: prepServers(routers.servers(selectedRouter))
+    }));
+
+    $('#namer-info').html(template({
+      name:'namer clients',
+      interfaces: sortBySuccess(namerIfaces)
+    }));
   }
 
   /**
@@ -252,10 +264,9 @@ var Interfaces = (function() {
    */
   return function(selectedRouter, routers, namers, template) {
     var router = routers.data[selectedRouter];
-    var routerData = router ? [router] : routers.data;
     var namerData = router ? [] : namers.data;
 
-    renderInterfaces(routerData, namerData, template);
+    renderInterfaces(selectedRouter, routers, namerData, template);
     $(".interfaces").on("click", ".interface", function() {
       window.location = $(this).find("a").attr("href");
       return false;
@@ -269,7 +280,7 @@ var Interfaces = (function() {
         success: function(metrics) {
           routers.update(metrics);
           namers.update(metrics);
-          renderInterfaces(routerData, namerData, template);
+          renderInterfaces(selectedRouter, routers, namerData, template);
         }
       });
     };

--- a/linkerd/admin/src/main/resources/io/buoyant/linkerd/admin/js/utils.js
+++ b/linkerd/admin/src/main/resources/io/buoyant/linkerd/admin/js/utils.js
@@ -102,7 +102,7 @@ function UpdateableChart(userOpts, canvas, widthFn) {
 
   this.chart = undefined;
   this.timeout = undefined;
-  this.ts = undefined;
+  this.tsMap = undefined;
 
   var defaults = {
     grid: {
@@ -128,7 +128,7 @@ function UpdateableChart(userOpts, canvas, widthFn) {
 }
 
 UpdateableChart.prototype.setMetric = function(metric) {
-  this.setMetrics([metric]);
+  this.setMetrics([{ name: metric, color: "83,176,196"}]);
 }
 
 UpdateableChart.prototype.setMetrics = function(metrics) {
@@ -141,44 +141,55 @@ UpdateableChart.prototype.setMetrics = function(metrics) {
   }
 
   this.tsMap = {};
+  _.each(metrics, this._addMetric.bind(this));
 
-  _.each(metrics, function(metric) {
-    this.tsMap[metric.name] = new TimeSeries();
-    this.chart.addTimeSeries(
-      this.tsMap[metric.name],
-      {
-        strokeStyle: "rgb(" + metric.color + ")",
-        fillStyle: "rgba(" + metric.color + ",0.3)",
-        lineWidth: 3
-    });
-  }.bind(this));
+  this.metrics = _.map(metrics, 'name');
+  this._getMetrics();
+}
 
-  this._getMetrics(_.map(metrics, 'name'));
+UpdateableChart.prototype.addMetrics = function(metrics) {
+  _.each(metrics, this._addMetric.bind(this));
+  this.metrics = this.metrics.concat(_.map(metrics, 'name'));
+}
+
+UpdateableChart.prototype._addMetric = function(metric) {
+  this.tsMap[metric.name] = new TimeSeries();
+  this.chart.addTimeSeries(
+    this.tsMap[metric.name],
+    {
+      strokeStyle: "rgb(" + metric.color + ")",
+      fillStyle: "rgba(" + metric.color + ",0.3)",
+      lineWidth: 3
+  });
 }
 
 UpdateableChart.prototype._resize = function() {
   this.canvas.width = this.widthFn();
 }
 
-UpdateableChart.prototype._getMetrics = function(metrics) {
-  $.ajax({
-    url: "/admin/metrics?" + $.param({m: metrics}, true), //use shallow/traditional encoding
-    dataType: "json",
-    cache: false,
-    success: (function(data) {
-      _.each(data, function(datum){
-        this.tsMap[datum.name].append(new Date().getTime(), datum.delta);
-      }.bind(this));
+UpdateableChart.prototype._getMetrics = function() {
+  if (this.metrics.length) {
+    $.ajax({
+      url: "/admin/metrics?" + $.param({m: this.metrics}, true), //use shallow/traditional encoding
+      dataType: "json",
+      cache: false,
+      success: (function(data) {
+        _.each(data, function(datum){
+          this.tsMap[datum.name].append(new Date().getTime(), datum.delta);
+        }.bind(this));
 
-      $(this.canvas).trigger(
-        "stat",
-        [
-          metrics,
-          _.sumBy(data, 'delta')
-        ]
-      );
+        $(this.canvas).trigger(
+          "stat",
+          [
+            this.metrics,
+            _.sumBy(data, 'delta')
+          ]
+        );
 
-      this.timeout = setTimeout(this._getMetrics.bind(this, metrics), 1000);
-    }).bind(this)
-  });
+        this.timeout = setTimeout(this._getMetrics.bind(this), 1000);
+      }).bind(this)
+    });
+  } else {
+    this.timeout = setTimeout(this._getMetrics.bind(this), 1000);
+  }
 }

--- a/linkerd/admin/src/main/resources/io/buoyant/linkerd/admin/template/interfaces.template
+++ b/linkerd/admin/src/main/resources/io/buoyant/linkerd/admin/template/interfaces.template
@@ -2,7 +2,7 @@
   <h1 class="text-center">{{name}}</h3>
   <div class="row">
   {{#each interfaces}}
-    <div class="col-sm-3">
+    <div class="col-sm-4">
       <div class="interface">
         <div class="row">
           <h3 class="sr-text col-sm-6 {{rateStyle}}">{{prettyRate}}</h3>
@@ -10,7 +10,9 @@
         </div>
         <hr>
         <div class="row name" title="{{name}}">
-          <a href="/metrics#{{requestsKey}}">{{name}}</a>
+          <a {{#if color}}style="color:{{color}}"{{/if}} href="/metrics#{{requestsKey}}">
+            {{name}}
+          </a>
         </div>
         <div class="row connections">
           {{connections}} active {{pluralize connections 'connection' 'connections'}}


### PR DESCRIPTION
Recent demos suggest that the admin front page is more useful if
clients are individually charted instead of only showing a some of
all requests. This change assigns colors to each client and uses
that color to chart requests.

Please help me choose some not-terrible colors. Fixes #149 

![screen shot 2016-03-14 at 4 42 53 pm](https://cloud.githubusercontent.com/assets/41829/13763659/20f9a276-ea05-11e5-97f5-f952d8a9867d.png)
