### PR TITLE
Move ProcInfo to facilitate code sharing

### DIFF
--- a/linkerd/admin/src/main/resources/io/buoyant/linkerd/admin/css/dashboard.css
+++ b/linkerd/admin/src/main/resources/io/buoyant/linkerd/admin/css/dashboard.css
@@ -1,0 +1,4 @@
+body {
+  background-image: radial-gradient(34% 43%, #161963 23%, #090B34 47%);
+  color: #FFFFFF;
+}

--- a/linkerd/admin/src/main/resources/io/buoyant/linkerd/admin/js/dashboard.js
+++ b/linkerd/admin/src/main/resources/io/buoyant/linkerd/admin/js/dashboard.js
@@ -1,0 +1,45 @@
+"use strict";
+
+/**
+ * Number of millis to wait between data updates.
+ */
+var UPDATE_INTERVAL = 1000;
+
+$.when(
+  $.get("/admin/metrics.json")
+).done(function(metricsJson) {
+
+  $(function() {
+    var dashboard = Dashboard();
+    dashboard.start(UPDATE_INTERVAL);
+  });
+});
+
+var Dashboard = (function() {
+
+  function render(data) {
+    var json = $.parseJSON(data);
+    $(".test-div").text("Fill in content.");
+  }
+
+  /**
+   * Returns a function that may be called to trigger an update.
+   */
+  return function() {
+
+    function update() {
+      $.ajax({
+        url: "/admin/metrics.json",
+        dataType: "text",
+        cache: false,
+        success: function(metrics) {
+          render(metrics);
+        }
+      });
+    }
+
+    return {
+      start: function(interval) { setInterval(update, interval); }
+    };
+  };
+})();

--- a/linkerd/admin/src/main/resources/io/buoyant/linkerd/admin/js/dashboard.js
+++ b/linkerd/admin/src/main/resources/io/buoyant/linkerd/admin/js/dashboard.js
@@ -4,32 +4,40 @@
  * Number of millis to wait between data updates.
  */
 var UPDATE_INTERVAL = 1000;
-var OVERVIEW_STATS_DESCRIPTION = {
-  stats: [
-    { description: "uptime", dataKey: "jvm/uptime",  elemId: "jvm-uptime", value: "0s" },
-    { description: "thread count", dataKey: "jvm/thread/count", elemId: "jvm-thread-count", value: "0" },
-    { description: "memory used", dataKey: "jvm/mem/current/used", elemId: "jvm-mem-current-used", value: "0MB" },
-    { description: "gc", dataKey: "jvm/gc/msec",  elemId: "jvm-gc-msec", value: "1ms" }
-  ]
-}
 
 $.when(
-  $.get("/files/template/overview_stats.template"),
+  $.get("/files/template/process_info.template"),
   $.get("/admin/metrics.json")
 ).done(function(overviewStatsRsp, metricsJson) {
   appendOverviewSection();
+  var procInfo = ProcInfo();
 
   $(function() {
     var dashboard = Dashboard();
+    procInfo.start(UPDATE_INTERVAL);
     dashboard.start(UPDATE_INTERVAL);
   });
 
   function appendOverviewSection() {
     var overviewTemplate = Handlebars.compile(overviewStatsRsp[0]);
-    var compiledHtml = overviewTemplate(OVERVIEW_STATS_DESCRIPTION);
+    var compiledHtml = overviewTemplate(getOverviewStatsData());
 
     var $overviewStats = $('<div />').html(compiledHtml);
     $overviewStats.appendTo("body");
+  }
+
+  function getOverviewStatsData() {
+    var buildVersion = $(".server-data").data("linkerd-version");
+
+    return {
+      stats: [
+        { description: "linkerd version", dataKey: "",  elemId: "linkerd-version", value: buildVersion },
+        { description: "uptime", dataKey: "jvm/uptime",  elemId: "jvm-uptime", value: "0s" },
+        { description: "thread count", dataKey: "jvm/thread/count", elemId: "jvm-thread-count", value: "0" },
+        { description: "memory used", dataKey: "jvm/mem/current/used", elemId: "jvm-mem-current-used", value: "0MB" },
+        { description: "gc", dataKey: "jvm/gc/msec",  elemId: "jvm-gc-msec", value: "1ms" }
+      ]
+    }
   }
 });
 

--- a/linkerd/admin/src/main/resources/io/buoyant/linkerd/admin/js/dashboard.js
+++ b/linkerd/admin/src/main/resources/io/buoyant/linkerd/admin/js/dashboard.js
@@ -4,15 +4,33 @@
  * Number of millis to wait between data updates.
  */
 var UPDATE_INTERVAL = 1000;
+var OVERVIEW_STATS_DESCRIPTION = {
+  stats: [
+    { description: "uptime", dataKey: "jvm/uptime",  elemId: "jvm-uptime", value: "0s" },
+    { description: "thread count", dataKey: "jvm/thread/count", elemId: "jvm-thread-count", value: "0" },
+    { description: "memory used", dataKey: "jvm/mem/current/used", elemId: "jvm-mem-current-used", value: "0MB" },
+    { description: "gc", dataKey: "jvm/gc/msec",  elemId: "jvm-gc-msec", value: "1ms" }
+  ]
+}
 
 $.when(
+  $.get("/files/template/overview_stats.template"),
   $.get("/admin/metrics.json")
-).done(function(metricsJson) {
+).done(function(overviewStatsRsp, metricsJson) {
+  appendOverviewSection();
 
   $(function() {
     var dashboard = Dashboard();
     dashboard.start(UPDATE_INTERVAL);
   });
+
+  function appendOverviewSection() {
+    var overviewTemplate = Handlebars.compile(overviewStatsRsp[0]);
+    var compiledHtml = overviewTemplate(OVERVIEW_STATS_DESCRIPTION);
+
+    var $overviewStats = $('<div />').html(compiledHtml);
+    $overviewStats.appendTo("body");
+  }
 });
 
 var Dashboard = (function() {

--- a/linkerd/admin/src/main/resources/io/buoyant/linkerd/admin/js/process_info.js
+++ b/linkerd/admin/src/main/resources/io/buoyant/linkerd/admin/js/process_info.js
@@ -1,0 +1,54 @@
+/**
+ * Process info for topline summary
+ */
+var ProcInfo = (function() {
+
+  var msToStr = new MsToStringConverter();
+  var bytesToStr = new BytesToStringConverter();
+  var refreshUri = "/admin/metrics";
+
+  function pretty(name, value) {
+    switch (name) {
+      case "jvm/uptime": return msToStr.convert(value);
+      case "jvm/mem/current/used": return bytesToStr.convert(value);
+      case "jvm/gc/msec": return msToStr.convert(value);
+      default: return value;
+    }
+  }
+
+  function render(data) {
+    var json = $.parseJSON(data);
+    _(json).each(function(obj) {
+      var id = obj.name.replace(/\//g, "-");
+      var value = pretty(obj.name, obj.value);
+      $("#"+id).text(value);
+    });
+  }
+
+  /**
+   * Returns a function that may be called to trigger an update.
+   */
+  return function() {
+    var url = refreshUri + "?";
+
+    $("#process-info ul li").each(function(i) {
+      var key = $(this).data("key");
+      if (key) {
+        url += "&m="+key;
+      }
+    });
+
+    function update() {
+      $.ajax({
+        url: url,
+        dataType: "text",
+        cache: false,
+        success: render
+      });
+    }
+
+    return {
+      start: function(interval) { setInterval(update, interval); }
+    };
+  };
+})();

--- a/linkerd/admin/src/main/resources/io/buoyant/linkerd/admin/js/summary.js
+++ b/linkerd/admin/src/main/resources/io/buoyant/linkerd/admin/js/summary.js
@@ -39,58 +39,6 @@ $.when(
   });
 });
 
-/**
- * Process info
- */
-var ProcInfo = (function() {
-
-  var msToStr = new MsToStringConverter();
-  var bytesToStr = new BytesToStringConverter();
-
-  function pretty(name, value) {
-    switch (name) {
-      case "jvm/uptime": return msToStr.convert(value);
-      case "jvm/mem/current/used": return bytesToStr.convert(value);
-      case "jvm/gc/msec": return msToStr.convert(value);
-      default: return value;
-    }
-  }
-
-  function render(data) {
-    var json = $.parseJSON(data);
-    _(json).each(function(obj) {
-      var id = obj.name.replace(/\//g, "-");
-      var value = pretty(obj.name, obj.value);
-      $("#"+id).text(value);
-    });
-  }
-
-  /**
-   * Returns a function that may be called to trigger an update.
-   */
-  return function() {
-    var url = $("#process-info").data("refresh-uri") + "?";
-    $("#process-info ul li").each(function(i) {
-      var key = $(this).data("key");
-      if (key) {
-        url += "&m="+key;
-      }
-    });
-
-    function update() {
-      $.ajax({
-        url: url,
-        dataType: "text",
-        cache: false,
-        success: render
-      });
-    }
-
-    return {
-      start: function(interval) { setInterval(update, interval); }
-    };
-  };
-})();
 
 /**
  * Big summary board of server requests

--- a/linkerd/admin/src/main/resources/io/buoyant/linkerd/admin/template/overview_stats.template
+++ b/linkerd/admin/src/main/resources/io/buoyant/linkerd/admin/template/overview_stats.template
@@ -1,0 +1,12 @@
+<div class="row text-center">
+  <div id="process-info" data-refresh-uri="/admin/metrics">
+    <ul class="list-inline topline-stats">
+      {{#each stats}}
+        <li data-key="{{dataKey}}">
+          <strong class="stat-label">{{description}}</strong>
+          <span id="{{elemId}}" class="stat">{{value}}</span>
+        </li>
+      {{/each}}
+    </ul>
+  </div>
+</div>

--- a/linkerd/admin/src/main/resources/io/buoyant/linkerd/admin/template/process_info.template
+++ b/linkerd/admin/src/main/resources/io/buoyant/linkerd/admin/template/process_info.template
@@ -1,5 +1,5 @@
 <div class="row text-center">
-  <div id="process-info" data-refresh-uri="/admin/metrics">
+  <div id="process-info">
     <ul class="list-inline topline-stats">
       {{#each stats}}
         <li data-key="{{dataKey}}">

--- a/linkerd/admin/src/main/scala/io/buoyant/linkerd/admin/AdminHandler.scala
+++ b/linkerd/admin/src/main/scala/io/buoyant/linkerd/admin/AdminHandler.scala
@@ -64,6 +64,7 @@ object AdminHandler extends HtmlView {
                   <li><a href="/metrics">metrics</a></li>
                   <li><a href="/admin/logging">logging</a></li>
                   <li><a href="https://linkerd.io/help/">help</a></li>
+                  <!-- <li><a href="/dashboard">Beta</a></li> -->
                 </ul>
 
                 <ul class="nav navbar-nav navbar-right">

--- a/linkerd/admin/src/main/scala/io/buoyant/linkerd/admin/DashboardHandler.scala
+++ b/linkerd/admin/src/main/scala/io/buoyant/linkerd/admin/DashboardHandler.scala
@@ -3,12 +3,9 @@ package io.buoyant.linkerd.admin
 import com.twitter.finagle.http.{Request, Response, Status}
 import com.twitter.finagle.Service
 import com.twitter.util.Future
-import io.buoyant.linkerd.{Build, Linker}
 
-private[admin] class DashboardHandler(linker: Linker) extends Service[Request, Response] {
-  import DashboardHandler._
-
-  lazy val html = dashboardHtml(linker.routers.length)
+private[admin] class DashboardHandler extends Service[Request, Response] {
+  lazy val html = dashboardHtml
 
   override def apply(req: Request): Future[Response] = req.path match {
     case "/dashboard" =>
@@ -16,35 +13,8 @@ private[admin] class DashboardHandler(linker: Linker) extends Service[Request, R
     case _ =>
       Future.value(Response(Status.NotFound))
   }
-}
 
-private object DashboardHandler {
-  private[this] case class Stat(
-    description: String,
-    elemId: String,
-    value: String,
-    style: String,
-    dataKey: String
-  )
-
-  def dashboardHtml(routerCount: Int) = {
-    val statsHtml =
-      List(
-        Stat("linkerd version", "linkerd-version", Build.load().version, "primary-stat", ""),
-        Stat("router count", "router-count", routerCount.toString, "primary-stat", ""),
-        Stat("uptime", "jvm-uptime", "0s", "", "jvm/uptime"),
-        Stat("thread count", "jvm-thread-count", "0", "", "jvm/thread/count"),
-        Stat("memory used", "jvm-mem-current-used", "0MB", "", "jvm/mem/current/used"),
-        Stat("gc", "jvm-gc-msec", "1s", "", "jvm/gc/msec")
-      ).map { stat =>
-          s"""
-        <li data-key="${stat.dataKey}">
-          <strong class="stat-label ${stat.style}">${stat.description}</strong>
-          <span id="${stat.elemId}" class="stat">${stat.value}</span>
-        </li>
-        """
-        }.mkString("\n")
-
+  def dashboardHtml = {
     AdminHandler.html(
       content = s"""
         <div class="row text-center">

--- a/linkerd/admin/src/main/scala/io/buoyant/linkerd/admin/DashboardHandler.scala
+++ b/linkerd/admin/src/main/scala/io/buoyant/linkerd/admin/DashboardHandler.scala
@@ -8,7 +8,7 @@ import io.buoyant.linkerd.{Build, Linker}
 private[admin] class DashboardHandler(linker: Linker) extends Service[Request, Response] {
   import DashboardHandler._
 
-  lazy val html = summaryHtml(linker.routers.length)
+  lazy val html = dashboardHtml(linker.routers.length)
 
   override def apply(req: Request): Future[Response] = req.path match {
     case "/dashboard" =>
@@ -27,7 +27,7 @@ private object DashboardHandler {
     dataKey: String
   )
 
-  def summaryHtml(routerCount: Int) = {
+  def dashboardHtml(routerCount: Int) = {
     val statsHtml =
       List(
         Stat("linkerd version", "linkerd-version", Build.load().version, "primary-stat", ""),

--- a/linkerd/admin/src/main/scala/io/buoyant/linkerd/admin/DashboardHandler.scala
+++ b/linkerd/admin/src/main/scala/io/buoyant/linkerd/admin/DashboardHandler.scala
@@ -5,21 +5,20 @@ import com.twitter.finagle.Service
 import com.twitter.util.Future
 import io.buoyant.linkerd.{Build, Linker}
 
-private[admin] class SummaryHandler(linker: Linker) extends Service[Request, Response] {
-  import SummaryHandler._
+private[admin] class DashboardHandler(linker: Linker) extends Service[Request, Response] {
+  import DashboardHandler._
 
   lazy val html = summaryHtml(linker.routers.length)
 
   override def apply(req: Request): Future[Response] = req.path match {
-    case "/" =>
+    case "/dashboard" =>
       AdminHandler.mkResponse(html)
     case _ =>
       Future.value(Response(Status.NotFound))
   }
 }
 
-private object SummaryHandler {
-
+private object DashboardHandler {
   private[this] case class Stat(
     description: String,
     elemId: String,
@@ -29,7 +28,6 @@ private object SummaryHandler {
   )
 
   def summaryHtml(routerCount: Int) = {
-
     val statsHtml =
       List(
         Stat("linkerd version", "linkerd-version", Build.load().version, "primary-stat", ""),
@@ -50,28 +48,15 @@ private object SummaryHandler {
     AdminHandler.html(
       content = s"""
         <div class="row text-center">
-          <div id="process-info" data-refresh-uri="/admin/metrics">
-            <ul class="list-inline topline-stats">
-              $statsHtml
-            </ul>
-          </div>
+          Welcome to the beta dashboard!
         </div>
-        <hr/>
-
-        <h1 class="text-center">request volume</h1>
-        <div class="row text-center requests">
-          <div id="request-stats" class="col-sm-2 dl-horizontal"></div>
-          <div class="col-sm-10">
-            <canvas id="request-canvas" height="200"></canvas>
-          </div>
+        <hr>
+        <div class="row text-center test-div">
         </div>
-
-        <div id="client-info" class="interfaces"></div>
-        <div id="server-info" class="interfaces"></div>
-        <div id="namer-info" class="interfaces"></div>
+        <hr>
       """,
-      csses = Seq("summary.css"),
-      javaScripts = Seq("lib/smoothie.js", "utils.js", "routers.js", "namers.js", "summary.js")
+      csses = Seq("dashboard.css"),
+      javaScripts = Seq("dashboard.js")
     )
   }
 }

--- a/linkerd/admin/src/main/scala/io/buoyant/linkerd/admin/DashboardHandler.scala
+++ b/linkerd/admin/src/main/scala/io/buoyant/linkerd/admin/DashboardHandler.scala
@@ -3,6 +3,7 @@ package io.buoyant.linkerd.admin
 import com.twitter.finagle.http.{Request, Response, Status}
 import com.twitter.finagle.Service
 import com.twitter.util.Future
+import io.buoyant.linkerd.Build
 
 private[admin] class DashboardHandler extends Service[Request, Response] {
   lazy val html = dashboardHtml
@@ -17,6 +18,7 @@ private[admin] class DashboardHandler extends Service[Request, Response] {
   def dashboardHtml = {
     AdminHandler.html(
       content = s"""
+        <div class="server-data" data-linkerd-version="${Build.load().version}" style="visibility:hidden"></div>
         <div class="row text-center">
           Welcome to the beta dashboard!
         </div>
@@ -26,7 +28,7 @@ private[admin] class DashboardHandler extends Service[Request, Response] {
         <hr>
       """,
       csses = Seq("dashboard.css"),
-      javaScripts = Seq("dashboard.js")
+      javaScripts = Seq("utils.js", "process_info.js", "dashboard.js")
     )
   }
 }

--- a/linkerd/admin/src/main/scala/io/buoyant/linkerd/admin/LinkerdAdmin.scala
+++ b/linkerd/admin/src/main/scala/io/buoyant/linkerd/admin/LinkerdAdmin.scala
@@ -17,15 +17,15 @@ class LinkerdAdmin(app: App, linker: Linker, config: LinkerConfig) extends Admin
   private[this] val dtabs: Future[Map[String, Dtab]] =
     Future.value(
       linker.routers.map { router =>
-        val RoutingFactory.BaseDtab(dtab) = router.params[RoutingFactory.BaseDtab]
-        router.label -> dtab()
-      }.toMap
+      val RoutingFactory.BaseDtab(dtab) = router.params[RoutingFactory.BaseDtab]
+      router.label -> dtab()
+    }.toMap
     )
 
   private[this] def linkerdAdminRoutes: Seq[(String, Service[Request, Response])] = Seq(
 
     "/" -> new SummaryHandler(linker),
-    "/dashboard" -> new DashboardHandler(linker),
+    "/dashboard" -> new DashboardHandler,
     "/files/" -> (StaticFilter andThen ResourceHandler.fromDirectoryOrJar(
       baseRequestPath = "/files/",
       baseResourcePath = "io/buoyant/linkerd/admin",

--- a/linkerd/admin/src/main/scala/io/buoyant/linkerd/admin/LinkerdAdmin.scala
+++ b/linkerd/admin/src/main/scala/io/buoyant/linkerd/admin/LinkerdAdmin.scala
@@ -25,6 +25,7 @@ class LinkerdAdmin(app: App, linker: Linker, config: LinkerConfig) extends Admin
   private[this] def linkerdAdminRoutes: Seq[(String, Service[Request, Response])] = Seq(
 
     "/" -> new SummaryHandler(linker),
+    "/dashboard" -> new DashboardHandler(linker),
     "/files/" -> (StaticFilter andThen ResourceHandler.fromDirectoryOrJar(
       baseRequestPath = "/files/",
       baseResourcePath = "io/buoyant/linkerd/admin",

--- a/linkerd/admin/src/main/scala/io/buoyant/linkerd/admin/LinkerdAdmin.scala
+++ b/linkerd/admin/src/main/scala/io/buoyant/linkerd/admin/LinkerdAdmin.scala
@@ -17,9 +17,9 @@ class LinkerdAdmin(app: App, linker: Linker, config: LinkerConfig) extends Admin
   private[this] val dtabs: Future[Map[String, Dtab]] =
     Future.value(
       linker.routers.map { router =>
-      val RoutingFactory.BaseDtab(dtab) = router.params[RoutingFactory.BaseDtab]
-      router.label -> dtab()
-    }.toMap
+        val RoutingFactory.BaseDtab(dtab) = router.params[RoutingFactory.BaseDtab]
+        router.label -> dtab()
+      }.toMap
     )
 
   private[this] def linkerdAdminRoutes: Seq[(String, Service[Request, Response])] = Seq(

--- a/linkerd/admin/src/main/scala/io/buoyant/linkerd/admin/SummaryHandler.scala
+++ b/linkerd/admin/src/main/scala/io/buoyant/linkerd/admin/SummaryHandler.scala
@@ -49,6 +49,13 @@ private object SummaryHandler {
 
     AdminHandler.html(
       content = s"""
+        <div class="row text-center">
+          <div id="process-info" data-refresh-uri="/admin/metrics">
+            <ul class="list-inline topline-stats">
+              $statsHtml
+            </ul>
+          </div>
+        </div>
         <hr/>
 
         <h1 class="text-center">request volume</h1>

--- a/linkerd/admin/src/main/scala/io/buoyant/linkerd/admin/SummaryHandler.scala
+++ b/linkerd/admin/src/main/scala/io/buoyant/linkerd/admin/SummaryHandler.scala
@@ -49,13 +49,6 @@ private object SummaryHandler {
 
     AdminHandler.html(
       content = s"""
-        <div class="row text-center">
-          <div id="process-info" data-refresh-uri="/admin/metrics">
-            <ul class="list-inline topline-stats">
-              $statsHtml
-            </ul>
-          </div>
-        </div>
         <hr/>
 
         <h1 class="text-center">request volume</h1>

--- a/linkerd/admin/src/main/scala/io/buoyant/linkerd/admin/SummaryHandler.scala
+++ b/linkerd/admin/src/main/scala/io/buoyant/linkerd/admin/SummaryHandler.scala
@@ -71,7 +71,7 @@ private object SummaryHandler {
         <div id="namer-info" class="interfaces"></div>
       """,
       csses = Seq("summary.css"),
-      javaScripts = Seq("lib/smoothie.js", "utils.js", "routers.js", "namers.js", "summary.js")
+      javaScripts = Seq("lib/smoothie.js", "utils.js", "process_info.js", "routers.js", "namers.js", "summary.js")
     )
   }
 }


### PR DESCRIPTION
Moved the module ProcInfo into its own file so that the code can be reused for the revamped dashboard.

The only thing I've changed in ProcInfo is including refreshUri in the file rather than getting it from the html

Branched off of #184 so will need to rebase off master when that hits.