### PR TITLE
boundPath clientTls strict mode

### DIFF
--- a/docs/config.md
+++ b/docs/config.md
@@ -215,6 +215,8 @@ supports the following options:
   * *commonNamePattern* -- The common name to use for destinations matching
     the above prefix.  Variables captured in the prefix may be used in this
     string.
+* *strict* -- Optional. When true, paths that fail to match any prefixes throw
+    an exception. Defaults to true.
 
 For example,
 
@@ -224,6 +226,7 @@ caCertPath: /foo/cacert.pem
 names:
 - prefix: "/io.l5d.fs/{host}"
   commonNamePattern: "{host}.buoyant.io"
+ strict: false
 ```
 
 #### Load Balancer

--- a/examples/acceptance-test.l5d
+++ b/examples/acceptance-test.l5d
@@ -120,7 +120,7 @@ routers:
 
 # TODO: test ssl traffic
 - protocol: http
-  label: tls
+  label: tlsStatic
   baseDtab: |
     /host     => /io.l5d.fs;
     /method   => /$/io.buoyant.http.anyMethodPfx/host;
@@ -132,6 +132,27 @@ routers:
       caCertPath: /foo/caCert.pem
   servers:
   - port: 4144
+    ip: 0.0.0.0
+    tls:
+      certPath: /foo/cert.pem
+      keyPath: /foo/key.pem
+
+- protocol: http
+  label: tlsBoundPath
+  baseDtab: |
+    /host     => /io.l5d.fs;
+    /method   => /$/io.buoyant.http.anyMethodPfx/host;
+    /http/1.1 => /method;
+  client:
+    tls:
+      kind: io.l5d.clientTls.boundPath
+      caCertPath: /foo/caCert.pem
+      strict: false
+      names:
+      - prefix: "/io.l5d.fs/{service}"
+        commonNamePattern: "{service}"
+  servers:
+  - port: 4145
     ip: 0.0.0.0
     tls:
       certPath: /foo/cert.pem

--- a/linkerd/admin/src/main/scala/io/buoyant/linkerd/admin/LinkerdAdmin.scala
+++ b/linkerd/admin/src/main/scala/io/buoyant/linkerd/admin/LinkerdAdmin.scala
@@ -17,9 +17,9 @@ class LinkerdAdmin(app: App, linker: Linker, config: LinkerConfig) extends Admin
   private[this] val dtabs: Future[Map[String, Dtab]] =
     Future.value(
       linker.routers.map { router =>
-        val RoutingFactory.BaseDtab(dtab) = router.params[RoutingFactory.BaseDtab]
-        router.label -> dtab()
-      }.toMap
+      val RoutingFactory.BaseDtab(dtab) = router.params[RoutingFactory.BaseDtab]
+      router.label -> dtab()
+    }.toMap
     )
 
   private[this] def linkerdAdminRoutes: Seq[(String, Service[Request, Response])] = Seq(

--- a/linkerd/tls/src/test/scala/io/l5d/clientTls/boundPathTest.scala
+++ b/linkerd/tls/src/test/scala/io/l5d/clientTls/boundPathTest.scala
@@ -1,5 +1,7 @@
 package io.l5d.clientTls
 
+import com.twitter.finagle.{Addr, Stack}
+import com.twitter.finagle.client.AddrMetadataExtraction.AddrMetadata
 import com.twitter.finagle.util.LoadService
 import io.buoyant.linkerd.TlsClientInitializer
 import org.scalatest.FunSuite
@@ -7,6 +9,14 @@ import org.scalatest.FunSuite
 class boundPathTest extends FunSuite {
   test("sanity") {
     static("hello", None).tlsClientPrep
+  }
+
+  test("boundPath throws MatcherError on failed match in strict mode") {
+    val meta = AddrMetadata(Addr.Metadata("id" -> "/foo/bar"))
+    val params = Stack.Params.empty + meta
+    intercept[MatcherError] {
+      boundPath(None, Seq(), Some(true)).tlsClientPrep.peerCommonName(params)
+    }
   }
 
   test("service registration") {


### PR DESCRIPTION
Before this change, if a path did not match the provided prefixes
it would serve plaintext silently. Now if strict: true it errors
instead

Fixes #182 