### PR TITLE
Change Marathon's AppID namer to ignore non-fatal failures

### DIFF
--- a/docs/config.md
+++ b/docs/config.md
@@ -26,7 +26,9 @@ routers:
     /host     => /io.l5d.fs;
     /method   => /$/io.buoyant.http.anyMethodPfx/host;
     /http/1.1 => /method;
-  httpUriInDst: true
+  identifier:
+    kind: default
+    httpUriInDst: true
   servers:
   - port: 4140
     ip: 0.0.0.0

--- a/examples/consul.l5d
+++ b/examples/consul.l5d
@@ -8,8 +8,9 @@ routers:
     /host     => /consul/dc1;
     /method   => /$/io.buoyant.http.anyMethodPfx/host;
     /http/1.1 => /method;
-
-  httpUriInDst: true
+  identifier:
+    kind: default
+    httpUriInDst: true
   servers:
   - port: 4140
     ip: 0.0.0.0

--- a/examples/marathon.l5d
+++ b/examples/marathon.l5d
@@ -12,7 +12,9 @@ routers:
     /host       => /$/io.buoyant.http.domainToPathPfx/marathonId;
     /method     => /$/io.buoyant.http.anyMethodPfx/host;
     /http/1.1   => /method;
-  httpUriInDst: true
+  identifier:
+    kind: default
+    httpUriInDst: true
   servers:
   - port: 4140
     ip: 0.0.0.0

--- a/marathon/src/main/scala/io/buoyant/marathon/v2/AppIdNamer.scala
+++ b/marathon/src/main/scala/io/buoyant/marathon/v2/AppIdNamer.scala
@@ -53,7 +53,7 @@ class AppIdNamer(
         Trace.recordBinary("marathon.found", found.isDefined)
         found match {
           case Some(name) => NameTree.Leaf(name)
-          case None =>  NameTree.Neg
+          case None => NameTree.Neg
         }
       }
     }

--- a/marathon/src/main/scala/io/buoyant/marathon/v2/AppIdNamer.scala
+++ b/marathon/src/main/scala/io/buoyant/marathon/v2/AppIdNamer.scala
@@ -8,7 +8,6 @@ import java.net.SocketAddress
 
 object AppIdNamer {
   object Closed extends Throwable
-  val log = Api.log
 }
 
 class AppIdNamer(
@@ -21,7 +20,6 @@ class AppIdNamer(
   import AppIdNamer._
 
   private[this] implicit val _timer = timer
-  private[this] case class PathSpan(app: Path, residual: Path)
 
   /**
    * Accepts names in the form:
@@ -37,93 +35,110 @@ class AppIdNamer(
    * Marathon master.
    */
   def lookup(path: Path): Activity[NameTree[Name]] =
-    appsActivity.map {
-      case apps =>
+    if (path.isEmpty) Activity.value(NameTree.Neg)
+    else {
+      // each time the map of all Apps updates, find the
+      // shortest-matching part of `path` that exists as an App ID.
+      val possibleIds = (1 to path.size).map(path.take(_))
+      appsActivity.map { apps =>
         Trace.recordBinary("marathon.path", path.show)
-
-        // enumerate all possible span lengths that could be marathon ids
-        val possibleSpans: Seq[PathSpan] = 1 to path.size map { i: Int =>
-          PathSpan(path.take(i), path.drop(i))
-        }
-
-        possibleSpans.find(sp => apps(sp.app.show)) match {
-          case Some(PathSpan(app, residual)) =>
-            val id = prefix ++ app
-
+        val found = possibleIds.collectFirst {
+          case app if apps(app) =>
             Trace.recordBinary("marathon.appId", app.show)
-            Trace.recordBinary("marathon.id", id.show)
-            Trace.recordBinary("marathon.found", app.show)
-
-            val addr = getAndMonitorAddr(app.show)
-            NameTree.Leaf(Name.Bound(addr, id, residual))
-
-          case None =>
-            Trace.recordBinary("marathon.notfound", path.show)
-            NameTree.Neg
+            val residual = path.drop(app.size)
+            val id = prefix ++ app
+            val addr = getAndMonitorAddr(app)
+            Name.Bound(addr, id, residual)
         }
+        Trace.recordBinary("marathon.found", found.isDefined)
+        found match {
+          case Some(name) => NameTree.Leaf(name)
+          case None =>  NameTree.Neg
+        }
+      }
     }
 
-  private[this] val appsActivity: Activity[Api.AppIds] = {
-    val states = Var.async[Activity.State[Api.AppIds]](Activity.Pending) { state =>
-      def loop(): Future[Unit] =
-        api.getAppIds().transform {
+  private[this] val appsActivity: Activity[Api.AppIds] =
+    Activity(Var.async[Activity.State[Api.AppIds]](Activity.Pending) { state =>
+      @volatile var initialized, stopped = false
+      @volatile var pending: Future[_] = Future.never
+
+      def loop(): Unit = if (!stopped) {
+        pending = api.getAppIds().respond {
           case Return(apps) =>
+            initialized = true
             state() = Activity.Ok(apps)
-            Future.sleep(ttl).before(loop())
+            Trace.recordBinary("marathon.apps", apps.map(_.show).mkString(","))
+            if (!stopped) {
+              pending = Future.sleep(ttl).onSuccess(_ => loop())
+            }
 
           case Throw(NonFatal(e)) =>
-            state() = Activity.Failed(e)
-            Future.sleep(ttl).before(loop())
+            if (!initialized) {
+              state() = Activity.Failed(e)
+            }
+            if (!stopped) {
+              pending = Future.sleep(ttl).onSuccess(_ => loop())
+            }
 
           case Throw(e) =>
             state() = Activity.Failed(e)
-            Future.exception(e)
         }
+      }
 
-      val work = loop()
+      loop()
       Closable.make { deadline =>
-        work.raise(Closed)
+        stopped = true
+        pending.raise(Closed)
         Future.Unit
       }
-    }
-    Activity(states)
-  }
+    })
 
-  private[this] var appMonitors: Map[String, Var[Addr]] = Map.empty
-  private[this] def getAndMonitorAddr(app: String): Var[Addr] = synchronized {
+  private[this] var appMonitors: Map[Path, Var[Addr]] = Map.empty
+
+  private[this] def getAndMonitorAddr(app: Path): Var[Addr] = synchronized {
     appMonitors.get(app) match {
       case Some(addr) => addr
 
       case None =>
         val addr = Var.async[Addr](Addr.Pending) { addr =>
-          def loop(): Future[Unit] =
-            api.getAddrs(app).transform { ret =>
-              ret match {
-                case Return(addrs) =>
-                  addr() = Addr.Bound(addrs)
-                  Future.sleep(ttl).before(loop())
+          @volatile var initialized, stopped = false
+          @volatile var pending: Future[_] = Future.never
 
-                case Throw(NonFatal(e)) =>
-                  addr() = Addr.Failed(e)
-                  Future.sleep(ttl).before(loop())
+          def loop(): Unit = if (!stopped) {
+            pending = api.getAddrs(app).respond {
+              case Return(addrs) =>
+                initialized = true
+                addr() = Addr.Bound(addrs)
+                if (!stopped) {
+                  pending = Future.sleep(ttl).onSuccess(_ => loop())
+                }
 
-                case Throw(e) =>
+              case Throw(NonFatal(e)) =>
+                if (!initialized) {
                   addr() = Addr.Failed(e)
-                  Future.exception(e)
-              }
+                }
+                if (!stopped) {
+                  pending = Future.sleep(ttl).onSuccess(_ => loop())
+                }
+
+              case Throw(e) =>
+                addr() = Addr.Failed(e)
             }
+          }
 
-          val work = loop()
+          loop()
           Closable.make { deadline =>
+            stopped = true
             synchronized {
               appMonitors -= app
             }
-            work.raise(Closed)
+            pending.raise(Closed)
             Future.Unit
           }
         }
-        appMonitors += (app -> addr)
 
+        appMonitors += (app -> addr)
         addr
     }
   }

--- a/marathon/src/test/scala/io/buoyant/marathon/v2/AppIdNamerTest.scala
+++ b/marathon/src/test/scala/io/buoyant/marathon/v2/AppIdNamerTest.scala
@@ -8,40 +8,36 @@ import java.net.{InetSocketAddress, SocketAddress}
 import org.scalatest.FunSuite
 
 class AppIdNamerTest extends FunSuite with Awaits {
+  case class TestApi(
+    ids: Future[Api.AppIds] = Future.never,
+    addrs: Future[Set[Address]] = Future.never
+  ) extends Api {
+    def getAppIds(): Future[Api.AppIds] = ids
+    def getAddrs(app: Path): Future[Set[Address]] = addrs
+  }
 
   test("Namer stays pending while looking up appId for the first time") {
-    class TestApi() extends Api {
-      def getAppIds(): Future[Api.AppIds] = Future.never
-      def getAddrs(app: String): Future[Set[Address]] = Future.never
-    }
-
-    val namer = new AppIdNamer(new TestApi(), Path.Utf8("io.l5d.marathon"), 250.millis)
+    val namer = new AppIdNamer(TestApi(), Path.Utf8("io.l5d.marathon"), 250.millis)
     @volatile var state: Activity.State[NameTree[Name]] = Activity.Pending
     namer.lookup(Path.read("/servicename/residual")).states.respond(state = _)
-
     assert(state == Activity.Pending)
   }
 
   test("Namer fails if the marathon api cannot be reached") {
-    class TestApi() extends Api {
-      def getAppIds(): Future[Api.AppIds] = Future.exception(ChannelWriteException(null))
-      def getAddrs(app: String): Future[Set[Address]] = Future.never
-    }
+    val err = ChannelWriteException(null)
+    val api = TestApi(ids = Future.exception(err))
+    val namer = new AppIdNamer(api, Path.Utf8("io.l5d.marathon"), 250.millis)
 
-    val namer = new AppIdNamer(new TestApi(), Path.Utf8("io.l5d.marathon"), 250.millis)
     @volatile var state: Activity.State[NameTree[Name]] = Activity.Pending
     namer.lookup(Path.read("/servicename/residual")).states.respond(state = _)
 
-    assert(state == Activity.Failed(ChannelWriteException(null)))
+    assert(state == Activity.Failed(err))
   }
 
   test("Namer returns neg when appId does not exist") {
-    class TestApi() extends Api {
-      def getAppIds(): Future[Api.AppIds] = Future.value(Set[String]("/foo", "/bar"))
-      def getAddrs(app: String): Future[Set[Address]] = Future.never
-    }
+    val api = TestApi(ids = Future.value(Set(Path.Utf8("foo"), Path.Utf8("bar"))))
+    val namer = new AppIdNamer(api, Path.Utf8("io.l5d.marathon"), 250.millis)
 
-    val namer = new AppIdNamer(new TestApi(), Path.Utf8("io.l5d.marathon"), 250.millis)
     @volatile var state: Activity.State[NameTree[Name]] = Activity.Pending
     namer.lookup(Path.read("/nosuchservice/residual")).states.respond(state = _)
 
@@ -49,39 +45,27 @@ class AppIdNamerTest extends FunSuite with Awaits {
   }
 
   test("Namer handles looking up /app/id") {
-    class TestApi() extends Api {
-      def getAppIds(): Future[Api.AppIds] = {
-        Future.value(Set("/service/name"))
-      }
-      def getAddrs(app: String): Future[Set[Address]] = Future.never
-    }
-
-    val namer = new AppIdNamer(new TestApi(), Path.Utf8("io.l5d.marathon"), 250.millis)
-    @volatile var state: Activity.State[NameTree[Name]] = Activity.Pending
+    val api = TestApi(ids = Future.value(Set(Path.read("/service/name"))))
+    val namer = new AppIdNamer(api, Path.Utf8("io.l5d.marathon"), 250.millis)
 
     val input = Path.Utf8("service", "name", "residual")
     val output = Path.Utf8("io.l5d.marathon", "service", "name")
+    @volatile var state: Activity.State[NameTree[Name]] = Activity.Pending
     namer.lookup(input).states.respond(state = _)
+
     assert(state == Activity.Ok(NameTree.Leaf(output)))
   }
 
   test("Namer updates when blocking call from getAppIds returns") {
-    val blockingCallResponder = new Promise[Unit]
+    val promisedAppIds = new Promise[Api.AppIds]
+    val api = TestApi(ids = promisedAppIds)
+    val namer = new AppIdNamer(api, Path.Utf8("io.l5d.marathon"), 250.millis)
 
-    class TestApi() extends Api {
-      def getAppIds(): Future[Api.AppIds] = {
-        blockingCallResponder before Future.value(Set[String]("/foo", "/servicename"))
-      }
-      def getAddrs(app: String): Future[Set[Address]] = Future.never
-    }
-
-    val namer = new AppIdNamer(new TestApi(), Path.Utf8("io.l5d.marathon"), 250.millis)
     @volatile var state: Activity.State[NameTree[Name]] = Activity.Pending
-
     namer.lookup(Path.read("/servicename/residual")).states.respond(state = _)
 
     assert(state == Activity.Pending)
-    blockingCallResponder.setDone()
+    promisedAppIds.setValue(Set(Path.Utf8("foo"), Path.Utf8("servicename")))
     assert(state == Activity.Ok(NameTree.Leaf(Path.Utf8("io.l5d.marathon", "servicename"))))
   }
 
@@ -89,20 +73,18 @@ class AppIdNamerTest extends FunSuite with Awaits {
     case Activity.Ok(NameTree.Leaf(bound: Name.Bound)) =>
       bound.addr.sample() match {
         case Addr.Bound(addrs, metadata) => f(addrs)
-        case _ => assert(false)
+        case addr => fail(s"$addr is not bound")
       }
-    case _ => assert(false)
+    case state => fail(s"$state is not a NameTree.Leaf[Name]")
   }
 
   test("Namer returns leaf with bound addr when addr exist") {
-    class TestApi() extends Api {
-      def getAppIds(): Future[Api.AppIds] = Future.value(Set[String]("/foo", "/servicename"))
-      def getAddrs(app: String): Future[Set[Address]] = Future.value(
-        Set[Address](Address("hostname", 8080))
-      )
-    }
+    val api = TestApi(
+      ids = Future.value(Set(Path.Utf8("foo"), Path.Utf8("servicename"))),
+      addrs = Future.value(Set(Address("hostname", 8080)))
+    )
 
-    val namer = new AppIdNamer(new TestApi(), Path.Utf8("io.l5d.marathon"), 250.millis)
+    val namer = new AppIdNamer(api, Path.Utf8("io.l5d.marathon"), 250.millis)
     @volatile var state: Activity.State[NameTree[Name]] = Activity.Pending
     namer.lookup(Path.read("/servicename/residual")).states.respond(state = _)
 
@@ -113,28 +95,23 @@ class AppIdNamerTest extends FunSuite with Awaits {
   }
 
   test("Addrs update when blocking call for getAddrs returns") {
-    val blockingCallResponder = new Promise[Unit]
-
-    class TestApi() extends Api {
-      def getAppIds(): Future[Api.AppIds] = Future.value(Set[String]("/foo", "/servicename"))
-      def getAddrs(app: String): Future[Set[Address]] = {
-        blockingCallResponder before
-          Future.value(Set[Address](Address("hostname", 8080)))
-      }
-    }
-
-    val namer = new AppIdNamer(new TestApi(), Path.Utf8("io.l5d.marathon"), 250.millis)
+    val promisedAddrs = new Promise[Set[Address]]
+    val api = TestApi(
+      ids = Future.value(Set(Path.Utf8("foo"), Path.Utf8("servicename"))),
+      addrs = promisedAddrs
+    )
+    val namer = new AppIdNamer(api, Path.Utf8("io.l5d.marathon"), 250.millis)
     @volatile var state: Activity.State[NameTree[Name]] = Activity.Pending
     namer.lookup(Path.read("/servicename/residual")).states.respond(state = _)
 
     state match {
       case Activity.Ok(NameTree.Leaf(bound: Name.Bound)) => assert(bound.addr.sample() == Addr.Pending)
-      case _ => assert(false)
+      case state => fail(s"$state is not a NameTree.Leaf[Name.Bound]")
     }
-    blockingCallResponder.setDone()
+    val addresses = Set(Address("hostname", 8080))
+    promisedAddrs.setValue(addresses)
     assertOnAddrs(state) { addrs =>
-      assert(addrs.size == 1)
-      assert(addrs.head.toString.contains("hostname:8080"))
+      assert(addrs == addresses)
     }
   }
 }

--- a/marathon/src/test/scala/io/buoyant/marathon/v2/AppIdNamerTest.scala
+++ b/marathon/src/test/scala/io/buoyant/marathon/v2/AppIdNamerTest.scala
@@ -2,31 +2,43 @@ package io.buoyant.marathon.v2
 
 import com.twitter.conversions.time._
 import com.twitter.finagle._
-import com.twitter.util.{Activity, Future, Promise}
+import com.twitter.util.{Activity, Future, MockTimer, Promise, Time, Var}
 import io.buoyant.test.Awaits
 import java.net.{InetSocketAddress, SocketAddress}
 import org.scalatest.FunSuite
 
 class AppIdNamerTest extends FunSuite with Awaits {
+  val ttl = 10.millis
+  val err = ChannelWriteException(null)
+  val exc = Future.exception(err)
+  def newTimer = new MockTimer
+
   case class TestApi(
     ids: Future[Api.AppIds] = Future.never,
-    addrs: Future[Set[Address]] = Future.never
+    addrs: Future[Set[Address]] = Future.never,
+    initIdsAlive: Boolean = true,
+    initAddrsAlive: Boolean = true
   ) extends Api {
-    def getAppIds(): Future[Api.AppIds] = ids
-    def getAddrs(app: Path): Future[Set[Address]] = addrs
+
+    @volatile var idsAlive = initIdsAlive
+    @volatile var addrsAlive = initAddrsAlive
+
+    def getAppIds(): Future[Api.AppIds] =
+      if (idsAlive) ids else exc
+    def getAddrs(app: Path): Future[Set[Address]] =
+      if (addrsAlive) addrs else exc
   }
 
   test("Namer stays pending while looking up appId for the first time") {
-    val namer = new AppIdNamer(TestApi(), Path.Utf8("io.l5d.marathon"), 250.millis)
+    val namer = new AppIdNamer(TestApi(), Path.Utf8("io.l5d.marathon"), ttl)
     @volatile var state: Activity.State[NameTree[Name]] = Activity.Pending
     namer.lookup(Path.read("/servicename/residual")).states.respond(state = _)
     assert(state == Activity.Pending)
   }
 
   test("Namer fails if the marathon api cannot be reached") {
-    val err = ChannelWriteException(null)
-    val api = TestApi(ids = Future.exception(err))
-    val namer = new AppIdNamer(api, Path.Utf8("io.l5d.marathon"), 250.millis)
+    val api = TestApi(ids = exc)
+    val namer = new AppIdNamer(api, Path.Utf8("io.l5d.marathon"), ttl)
 
     @volatile var state: Activity.State[NameTree[Name]] = Activity.Pending
     namer.lookup(Path.read("/servicename/residual")).states.respond(state = _)
@@ -36,7 +48,7 @@ class AppIdNamerTest extends FunSuite with Awaits {
 
   test("Namer returns neg when appId does not exist") {
     val api = TestApi(ids = Future.value(Set(Path.Utf8("foo"), Path.Utf8("bar"))))
-    val namer = new AppIdNamer(api, Path.Utf8("io.l5d.marathon"), 250.millis)
+    val namer = new AppIdNamer(api, Path.Utf8("io.l5d.marathon"), ttl)
 
     @volatile var state: Activity.State[NameTree[Name]] = Activity.Pending
     namer.lookup(Path.read("/nosuchservice/residual")).states.respond(state = _)
@@ -46,7 +58,7 @@ class AppIdNamerTest extends FunSuite with Awaits {
 
   test("Namer handles looking up /app/id") {
     val api = TestApi(ids = Future.value(Set(Path.read("/service/name"))))
-    val namer = new AppIdNamer(api, Path.Utf8("io.l5d.marathon"), 250.millis)
+    val namer = new AppIdNamer(api, Path.Utf8("io.l5d.marathon"), ttl)
 
     val input = Path.Utf8("service", "name", "residual")
     val output = Path.Utf8("io.l5d.marathon", "service", "name")
@@ -59,7 +71,7 @@ class AppIdNamerTest extends FunSuite with Awaits {
   test("Namer updates when blocking call from getAppIds returns") {
     val promisedAppIds = new Promise[Api.AppIds]
     val api = TestApi(ids = promisedAppIds)
-    val namer = new AppIdNamer(api, Path.Utf8("io.l5d.marathon"), 250.millis)
+    val namer = new AppIdNamer(api, Path.Utf8("io.l5d.marathon"), ttl)
 
     @volatile var state: Activity.State[NameTree[Name]] = Activity.Pending
     namer.lookup(Path.read("/servicename/residual")).states.respond(state = _)
@@ -69,29 +81,36 @@ class AppIdNamerTest extends FunSuite with Awaits {
     assert(state == Activity.Ok(NameTree.Leaf(Path.Utf8("io.l5d.marathon", "servicename"))))
   }
 
-  def assertOnAddrs(state: Activity.State[NameTree[Name]])(f: Set[Address] => Unit) = state match {
+  def assertAddrs(state: Activity.State[NameTree[Name]], expected: Set[Address]) = state match {
     case Activity.Ok(NameTree.Leaf(bound: Name.Bound)) =>
       bound.addr.sample() match {
-        case Addr.Bound(addrs, metadata) => f(addrs)
+        case Addr.Bound(addrs, metadata) => assert(addrs == expected)
         case addr => fail(s"$addr is not bound")
       }
     case state => fail(s"$state is not a NameTree.Leaf[Name]")
   }
 
+  def assertAddrsFail(state: Activity.State[NameTree[Name]]) = state match {
+    case Activity.Ok(NameTree.Leaf(bound: Name.Bound)) =>
+      bound.addr.sample() match {
+        case Addr.Bound(addrs, metadata) => fail(s"$addrs is bound")
+        case addr => assert(addr == Addr.Failed(err))
+      }
+    case state => fail(s"$state is not a NameTree.Leaf[Name]")
+  }
+
   test("Namer returns leaf with bound addr when addr exist") {
+    val addrs = Set(Address("hostname", 8080))
     val api = TestApi(
       ids = Future.value(Set(Path.Utf8("foo"), Path.Utf8("servicename"))),
-      addrs = Future.value(Set(Address("hostname", 8080)))
+      addrs = Future.value(addrs)
     )
 
-    val namer = new AppIdNamer(api, Path.Utf8("io.l5d.marathon"), 250.millis)
+    val namer = new AppIdNamer(api, Path.Utf8("io.l5d.marathon"), ttl)
     @volatile var state: Activity.State[NameTree[Name]] = Activity.Pending
     namer.lookup(Path.read("/servicename/residual")).states.respond(state = _)
 
-    assertOnAddrs(state) { addrs =>
-      assert(addrs.size == 1)
-      assert(addrs.head.toString.contains("hostname:8080"))
-    }
+    assertAddrs(state, addrs)
   }
 
   test("Addrs update when blocking call for getAddrs returns") {
@@ -100,7 +119,7 @@ class AppIdNamerTest extends FunSuite with Awaits {
       ids = Future.value(Set(Path.Utf8("foo"), Path.Utf8("servicename"))),
       addrs = promisedAddrs
     )
-    val namer = new AppIdNamer(api, Path.Utf8("io.l5d.marathon"), 250.millis)
+    val namer = new AppIdNamer(api, Path.Utf8("io.l5d.marathon"), ttl)
     @volatile var state: Activity.State[NameTree[Name]] = Activity.Pending
     namer.lookup(Path.read("/servicename/residual")).states.respond(state = _)
 
@@ -110,8 +129,150 @@ class AppIdNamerTest extends FunSuite with Awaits {
     }
     val addresses = Set(Address("hostname", 8080))
     promisedAddrs.setValue(addresses)
-    assertOnAddrs(state) { addrs =>
-      assert(addrs == addresses)
+    assertAddrs(state, addresses)
+  }
+
+  test("Namer recovers if marathon api fails initially") {
+    val api = TestApi(
+      ids = Future.value(Set(Path.read("/foo/bar"))),
+      addrs = Future.never,
+      initIdsAlive = false,
+      initAddrsAlive = true
+    )
+
+    val timer = newTimer
+    val namer = new AppIdNamer(api, Path.Utf8("io.l5d.marathon"), ttl, timer)
+    @volatile var state: Activity.State[NameTree[Name]] = Activity.Pending
+
+    val input = Path.Utf8("foo", "bar", "residual")
+    val output = Path.Utf8("io.l5d.marathon", "foo", "bar")
+
+    Time.withCurrentTimeFrozen { tc =>
+      namer.lookup(input).states.respond(state = _)
+      assert(state == Activity.Failed(err))
+
+      api.idsAlive = true
+      tc.advance(ttl)
+      timer.tick()
+
+      namer.lookup(input).states.respond(state = _)
+      assert(state == Activity.Ok(NameTree.Leaf(output)))
+    }
+  }
+
+  test("Namer returns a cached address when the marathon api goes down") {
+    val api = TestApi(
+      ids = Future.value(Set(Path.read("/foo/bar"))),
+      addrs = Future.never,
+      initIdsAlive = true,
+      initAddrsAlive = true
+    )
+
+    val timer = newTimer
+    val namer = new AppIdNamer(api, Path.Utf8("io.l5d.marathon"), ttl, timer)
+    @volatile var state: Activity.State[NameTree[Name]] = Activity.Pending
+
+    val input = Path.Utf8("foo", "bar", "residual")
+    val output = Path.Utf8("io.l5d.marathon", "foo", "bar")
+
+    Time.withCurrentTimeFrozen { tc =>
+      namer.lookup(input).states.respond(state = _)
+      assert(state == Activity.Ok(NameTree.Leaf(output)))
+
+      api.idsAlive = false
+      tc.advance(ttl)
+      timer.tick()
+
+      namer.lookup(input).states.respond(state = _)
+      assert(state == Activity.Ok(NameTree.Leaf(output)))
+    }
+  }
+
+  test("Namer returns failure if getAddrs() fails due to marathon api being down") {
+    val api = TestApi(
+      ids = Future.value(Set(Path.Utf8("foo"), Path.Utf8("bar"))),
+      addrs = exc,
+      initIdsAlive = true,
+      initAddrsAlive = false
+    )
+
+    val namer = new AppIdNamer(api, Path.Utf8("io.l5d.marathon"), ttl)
+    @volatile var state: Activity.State[NameTree[Name]] = Activity.Pending
+    namer.lookup(Path.read("/bar/residual")).states.respond(state = _)
+
+    assertAddrsFail(state)
+  }
+
+  test("Namer recovers if getAddrs() fails initially") {
+    val addrs = Set(Address("hostname", 8080))
+
+    val api = TestApi(
+      ids = Future.value(Set(Path.Utf8("foo"), Path.Utf8("bar"))),
+      addrs = Future.value(addrs),
+      initIdsAlive = true,
+      initAddrsAlive = false
+    )
+
+    val timer = newTimer
+    val namer = new AppIdNamer(api, Path.Utf8("io.l5d.marathon"), ttl, timer)
+    @volatile var state: Activity.State[NameTree[Name]] = Activity.Pending
+
+    Time.withCurrentTimeFrozen { tc =>
+      namer.lookup(Path.read("/bar/residual")).states.respond(state = _)
+
+      assertAddrsFail(state)
+
+      api.addrsAlive = true
+      tc.advance(ttl)
+      timer.tick()
+
+      namer.lookup(Path.read("/bar/residual")).states.respond(state = _)
+      assertAddrs(state, addrs)
+    }
+  }
+
+  test("Namer returns cached bound address if getAddrs() fails after a successful call") {
+    val addr = Address("hostname", 8080)
+
+    val api = TestApi(
+      ids = Future.value(Set(Path.Utf8("foo"), Path.Utf8("bar"))),
+      addrs = Future.value(Set(addr)),
+      initIdsAlive = true,
+      initAddrsAlive = true
+    )
+
+    val timer = newTimer
+    val namer = new AppIdNamer(api, Path.Utf8("io.l5d.marathon"), ttl, timer)
+    @volatile var state: Activity.State[NameTree[Name]] = Activity.Pending
+
+    Time.withCurrentTimeFrozen { tc =>
+      namer.lookup(Path.read("/bar/residual")).states.respond(state = _)
+      assert(state == Activity.Ok(NameTree.Leaf(Path.Utf8("io.l5d.marathon", "bar"))))
+
+      @volatile var boundAddr: Var[Addr] = Var.value(Addr.Pending)
+      state match {
+        case Activity.Ok(NameTree.Leaf(bound: Name.Bound)) =>
+          boundAddr = bound.addr
+        case state => fail(s"$state is not a NameTree.Leaf[Name]")
+      }
+
+      @volatile var addrTest: Addr = Addr.Pending
+      val closable = boundAddr.changes.respond(addrTest = _)
+
+      try {
+        assert(addrTest == Addr.Bound(addr))
+        assertAddrs(state, Set(addr))
+
+        api.addrsAlive = false
+        tc.advance(ttl)
+        timer.tick()
+
+        namer.lookup(Path.read("/bar/residual")).states.respond(state = _)
+        assert(addrTest == Addr.Bound(addr))
+        assertAddrs(state, Set(addr))
+      } finally {
+        await(closable.close())
+      }
     }
   }
 }


### PR DESCRIPTION
If the marathon API is down or throws errors for other reasons, the namer
should not necessarily return an Activity.Failed.  If apps have previously been
discovered, the error is simply not returned and polling continues.

This change also ensures that proper RFC3986-compatible URI names are generated
when requesting AppIDs from the Marathon API.  In doing so, the Marathon client
API has been changed to use finagle Paths as App IDs (instead of arbitrary
Strings).

Tests have been simplified somewhat.