### PR TITLE
Add polling timeout to the marathon namer config

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -2,6 +2,8 @@
 
 * Breaking change to configs: `httpUriInDst` is now specified under the
   `identifier` header (see docs for add'l info)
+* Add a `ttlMs` marathon namer config option to configure the polling
+  timeout against the marathon API.
 
 ## 0.2.1
 

--- a/docs/config.md
+++ b/docs/config.md
@@ -604,6 +604,8 @@ The Marathon namer is configured with kind `io.l5d.experimental.marathon`, and t
   depends on your Marathon configuration. For example, running Marathon
   locally, the API is avaiable at `localhost:8080/v2/`, while the default setup
   on AWS/DCOS is `$(dcos config show core.dcos_url)/marathon/v2/apps`.
+* *ttlMs* -- the polling timeout in milliseconds against the marathon API
+  (default: 5000)
 
 For example:
 ```yaml
@@ -613,6 +615,7 @@ namers:
   host:      marathon.mesos
   port:      80
   uriPrefix: /marathon
+  ttlMs:     500
 ```
 
 The default _prefix_ is `io.l5d.marathon`. (Note that this is *different* from

--- a/examples/marathon.l5d
+++ b/examples/marathon.l5d
@@ -4,6 +4,7 @@ namers:
   host:      marathon.mesos
   port:      80
   uriPrefix: /marathon
+  ttlMs:     300
 
 routers:
 - protocol: http

--- a/namer/marathon/src/main/scala/io/l5d/marathon.scala
+++ b/namer/marathon/src/main/scala/io/l5d/marathon.scala
@@ -18,6 +18,7 @@ import io.buoyant.marathon.v2.{Api, AppIdNamer}
  *   host:      marathon.mesos
  *   port:      80
  *   uriPrefix: /marathon
+ *   ttlMs:     5000
  * </pre>
  */
 class MarathonInitializer extends NamerInitializer {
@@ -29,7 +30,8 @@ object MarathonInitializer extends MarathonInitializer
 case class marathon(
   host: Option[String],
   port: Option[Port],
-  uriPrefix: Option[String]
+  uriPrefix: Option[String],
+  ttlMs: Option[Int]
 ) extends NamerConfig {
   @JsonIgnore
   override def defaultPrefix: Path = Path.read("/io.l5d.marathon")
@@ -40,6 +42,7 @@ case class marathon(
     case None => 80
   }
   private[this] def getUriPrefix = uriPrefix.getOrElse("")
+  private[this] def getTtl = ttlMs.getOrElse(5000).millis
 
   /**
    * Construct a namer.
@@ -50,6 +53,6 @@ case class marathon(
       .configured(Label("namer" + prefix.show))
       .newService(s"/$$/inet/$getHost/$getPort")
 
-    new AppIdNamer(Api(service, getHost, getUriPrefix), prefix, 250.millis)
+    new AppIdNamer(Api(service, getHost, getUriPrefix), prefix, getTtl)
   }
 }

--- a/namer/marathon/src/test/scala/io/l5d/MarathonTest.scala
+++ b/namer/marathon/src/test/scala/io/l5d/MarathonTest.scala
@@ -11,7 +11,7 @@ class MarathonTest extends FunSuite {
 
   test("sanity") {
     // ensure it doesn't totally blowup
-    marathon(None, None, None).newNamer(Stack.Params.empty)
+    marathon(None, None, None, None).newNamer(Stack.Params.empty)
   }
 
   test("service registration") {
@@ -25,13 +25,15 @@ class MarathonTest extends FunSuite {
                   |host:      marathon.mesos
                   |port:      80
                   |uriPrefix: /marathon
+                  |ttlMs:     300
       """.stripMargin
 
     val mapper = Parser.objectMapper(yaml, Iterable(Seq(MarathonInitializer)))
     val marathon = mapper.readValue[NamerConfig](yaml).asInstanceOf[marathon]
-    assert(marathon.host == Some("marathon.mesos"))
-    assert(marathon.port == Some(Port(80)))
-    assert(marathon.uriPrefix == Some("/marathon"))
-    assert(marathon._prefix == Some(Path.read("/io.l5d.marathon")))
+    assert(marathon.host.contains("marathon.mesos"))
+    assert(marathon.port.contains(Port(80)))
+    assert(marathon.uriPrefix.contains("/marathon"))
+    assert(marathon._prefix.contains(Path.read("/io.l5d.marathon")))
+    assert(marathon.ttlMs.contains(300))
   }
 }


### PR DESCRIPTION
Adds a config option to the marathon namer config to allow changing of the polling timeout against the marathon API.

I wasn't sure what to call the config param - `pollingTimeoutMs`/`pollingTimeoutMillis` was the other option I was thinking about.  Opinions welcome.

Fixes #167