### PR TITLE
Add a metrics collector to query for dashboard data

### DIFF
--- a/linkerd/admin/src/main/resources/io/buoyant/linkerd/admin/js/dashboard.js
+++ b/linkerd/admin/src/main/resources/io/buoyant/linkerd/admin/js/dashboard.js
@@ -11,11 +11,13 @@ $.when(
 ).done(function(overviewStatsRsp, metricsJson) {
   appendOverviewSection();
   var procInfo = ProcInfo();
+  var dashboard = Dashboard();
+
+  var metricsListeners = [procInfo, dashboard];
+  var metricsCollector = MetricsCollector(metricsListeners);
 
   $(function() {
-    var dashboard = Dashboard();
-    procInfo.start(UPDATE_INTERVAL);
-    dashboard.start(UPDATE_INTERVAL);
+    metricsCollector.start(UPDATE_INTERVAL);
   });
 
   function appendOverviewSection() {
@@ -44,28 +46,17 @@ $.when(
 var Dashboard = (function() {
 
   function render(data) {
-    var json = $.parseJSON(data);
     $(".test-div").text("Fill in content.");
   }
 
-  /**
-   * Returns a function that may be called to trigger an update.
-   */
   return function() {
-
-    function update() {
-      $.ajax({
-        url: "/admin/metrics.json",
-        dataType: "text",
-        cache: false,
-        success: function(metrics) {
-          render(metrics);
-        }
-      });
-    }
-
     return {
-      start: function(interval) { setInterval(update, interval); }
+      onMetricsUpdate: function(data) {
+        render(data.general);
+      },
+      desiredMetrics: function() {
+        return [];
+      }
     };
   };
 })();

--- a/linkerd/admin/src/main/resources/io/buoyant/linkerd/admin/js/metrics_collector.js
+++ b/linkerd/admin/src/main/resources/io/buoyant/linkerd/admin/js/metrics_collector.js
@@ -1,0 +1,67 @@
+/**
+  A module to consolidate our backend metric requests. Collects all metrics that
+  we need and gets them in two requests - one to metrics.json and one to metrics
+  with the desired params.
+
+  Register a listener to receive metric updates. Each listener needs to implement:
+    - onMetricsUpdate(data) - to handle new incoming data
+      data is of the form:
+      {
+        general: {}, // data obtained from /metrics.json
+        specific: {} // data obtained from /metrics?m=...
+      }
+    - desiredMetrics() - returns a list of metrics the listener wants
+*/
+var MetricsCollector = (function() {
+  var generalUpdateUri = "/admin/metrics.json";
+  var metricsUpdateUri = "/admin/metrics?";
+
+  function url(listeners) {
+    var params = _.reduce(listeners, function(mem, listener) {
+      return mem.concat(listener.desiredMetrics())
+    }, []);
+
+    return metricsUpdateUri + $.param({ m: params }, true);
+  }
+
+  function validateListeners(listeners) {
+    _.each(listeners, function(listener) {
+      if (!listener.onMetricsUpdate || !listener.desiredMetrics) {
+        console.error("This listener needs to implement onMetricsUpdate and desiredMetrics");
+      }
+    });
+  }
+
+  return function(listeners) {
+    validateListeners(listeners);
+
+    function update() {
+      var general = $.ajax({
+        url: generalUpdateUri,
+        dataType: "json",
+        cache: false
+      });
+
+      var metricSpecific = $.ajax({
+        url: url(listeners),
+        dataType: "json",
+        cache: false
+      });
+
+      $.when(general, metricSpecific).done(function(generalData, metricSpecificData) {
+        var data = {
+          general: generalData[0],
+          specific: metricSpecificData[0]
+        }
+
+        _.each(listeners, function(listener) {
+          listener.onMetricsUpdate(data);
+        });
+      });
+    }
+
+    return {
+      start: function(interval) { setInterval(update, interval); }
+    };
+  };
+})();

--- a/linkerd/admin/src/main/scala/io/buoyant/linkerd/admin/DashboardHandler.scala
+++ b/linkerd/admin/src/main/scala/io/buoyant/linkerd/admin/DashboardHandler.scala
@@ -28,7 +28,7 @@ private[admin] class DashboardHandler extends Service[Request, Response] {
         <hr>
       """,
       csses = Seq("dashboard.css"),
-      javaScripts = Seq("utils.js", "process_info.js", "dashboard.js"),
+      javaScripts = Seq("utils.js", "process_info.js", "metrics_collector.js", "dashboard.js"),
       navbar = AdminHandler.version2NavBar
     )
   }


### PR DESCRIPTION
Fixes #195 

  A module to consolidate our backend metric requests. Collects all metrics that
  we need and gets them in two requests - one to metrics.json and one to metrics
  with the desired params.

  Register a listener to receive metric updates. Each listener needs to implement:
    - onMetricsUpdate(data) - to handle new incoming data
      data is of the form:
      {
        general: {}, // data obtained from /metrics.json
        specific: {} // data obtained from /metrics?m=...
      }
    - desiredMetrics() - returns a list of metrics the listener wants


general and specific probably aren't the best names, suggestions welcome!