### PR TITLE
Differentiate dashboard v1 & v2 banners

### DIFF
--- a/admin/src/main/scala/io/buoyant/admin/HtmlView.scala
+++ b/admin/src/main/scala/io/buoyant/admin/HtmlView.scala
@@ -8,7 +8,8 @@ trait HtmlView {
     content: String,
     tailContent: String = "",
     csses: Seq[String] = Nil,
-    javaScripts: Seq[String] = Nil
+    javaScripts: Seq[String] = Nil,
+    navbar: String = ""
   ): String
 
   def mkResponse(

--- a/admin/src/main/scala/io/buoyant/admin/names/DelegateHandler.scala
+++ b/admin/src/main/scala/io/buoyant/admin/names/DelegateHandler.scala
@@ -51,6 +51,6 @@ class DelegateHandler(
         <script id="data" type="application/json">${DelegateApiHandler.Codec.writeStr(dtab)}</script>
       """,
       javaScripts = Seq("dtab_viewer.js", "delegate.js"),
-      csses = Seq("delegator.css")
+      csses = Seq("styleguide/styleguide.css", "styleguide/local.css", "admin.css", "delegator.css")
     )
 }

--- a/linkerd/admin/src/main/resources/io/buoyant/linkerd/admin/css/dashboard.css
+++ b/linkerd/admin/src/main/resources/io/buoyant/linkerd/admin/css/dashboard.css
@@ -1,4 +1,26 @@
 body {
   background-image: radial-gradient(34% 43%, #161963 23%, #090B34 47%);
+  background-size: cover;
+  background-repeat: no-repeat;
   color: #FFFFFF;
+  height: 100vh;
+}
+
+nav {
+  padding: 9px 28px;
+  font-size: 18px;
+  font-weight: 100;
+  line-height: 1.1
+}
+
+#navbar {
+  margin-top: 4px;
+}
+
+.navbar-brand-img img {
+  height: 26px;
+}
+
+nav ul.navbar-nav {
+  margin-left: 18px;
 }

--- a/linkerd/admin/src/main/scala/io/buoyant/linkerd/admin/AdminHandler.scala
+++ b/linkerd/admin/src/main/scala/io/buoyant/linkerd/admin/AdminHandler.scala
@@ -7,6 +7,60 @@ import io.buoyant.admin.HtmlView
 
 object AdminHandler extends HtmlView {
 
+  val version1NavBar =
+    s"""<nav class="navbar navbar-inverse navbar-fixed-top">
+      <div class="container">
+        <div class="navbar-header">
+          <button type="button" class="navbar-toggle collapsed" data-toggle="collapse" data-target="#navbar" aria-expanded="false">
+            <span class="sr-only">Toggle navigation</span>
+            <span class="icon-bar"></span>
+            <span class="icon-bar"></span>
+            <span class="icon-bar"></span>
+          </button>
+
+          <a class="navbar-brand-img" href="/">
+            <img alt="Logo" src="/files/images/logo.svg">
+          </a>
+        </div>
+        <div id="navbar" class="collapse navbar-collapse">
+          <ul class="nav navbar-nav">
+            <li><a href="/delegator">dtab</a></li>
+            <li><a href="/metrics">metrics</a></li>
+            <li><a href="/admin/logging">logging</a></li>
+            <li><a href="https://linkerd.io/help/">help</a></li>
+            <!-- <li><a href="/dashboard">Beta</a></li> -->
+          </ul>
+
+          <ul class="nav navbar-nav navbar-right">
+            <li class="dropdown">
+              <a href="#" class="dropdown-toggle" data-toggle="dropdown" role="button" aria-haspopup="true" aria-expanded="false">
+                <span class="router-label">All</span> <span class="caret"></span>
+              </a>
+              <ul class="dropdown-menu">
+              </ul>
+            </li>
+          </ul>
+        </div>
+      </div>
+    </nav>"""
+
+  val version2NavBar =
+    s"""<nav class="navbar navbar-inverse">
+      <div class="navbar-header">
+        <a class="navbar-brand-img" href="/">
+          <img alt="Logo" src="/files/images/logo.svg">
+        </a>
+      </div>
+      <div id="navbar" class="collapse navbar-collapse">
+        <ul class="nav navbar-nav">
+          <li>router overview</li>
+        </ul>
+        <ul class="nav navbar-nav navbar-right">
+          <li>version 2.0</li>
+        </ul>
+      </div>
+    </nav>"""
+
   def mkResponse(
     content: String,
     mediaType: String = MediaType.Html
@@ -21,7 +75,8 @@ object AdminHandler extends HtmlView {
     content: String,
     tailContent: String = "",
     csses: Seq[String] = Nil,
-    javaScripts: Seq[String] = Nil
+    javaScripts: Seq[String] = Nil,
+    navbar: String = version1NavBar
   ): String = {
     val cssesHtml = csses.map { css =>
       s"""<link type="text/css" href="/files/css/$css" rel="stylesheet"/>"""
@@ -37,48 +92,11 @@ object AdminHandler extends HtmlView {
         <head>
           <title>linkerd admin</title>
           <link type="text/css" href="/files/css/lib/bootstrap.min.css" rel="stylesheet"/>
-          <link type="text/css" href="/files/css/styleguide/styleguide.css" rel="stylesheet"/>
-          <link type="text/css" href="/files/css/styleguide/local.css" rel="stylesheet"/>
-          <link type="text/css" href="/files/css/admin.css" rel="stylesheet"/>
           <link rel="shortcut icon" href="/favicon.png" />
           $cssesHtml
         </head>
         <body>
-          <nav class="navbar navbar-inverse navbar-fixed-top">
-            <div class="container">
-              <div class="navbar-header">
-                <button type="button" class="navbar-toggle collapsed" data-toggle="collapse" data-target="#navbar" aria-expanded="false">
-                  <span class="sr-only">Toggle navigation</span>
-                  <span class="icon-bar"></span>
-                  <span class="icon-bar"></span>
-                  <span class="icon-bar"></span>
-                </button>
-
-                <a class="navbar-brand-img" href="/">
-                  <img alt="Logo" src="/files/images/logo.svg">
-                </a>
-              </div>
-              <div id="navbar" class="collapse navbar-collapse">
-                <ul class="nav navbar-nav">
-                  <li><a href="/delegator">dtab</a></li>
-                  <li><a href="/metrics">metrics</a></li>
-                  <li><a href="/admin/logging">logging</a></li>
-                  <li><a href="https://linkerd.io/help/">help</a></li>
-                  <!-- <li><a href="/dashboard">Beta</a></li> -->
-                </ul>
-
-                <ul class="nav navbar-nav navbar-right">
-                  <li class="dropdown">
-                    <a href="#" class="dropdown-toggle" data-toggle="dropdown" role="button" aria-haspopup="true" aria-expanded="false">
-                      <span class="router-label">All</span> <span class="caret"></span>
-                    </a>
-                    <ul class="dropdown-menu">
-                    </ul>
-                  </li>
-                </ul>
-              </div>
-            </div>
-          </nav>
+          $navbar
 
           <div class="container-fluid">
             $content

--- a/linkerd/admin/src/main/scala/io/buoyant/linkerd/admin/DashboardHandler.scala
+++ b/linkerd/admin/src/main/scala/io/buoyant/linkerd/admin/DashboardHandler.scala
@@ -28,7 +28,8 @@ private[admin] class DashboardHandler extends Service[Request, Response] {
         <hr>
       """,
       csses = Seq("dashboard.css"),
-      javaScripts = Seq("utils.js", "process_info.js", "dashboard.js")
+      javaScripts = Seq("utils.js", "process_info.js", "dashboard.js"),
+      navbar = AdminHandler.version2NavBar
     )
   }
 }

--- a/linkerd/admin/src/main/scala/io/buoyant/linkerd/admin/LinkerdAdmin.scala
+++ b/linkerd/admin/src/main/scala/io/buoyant/linkerd/admin/LinkerdAdmin.scala
@@ -17,9 +17,9 @@ class LinkerdAdmin(app: App, linker: Linker, config: LinkerConfig) extends Admin
   private[this] val dtabs: Future[Map[String, Dtab]] =
     Future.value(
       linker.routers.map { router =>
-        val RoutingFactory.BaseDtab(dtab) = router.params[RoutingFactory.BaseDtab]
-        router.label -> dtab()
-      }.toMap
+      val RoutingFactory.BaseDtab(dtab) = router.params[RoutingFactory.BaseDtab]
+      router.label -> dtab()
+    }.toMap
     )
 
   private[this] def linkerdAdminRoutes: Seq[(String, Service[Request, Response])] = Seq(

--- a/linkerd/admin/src/main/scala/io/buoyant/linkerd/admin/MetricsHandler.scala
+++ b/linkerd/admin/src/main/scala/io/buoyant/linkerd/admin/MetricsHandler.scala
@@ -17,6 +17,6 @@ private object MetricsHandler extends Service[Request, Response] {
         </div>
       """,
       javaScripts = Seq("lib/smoothie.js", "utils.js", "routers.js", "metrics.js"),
-      csses = Seq("metrics.css")
+      csses = Seq("styleguide/styleguide.css", "styleguide/local.css", "admin.css", "metrics.css")
     )
 }

--- a/linkerd/admin/src/main/scala/io/buoyant/linkerd/admin/SummaryHandler.scala
+++ b/linkerd/admin/src/main/scala/io/buoyant/linkerd/admin/SummaryHandler.scala
@@ -70,7 +70,7 @@ private object SummaryHandler {
         <div id="server-info" class="interfaces"></div>
         <div id="namer-info" class="interfaces"></div>
       """,
-      csses = Seq("summary.css"),
+      csses = Seq("styleguide/styleguide.css", "styleguide/local.css", "admin.css", "summary.css"),
       javaScripts = Seq("lib/smoothie.js", "utils.js", "process_info.js", "routers.js", "namers.js", "summary.js")
     )
   }


### PR DESCRIPTION
Adds version 2 banner and moves version 1 specific css out of
AdminHandler

![screen shot 2016-03-25 at 11 29 37 am](https://cloud.githubusercontent.com/assets/41829/14052760/cd7d5984-f289-11e5-9e0d-7bd942057f12.png)

Unresolved:
- [ ] the linkerd logo needs to be re-rendered with larger font
- [ ] we need to decide if we're going to use Helvetica, DINNextLT, or what