### PR TITLE
Surface namer exceptions in the delegator API.

### DIFF
--- a/examples/marathon.l5d
+++ b/examples/marathon.l5d
@@ -7,14 +7,14 @@ namers:
 
 routers:
 - protocol: http
+  identifier:
+    kind: default
+    httpUriInDst: true
   baseDtab: |
     /marathonId => /io.l5d.marathon;
     /host       => /$/io.buoyant.http.domainToPathPfx/marathonId;
     /method     => /$/io.buoyant.http.anyMethodPfx/host;
     /http/1.1   => /method;
-  identifier:
-    kind: default
-    httpUriInDst: true
   servers:
   - port: 4140
     ip: 0.0.0.0

--- a/linkerd/admin/src/main/resources/io/buoyant/linkerd/admin/js/delegate.js
+++ b/linkerd/admin/src/main/resources/io/buoyant/linkerd/admin/js/delegate.js
@@ -63,9 +63,10 @@ function renderNode(obj){
   switch(obj.type) {
     case "delegate": obj.isDelegate = true; obj.child = renderNode(obj.delegate); break;
     case "alt": obj.isAlt = true; obj.child = obj.alt.map(function(e,i){ return renderNode(e); }).join(""); break;
-    case "neg": obj.isNeg = true; obj.break;
+    case "neg": obj.isNeg = true; break;
     case "fail": obj.isFail = true; break;
     case "leaf": obj.isLeaf = true; obj.child = renderNode(obj.bound); break;
+    case "exception": obj.isException = true; break;
   }
   return templates.node(obj);
 }

--- a/linkerd/admin/src/main/resources/io/buoyant/linkerd/admin/template/delegatenode.template
+++ b/linkerd/admin/src/main/resources/io/buoyant/linkerd/admin/template/delegatenode.template
@@ -25,6 +25,8 @@
       list-group-item-danger
     {{else if isFail}}
       list-group-item-danger
+    {{else if isException}}
+      list-group-item-danger
     {{else}}
       list-group-item-success
     {{/if}}'
@@ -36,6 +38,12 @@
         No Further Branch Matches
       {{else if isFail}}
         Explicit Failure
+      {{else if isException}}
+        {{#if message}}
+          Exception: {{message}}
+        {{else}}
+          Unknown Exception
+        {{/if}}
       {{else}}
         Bound Path
       {{/if}}

--- a/linkerd/admin/src/main/scala/io/buoyant/linkerd/admin/names/WebDelegator.scala
+++ b/linkerd/admin/src/main/scala/io/buoyant/linkerd/admin/names/WebDelegator.scala
@@ -71,6 +71,7 @@ private[admin] object WebDelegator {
     new JsonSubTypes.Type(value = classOf[JsonDelegateTree.Empty], name = "empty"),
     new JsonSubTypes.Type(value = classOf[JsonDelegateTree.Fail], name = "fail"),
     new JsonSubTypes.Type(value = classOf[JsonDelegateTree.Neg], name = "neg"),
+    new JsonSubTypes.Type(value = classOf[JsonDelegateTree.Exception], name = "exception"),
     new JsonSubTypes.Type(value = classOf[JsonDelegateTree.Delegate], name = "delegate"),
     new JsonSubTypes.Type(value = classOf[JsonDelegateTree.Leaf], name = "leaf"),
     new JsonSubTypes.Type(value = classOf[JsonDelegateTree.Alt], name = "alt"),
@@ -81,6 +82,7 @@ private[admin] object WebDelegator {
     case class Empty(path: Path, dentry: Option[Dentry]) extends JsonDelegateTree
     case class Fail(path: Path, dentry: Option[Dentry]) extends JsonDelegateTree
     case class Neg(path: Path, dentry: Option[Dentry]) extends JsonDelegateTree
+    case class Exception(path: Path, dentry: Option[Dentry], message: String) extends JsonDelegateTree
     case class Delegate(path: Path, dentry: Option[Dentry], delegate: JsonDelegateTree) extends JsonDelegateTree
     case class Leaf(path: Path, dentry: Option[Dentry], bound: Bound) extends JsonDelegateTree
     case class Alt(path: Path, dentry: Option[Dentry], alt: Seq[JsonDelegateTree]) extends JsonDelegateTree
@@ -88,6 +90,7 @@ private[admin] object WebDelegator {
     case class Weighted(weight: Double, tree: JsonDelegateTree)
 
     def mk(d: DelegateTree[Name.Bound]): JsonDelegateTree = d match {
+      case DelegateTree.Exception(p, d, e) => JsonDelegateTree.Exception(p, mkDentry(d), e.getMessage)
       case DelegateTree.Empty(p, d) => JsonDelegateTree.Empty(p, mkDentry(d))
       case DelegateTree.Fail(p, d) => JsonDelegateTree.Fail(p, mkDentry(d))
       case DelegateTree.Neg(p, d) => JsonDelegateTree.Neg(p, mkDentry(d))

--- a/namer/core/src/test/scala/io/buoyant/namer/TestNamer.scala
+++ b/namer/core/src/test/scala/io/buoyant/namer/TestNamer.scala
@@ -48,3 +48,24 @@ class ConflictingNamer extends NamerConfig {
   @JsonIgnore
   override def newNamer(params: Stack.Params): Namer = ???
 }
+
+class ErrorNamerInitializer extends NamerInitializer {
+  val configClass = classOf[ErrorNamerConfig]
+  override val configId = "error"
+}
+
+object ErrorNamerInitializer extends ErrorNamerInitializer
+
+case class TestNamingError(path: Path) extends Throwable(s"error naming ${path.show}") {
+  override def toString = s"TestNamingError(${path.show})"
+}
+
+class ErrorNamerConfig extends NamerConfig { config =>
+  @JsonIgnore
+  override def defaultPrefix: Path = Path.read("/error")
+
+  @JsonIgnore
+  override def newNamer(params: Stack.Params) = new Namer {
+    def lookup(path: Path) = Activity.exception(TestNamingError(prefix ++ path))
+  }
+}


### PR DESCRIPTION
When resolving a name, a namer may return an Activity.Failed with an exception.
Previously, this manifested as a 500 error.  Instead, these errors should be
mapped into the DelegatorTree response i.e. so that clients may illustrate
where these failures occurred.