### PR TITLE
Add an enableProbation flag to the load balancer config

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -4,6 +4,8 @@
   `identifier` header (see docs for add'l info)
 * Add a `ttlMs` marathon namer config option to configure the polling
   timeout against the marathon API.
+* Add a `enableProbation` config option for configuring a client's load balancer
+  probation setting
 
 ## 0.2.1
 

--- a/docs/config.md
+++ b/docs/config.md
@@ -53,6 +53,7 @@ routers:
       caCertPath: /foo/caCert.pem
     loadBalancer:
       kind: ewma
+      enableProbation: false
   timeoutMs: 1000
 
 - protocol: thrift
@@ -230,6 +231,9 @@ names:
 * *loadBalancer* -- Optional.  Specifies a load balancer to use.  It must be an
 object containing keys:
   * *kind* -- One of the supported load balancers.
+  * *enableProbation* -- Optional.  Controls whether endpoints are eagerly evicted from
+    service discovery. (default: true)
+    See Finagle's [LoadBalancerFactory.EnableProbation](https://github.com/twitter/finagle/blob/develop/finagle-core/src/main/scala/com/twitter/finagle/loadbalancer/LoadBalancerFactory.scala#L28)
   * Any options specific to the load balancer.
 
 If unspecified, p2c is used.

--- a/linkerd/core/src/main/scala/io/buoyant/linkerd/LoadBalancerConfig.scala
+++ b/linkerd/core/src/main/scala/io/buoyant/linkerd/LoadBalancerConfig.scala
@@ -4,6 +4,7 @@ import com.fasterxml.jackson.annotation.JsonSubTypes.Type
 import com.fasterxml.jackson.annotation.{JsonIgnore, JsonSubTypes, JsonTypeInfo}
 import com.twitter.conversions.time._
 import com.twitter.finagle.Stack
+import com.twitter.finagle.loadbalancer.LoadBalancerFactory.EnableProbation
 import com.twitter.finagle.loadbalancer.{Balancers, LoadBalancerFactory}
 
 @JsonTypeInfo(use = JsonTypeInfo.Id.NAME, include = JsonTypeInfo.As.PROPERTY, property = "kind")
@@ -16,8 +17,11 @@ import com.twitter.finagle.loadbalancer.{Balancers, LoadBalancerFactory}
 trait LoadBalancerConfig {
   val factory: LoadBalancerFactory
 
+  val enableProbation: Option[Boolean] = None
+
   @JsonIgnore
-  def clientParams = Stack.Params.empty + LoadBalancerFactory.Param(factory)
+  def clientParams = Stack.Params.empty + LoadBalancerFactory.Param(factory) +
+    LoadBalancerFactory.EnableProbation(enableProbation.getOrElse(true))
 }
 
 case class P2C(maxEffort: Option[Int]) extends LoadBalancerConfig {

--- a/linkerd/core/src/test/scala/io/buoyant/linkerd/LoadBalancerTest.scala
+++ b/linkerd/core/src/test/scala/io/buoyant/linkerd/LoadBalancerTest.scala
@@ -15,6 +15,7 @@ class LoadBalancerTest extends FunSuite {
       |  client:
       |    loadBalancer:
       |      kind: $balancer
+      |      enableProbation: false
       |  servers:
       |  - {}
       |""".stripMargin
@@ -22,6 +23,9 @@ class LoadBalancerTest extends FunSuite {
       val linker = Linker.load(config, Linker.Initializers(protocol = Seq(TestProtocol.Plain)))
       val factory = linker.routers.head.params[LoadBalancerFactory.Param]
       assert(factory.loadBalancerFactory != DefaultBalancerFactory)
+
+      val enableProbation = linker.routers.head.params[LoadBalancerFactory.EnableProbation]
+      assert(enableProbation == LoadBalancerFactory.EnableProbation(false))
     }
   }
 }


### PR DESCRIPTION
Allows us to control whether endpoints are eagerly evicted from service discovery

See https://github.com/twitter/finagle/blob/develop/finagle-core/src/main/scala/com/twitter/finagle/loadbalancer/LoadBalancerFactory.scala#L28

Fixes #166