### PR TITLE
Add a skeleton endpoint to access new dashboard at /dashboard

### DIFF
--- a/linkerd/admin/src/main/resources/io/buoyant/linkerd/admin/css/dashboard.css
+++ b/linkerd/admin/src/main/resources/io/buoyant/linkerd/admin/css/dashboard.css
@@ -1,0 +1,4 @@
+body {
+  background-image: radial-gradient(34% 43%, #161963 23%, #090B34 47%);
+  color: #FFFFFF;
+}

--- a/linkerd/admin/src/main/resources/io/buoyant/linkerd/admin/js/dashboard.js
+++ b/linkerd/admin/src/main/resources/io/buoyant/linkerd/admin/js/dashboard.js
@@ -1,0 +1,63 @@
+"use strict";
+
+/**
+ * Number of millis to wait between data updates.
+ */
+var UPDATE_INTERVAL = 1000;
+var OVERVIEW_STATS_DESCRIPTION = {
+  stats: [
+    { description: "uptime", dataKey: "jvm/uptime",  elemId: "jvm-uptime", value: "0s" },
+    { description: "thread count", dataKey: "jvm/thread/count", elemId: "jvm-thread-count", value: "0" },
+    { description: "memory used", dataKey: "jvm/mem/current/used", elemId: "jvm-mem-current-used", value: "0MB" },
+    { description: "gc", dataKey: "jvm/gc/msec",  elemId: "jvm-gc-msec", value: "1ms" }
+  ]
+}
+
+$.when(
+  $.get("/files/template/overview_stats.template"),
+  $.get("/admin/metrics.json")
+).done(function(overviewStatsRsp, metricsJson) {
+  appendOverviewSection();
+
+  $(function() {
+    var dashboard = Dashboard();
+    dashboard.start(UPDATE_INTERVAL);
+  });
+
+  function appendOverviewSection() {
+    var overviewTemplate = Handlebars.compile(overviewStatsRsp[0]);
+    var compiledHtml = overviewTemplate(OVERVIEW_STATS_DESCRIPTION);
+
+    var $overviewStats = $('<div />').html(compiledHtml);
+    $overviewStats.appendTo("body");
+  }
+});
+
+var Dashboard = (function() {
+
+  function render(data) {
+    var json = $.parseJSON(data);
+    $(".test-div").text("Fill in content.");
+  }
+
+  /**
+   * Returns a function that may be called to trigger an update.
+   */
+  return function() {
+
+    function update() {
+      $.ajax({
+        url: "/admin/metrics.json",
+        dataType: "text",
+        cache: false,
+        success: function(metrics) {
+          render(metrics);
+        }
+      });
+    }
+
+    return {
+      start: function(interval) { setInterval(update, interval); }
+    };
+  };
+})();

--- a/linkerd/admin/src/main/resources/io/buoyant/linkerd/admin/template/overview_stats.template
+++ b/linkerd/admin/src/main/resources/io/buoyant/linkerd/admin/template/overview_stats.template
@@ -1,0 +1,12 @@
+<div class="row text-center">
+  <div id="process-info" data-refresh-uri="/admin/metrics">
+    <ul class="list-inline topline-stats">
+      {{#each stats}}
+        <li data-key="{{dataKey}}">
+          <strong class="stat-label">{{description}}</strong>
+          <span id="{{elemId}}" class="stat">{{value}}</span>
+        </li>
+      {{/each}}
+    </ul>
+  </div>
+</div>

--- a/linkerd/admin/src/main/scala/io/buoyant/linkerd/admin/AdminHandler.scala
+++ b/linkerd/admin/src/main/scala/io/buoyant/linkerd/admin/AdminHandler.scala
@@ -64,6 +64,7 @@ object AdminHandler extends HtmlView {
                   <li><a href="/metrics">metrics</a></li>
                   <li><a href="/admin/logging">logging</a></li>
                   <li><a href="https://linkerd.io/help/">help</a></li>
+                  <!-- <li><a href="/dashboard">Beta</a></li> -->
                 </ul>
 
                 <ul class="nav navbar-nav navbar-right">

--- a/linkerd/admin/src/main/scala/io/buoyant/linkerd/admin/DashboardHandler.scala
+++ b/linkerd/admin/src/main/scala/io/buoyant/linkerd/admin/DashboardHandler.scala
@@ -1,0 +1,32 @@
+package io.buoyant.linkerd.admin
+
+import com.twitter.finagle.http.{Request, Response, Status}
+import com.twitter.finagle.Service
+import com.twitter.util.Future
+
+private[admin] class DashboardHandler extends Service[Request, Response] {
+  lazy val html = dashboardHtml
+
+  override def apply(req: Request): Future[Response] = req.path match {
+    case "/dashboard" =>
+      AdminHandler.mkResponse(html)
+    case _ =>
+      Future.value(Response(Status.NotFound))
+  }
+
+  def dashboardHtml = {
+    AdminHandler.html(
+      content = s"""
+        <div class="row text-center">
+          Welcome to the beta dashboard!
+        </div>
+        <hr>
+        <div class="row text-center test-div">
+        </div>
+        <hr>
+      """,
+      csses = Seq("dashboard.css"),
+      javaScripts = Seq("dashboard.js")
+    )
+  }
+}

--- a/linkerd/admin/src/main/scala/io/buoyant/linkerd/admin/LinkerdAdmin.scala
+++ b/linkerd/admin/src/main/scala/io/buoyant/linkerd/admin/LinkerdAdmin.scala
@@ -17,14 +17,15 @@ class LinkerdAdmin(app: App, linker: Linker, config: LinkerConfig) extends Admin
   private[this] val dtabs: Future[Map[String, Dtab]] =
     Future.value(
       linker.routers.map { router =>
-      val RoutingFactory.BaseDtab(dtab) = router.params[RoutingFactory.BaseDtab]
-      router.label -> dtab()
-    }.toMap
+        val RoutingFactory.BaseDtab(dtab) = router.params[RoutingFactory.BaseDtab]
+        router.label -> dtab()
+      }.toMap
     )
 
   private[this] def linkerdAdminRoutes: Seq[(String, Service[Request, Response])] = Seq(
 
     "/" -> new SummaryHandler(linker),
+    "/dashboard" -> new DashboardHandler,
     "/files/" -> (StaticFilter andThen ResourceHandler.fromDirectoryOrJar(
       baseRequestPath = "/files/",
       baseResourcePath = "io/buoyant/linkerd/admin",

--- a/linkerd/admin/src/main/scala/io/buoyant/linkerd/admin/SummaryHandler.scala
+++ b/linkerd/admin/src/main/scala/io/buoyant/linkerd/admin/SummaryHandler.scala
@@ -1,12 +1,9 @@
 package io.buoyant.linkerd.admin
 
-import com.twitter.finagle.http.{MediaType, Request, Response, Status}
-import com.twitter.finagle.{Http => FHttp, Service, http => fhttp, param}
-import com.twitter.io.Buf
-import com.twitter.server.TwitterServer
+import com.twitter.finagle.http.{Request, Response, Status}
+import com.twitter.finagle.Service
 import com.twitter.util.Future
 import io.buoyant.linkerd.{Build, Linker}
-import scala.util.matching.Regex
 
 private[admin] class SummaryHandler(linker: Linker) extends Service[Request, Response] {
   import SummaryHandler._


### PR DESCRIPTION
So we can start work on the new dashboard.

* Added basic js and css files as starting points/entry points - copied over basics from summary.js
* Copied over SummaryHandler as a base for the new dashboard.  
* We don't use Stat/statsHtml right now anywhere, but the designs have those stats at the bottom of the page, so I added it now.  I can remove/simplify it, right now it's wholesale from SummaryHandler.

Fixes #184