### PR TITLE
Support building against -SNAPSHOT twitter dependencies

### DIFF
--- a/circle.yml
+++ b/circle.yml
@@ -17,21 +17,13 @@ dependencies:
       mkdir -p .gitshas
       export GIT_SHA_DIR=$PWD/.gitshas
       ./project/install-twitter-develop-deps.sh
-      ./sbt 'set developTwitterDeps in Global := true' update
-    else
-      ./sbt update
     fi
+  - ./sbt update
 
 test:
   override:
-  - >
-    if [ -n "${TWITTER_DEVELOP}" ]; then
-      ./sbt 'set developTwitterDeps in Global := true' coverage test
-      ./sbt 'set developTwitterDeps in Global := true' integration:compile e2e:test assembly
-    else
-      ./sbt coverage test
-      ./sbt integration:compile e2e:test assembly
-    fi
+  - ./sbt coverage test
+  - ./sbt integration:compile e2e:test assembly
   - ./test-config.sh
 
   post:

--- a/circle.yml
+++ b/circle.yml
@@ -9,12 +9,31 @@ general:
 dependencies:
   cache_directories:
   - .sbt-launch.jar
+  - .gitshas
+
   override:
-  - ./sbt update test:compile e2e:compile integration:compile
+  - >
+    if [ -n "${TWITTER_DEVELOP}" ]; then
+      mkdir -p .gitshas
+      export GIT_SHA_DIR=$PWD/.gitshas
+      ./project/install-twitter-develop-deps.sh
+      ./sbt 'set developTwitterDeps in Global := true' update
+    else
+      ./sbt update
+    fi
 
 test:
   override:
-  # unfortunately these have to be two separate sbt commands ¯\_(ツ)_/¯
-  - ./sbt coverage test && ./sbt coverageAggregate
-  - ./sbt e2e:test assembly
+  - >
+    if [ -n "${TWITTER_DEVELOP}" ]; then
+      ./sbt 'set developTwitterDeps in Global := true' coverage test
+      ./sbt 'set developTwitterDeps in Global := true' integration:compile e2e:test assembly
+    else
+      ./sbt coverage test
+      ./sbt integration:compile e2e:test assembly
+    fi
   - ./test-config.sh
+
+  post:
+  - ./sbt coverageAggregate
+  - mkdir -p $CIRCLE_TEST_REPORTS/junit && find . -type f -regex ".*/target/test-reports/.*xml" -exec cp {} $CIRCLE_TEST_REPORTS/junit/ \;

--- a/project/Base.scala
+++ b/project/Base.scala
@@ -41,7 +41,8 @@ class Base extends Build {
       "local-m2" at s"file:${Path.userHome.absolutePath}/.m2/repository",
       "typesafe" at "https://repo.typesafe.com/typesafe/releases"
     ),
-    aggregate in assembly := false
+    aggregate in assembly := false,
+    developTwitterDeps := sys.env.contains("TWITTER_DEVELOP")
   )
 
   val scalariformSettings = baseScalariformSettings ++ Seq(

--- a/project/Base.scala
+++ b/project/Base.scala
@@ -25,25 +25,23 @@ class Base extends Build {
     }
   }
 
-  val orgSettings = Seq(
+  val developTwitterDeps = settingKey[Boolean]("use SNAPSHOT twitter dependencies")
+  val doDevelopTwitterDeps = developTwitterDeps ?? false
+
+  val baseSettings = Seq(
     organization := "io.buoyant",
     version := Git.version,
-    homepage := Some(url("https://linkerd.io"))
-  )
-
-  val scalaSettings = Seq(
+    homepage := Some(url("https://linkerd.io")),
     scalaVersion in GlobalScope := "2.11.7",
-    scalacOptions ++= Seq("-Xfatal-warnings", "-deprecation")
-  )
-
-  val resolverSettings = Seq(
+    scalacOptions ++= Seq("-Xfatal-warnings", "-deprecation"),
     // XXX
     //conflictManager := ConflictManager.strict,
     resolvers ++= Seq(
       "twitter-repo" at "https://maven.twttr.com",
       "local-m2" at s"file:${Path.userHome.absolutePath}/.m2/repository",
       "typesafe" at "https://repo.typesafe.com/typesafe/releases"
-    )
+    ),
+    aggregate in assembly := false
   )
 
   val scalariformSettings = baseScalariformSettings ++ Seq(
@@ -126,18 +124,20 @@ class Base extends Build {
 
   def project(id: String, dir: File): Project = Project(id, dir)
     .settings(name := id)
-    .settings(orgSettings)
-    .settings(scalaSettings)
-    .settings(resolverSettings)
+    .settings(baseSettings)
     .settings(scalariformSettings)
-    .settings(aggregate in assembly := false)
 
   /**
    * Test utilities (mostly for dealing with async APIs)
    */
   val testUtil = projectDir("test-util")
-    .settings(libraryDependencies += Deps.twitterUtil("core"))
     .settings(libraryDependencies += Deps.scalatest)
+    .settings(libraryDependencies += {
+      val dep = Deps.twitterUtil("core")
+      if (doDevelopTwitterDeps.value) {
+        dep.copy(revision = dep.revision+"-SNAPSHOT")
+      } else dep
+    })
 
   /**
    * Extends Project with helpers to reduce boilerplate in project definitions.
@@ -158,6 +158,19 @@ class Base extends Build {
 
     def configWithLibs(cfg: Configuration)(dep: ModuleID, deps: ModuleID*): Project =
       withLibs((dep +: deps).map(_ % cfg))
+
+    def withTwitterLib(dep: ModuleID): Project =
+      project.settings(libraryDependencies += {
+        if (doDevelopTwitterDeps.value) {
+          dep.copy(revision = dep.revision+"-SNAPSHOT")
+        } else dep
+      })
+
+    def withTwitterLibs(deps: Seq[ModuleID]): Project =
+      deps.foldLeft(project) { case (project, dep) => project.withTwitterLib(dep) }
+
+    def withTwitterLibs(dep: ModuleID, deps: ModuleID*): Project =
+      withTwitterLibs(dep +: deps)
 
     /** Enable the test config for a project with basic dependencies */
     def withTests(): Project = project.dependsOn(testUtil % Test)

--- a/project/Deps.scala
+++ b/project/Deps.scala
@@ -4,11 +4,11 @@ object Deps {
 
   // process lifecycle
   val twitterServer =
-    ("com.twitter" %% "twitter-server" % "1.19.0").
-      exclude("com.twitter", "finagle-zipkin_2.11")
+    ("com.twitter" %% "twitter-server" % "1.19.0")
+      .exclude("com.twitter", "finagle-zipkin_2.11")
 
   def twitterUtil(mod: String) =
-    "com.twitter" %% s"util-$mod" %  "6.33.0"
+    "com.twitter" %% s"util-$mod" % "6.33.0"
 
   // networking
   def finagle(mod: String) =

--- a/project/LinkerdBuild.scala
+++ b/project/LinkerdBuild.scala
@@ -20,42 +20,42 @@ import pl.project13.scala.sbt.JmhPlugin
 object LinkerdBuild extends Base {
 
   val k8s = projectDir("k8s")
-    .withLib(Deps.finagle("http"))
+    .withTwitterLib(Deps.finagle("http"))
     .withLibs(Deps.jackson)
     .withTests()
 
   val consul = projectDir("consul")
-    .withLib(Deps.finagle("http"))
+    .withTwitterLib(Deps.finagle("http"))
     .withLibs(Deps.jackson)
     .withTests()
 
   val marathon = projectDir("marathon")
-    .withLib(Deps.finagle("http"))
+    .withTwitterLib(Deps.finagle("http"))
     .withLibs(Deps.jackson)
     .withTests()
 
   object Router {
     val core = projectDir("router/core")
-      .withLib(Deps.finagle("core"))
+      .withTwitterLib(Deps.finagle("core"))
       .withTests()
       .withE2e()
 
     val http = projectDir("router/http")
       .dependsOn(core)
-      .withLib(Deps.finagle("http"))
+      .withTwitterLib(Deps.finagle("http"))
       .withTests()
       .withE2e()
 
     val mux = projectDir("router/mux")
       .dependsOn(core)
-      .withLib(Deps.finagle("mux"))
+      .withTwitterLib(Deps.finagle("mux"))
       .withE2e()
 
     val thriftIdl = projectDir("router/thrift-idl")
-      .withLib(Deps.finagle("thrift"))
+      .withTwitterLib(Deps.finagle("thrift"))
 
     val thrift = projectDir("router/thrift")
-      .withLib(Deps.finagle("thrift"))
+      .withTwitterLib(Deps.finagle("thrift"))
       .withTests()
       .withE2e()
       .dependsOn(
@@ -68,8 +68,7 @@ object LinkerdBuild extends Base {
   }
 
   val configCore = projectDir("config")
-    .withLib(Deps.finagle("core"))
-    .withLib(Deps.finagle("thrift"))
+    .withTwitterLibs(Deps.finagle("core"), Deps.finagle("thrift"))
     .withLibs(Deps.jackson)
     .withLib(Deps.jacksonYaml)
 
@@ -97,7 +96,7 @@ object LinkerdBuild extends Base {
       .withTests()
 
     val serversets = projectDir("namer/serversets")
-      .withLib(Deps.finagle("serversets").exclude("org.slf4j", "slf4j-jdk14"))
+      .withTwitterLib(Deps.finagle("serversets").exclude("org.slf4j", "slf4j-jdk14"))
       .withTests()
       .dependsOn(core % "compile->compile;test->test")
 
@@ -107,7 +106,7 @@ object LinkerdBuild extends Base {
 
   val admin = projectDir("admin")
     .dependsOn(configCore)
-    .withLib(Deps.twitterServer)
+    .withTwitterLib(Deps.twitterServer)
 
   object Linkerd {
 
@@ -160,12 +159,12 @@ object LinkerdBuild extends Base {
       val benchmark = projectDir("linkerd/protocol/benchmark")
         .dependsOn(http, Protocol.http)
         .dependsOn(testUtil)
-        .settings(libraryDependencies += Deps.twitterUtil("benchmark"))
+        .withTwitterLib(Deps.twitterUtil("benchmark"))
         .enablePlugins(JmhPlugin)
     }
 
     val admin = projectDir("linkerd/admin")
-      .withLib(Deps.twitterServer)
+      .withTwitterLib(Deps.twitterServer)
       .withTests()
       .dependsOn(core % "compile->compile;test->test")
       .dependsOn(LinkerdBuild.admin)
@@ -174,7 +173,7 @@ object LinkerdBuild extends Base {
 
     val main = projectDir("linkerd/main")
       .dependsOn(admin, configCore, core, LinkerdBuild.admin)
-      .withLib(Deps.twitterServer)
+      .withTwitterLib(Deps.twitterServer)
       .withLibs(Deps.jacksonCore, Deps.jacksonDatabind, Deps.jacksonYaml)
       .withBuildProperties()
 
@@ -185,7 +184,7 @@ object LinkerdBuild extends Base {
       // fs service discovery.
       .configDependsOn(Minimal)(admin, core, main, configCore, Namer.fs, Protocol.http)
       .settings(inConfig(Minimal)(MinimalSettings))
-      .withLib(Deps.finagle("stats") % Minimal)
+      .withTwitterLib(Deps.finagle("stats") % Minimal)
       // Bundle is includes all of the supported features:
       .configDependsOn(Bundle)(
         Identifier.http,

--- a/project/install-twitter-develop-deps.sh
+++ b/project/install-twitter-develop-deps.sh
@@ -1,0 +1,139 @@
+#!/bin/bash
+
+# Fetch twitter dependencies from the develop branches and
+# publishLocal -SNAPSHOT dependencies.
+
+set -xeu
+
+# Based on Finagle's dependency-fetching script.
+
+# Optionally accept the scala version as an argument
+SCALA_VERSION=${1:-2.11.7}
+
+# Allow git shas to be cached so that rebuilds aer only done as needed.
+function tracking_shas(){
+  [ -z "${IGNORE_GIT_SHA_DIR:-}" ] && [ -n "$GIT_SHA_DIR" ] && [ -d $GIT_SHA_DIR ]
+}
+
+function get_cached_sha(){
+  local name=$1
+  local path=${GIT_SHA_DIR}/${name}.sha
+  if tracking_shas && [ -f $path ]; then
+    cat $path
+  else
+    echo
+  fi
+}
+
+function update_sha(){
+  local name=$1
+  local sha=$2
+  local path=${GIT_SHA_DIR}/${name}.sha
+  if tracking_shas; then
+    echo $sha > $path
+  fi
+}
+
+BASE_DIR=$(pwd -P)
+TMP_DIR=$(mktemp -d -t linkerd.XXXXXX.tmp)
+cd $TMP_DIR
+
+function run_sbt() {
+  if [ ! -f sbt-launch.jar ] && [ -f $TMP_DIR/sbt-launch.jar ]; then
+    cp $TMP_DIR/sbt-launch.jar sbt-launch.jar
+  fi
+  ./sbt ++$SCALA_VERSION $@
+  if [ -f sbt-launch.jar ] && [ ! -f $TMP_DIR/sbt-launch.jar ]; then
+    cp sbt-launch.jar $TMP_DIR/
+  fi
+}
+
+git clone --depth=1 --branch=develop https://github.com/twitter/util.git
+git clone --depth=1 --branch=develop https://github.com/twitter/ostrich.git
+git clone --depth=1 --branch=develop https://github.com/twitter/finagle.git
+git clone --depth=1 --branch=develop https://github.com/twitter/scrooge.git
+git clone --depth=1 --branch=develop https://github.com/twitter/twitter-server.git
+
+cd $TMP_DIR/util
+if tracking_shas; then
+  orig_sha=$(get_cached_sha util)
+  new_sha=$(git rev-list -1 --abbrev-commit HEAD)
+  if [ "$orig_sha" != "$new_sha" ]; then
+    run_sbt publishLocal
+  fi
+  update_sha util $new_sha
+else
+  run_sbt publishLocal
+fi
+
+cd $TMP_DIR/ostrich
+if tracking_shas; then
+  orig_sha=$(get_cached_sha ostrich)
+  new_sha=$(git rev-list -1 --abbrev-commit HEAD)
+  if [ "$orig_sha" != "$new_sha" ]; then
+    run_sbt publishLocal
+  fi
+  update_sha ostrich $new_sha
+else
+  run_sbt publishLocal
+fi
+
+cd $TMP_DIR/scrooge
+if tracking_shas; then
+  orig_sha=$(get_cached_sha scrooge-core)
+  new_sha=$(git rev-list -1 --abbrev-commit HEAD)
+  if [ "$orig_sha" != "$new_sha" ]; then
+    run_sbt scrooge-core/publishLocal
+  fi
+  update_sha scrooge-core $new_sha
+else
+  run_sbt scrooge-core/publishLocal
+fi
+
+cd $TMP_DIR/finagle
+if tracking_shas; then
+  orig_sha=$(get_cached_sha finagle)
+  new_sha=$(git rev-list -1 --abbrev-commit HEAD)
+  if [ "$orig_sha" != "$new_sha" ]; then
+    run_sbt finagle-core/publishLocal \
+        finagle-http/publishLocal \
+        finagle-http2/publishLocal \
+        finagle-mux/publishLocal \
+        finagle-ostrich4/publishLocal \
+        finagle-thrift/publishLocal \
+        finagle-thriftmux/publishLocal \
+        finagle-stats/publishLocal \
+        finagle-serversets/publishLocal \
+        finagle-zipkin/publishLocal \
+        finagle-benchmark/publishLocal
+  fi
+  update_sha finagle $new_sha
+else
+  run_sbt finagle-core/publishLocal \
+      finagle-http/publishLocal \
+      finagle-http2/publishLocal \
+      finagle-mux/publishLocal \
+      finagle-ostrich4/publishLocal \
+      finagle-thrift/publishLocal \
+      finagle-thriftmux/publishLocal \
+      finagle-stats/publishLocal \
+      finagle-serversets/publishLocal \
+      finagle-zipkin/publishLocal \
+      finagle-benchmark/publishLocal
+fi
+
+cd $TMP_DIR/twitter-server
+if tracking_shas; then
+  orig_sha=$(get_cached_sha twitter-server)
+  new_sha=$(git rev-list -1 --abbrev-commit HEAD)
+  if [ "$orig_sha" != "$new_sha" ]; then
+    run_sbt publishLocal
+  fi
+  update_sha twitter-server $new_sha
+else
+  run_sbt publishLocal
+fi
+
+# clean up
+cd $BASE_DIR
+rm -rf $TMP_DIR

--- a/test-config.sh
+++ b/test-config.sh
@@ -30,11 +30,7 @@ function cleanup {
 function run_tests {
   export LOG_LEVEL=DEBUG
 
-  if [ -n "${TWITTER_DEVELOP}" ]; then
-    ./sbt 'set developTwitterDeps in Global := true' examples/acceptance-test:run &
-  else
-    ./sbt examples/acceptance-test:run &
-  fi
+  ./sbt examples/acceptance-test:run &
 
   # Wait for linkerd to initialize
   sleep 60

--- a/test-config.sh
+++ b/test-config.sh
@@ -30,7 +30,11 @@ function cleanup {
 function run_tests {
   export LOG_LEVEL=DEBUG
 
-  ./sbt examples/acceptance-test:run &
+  if [ -n "${TWITTER_DEVELOP}" ]; then
+    ./sbt 'set developTwitterDeps in Global := true' examples/acceptance-test:run &
+  else
+    ./sbt examples/acceptance-test:run &
+  fi
 
   # Wait for linkerd to initialize
   sleep 60


### PR DESCRIPTION
Add an sbt setting, developTwitterDeps, that causes all twitter dependencies to
be set to their SNAPSHOT versions.  The project/install-twitter-develop-deps.sh
script fetches and installs SNAPSHOT version of all relevant projects.

Once SNAPSHOT versions are published, linkerd may be tested against these
dependencies with the following:

    ./sbt 'set developTwitterDeps in Global := true' test

circle.yml has been updated to support develop builds (via environment) and to publish test reports.