### PR TITLE
Delegate page for dashboard v2

### DIFF
--- a/linkerd/admin/src/main/resources/io/buoyant/linkerd/admin/css/dashboard.css
+++ b/linkerd/admin/src/main/resources/io/buoyant/linkerd/admin/css/dashboard.css
@@ -24,3 +24,22 @@ nav {
 nav ul.navbar-nav {
   margin-left: 18px;
 }
+
+.modal-content {
+  border-color: #fff;
+  background-color: #999;
+}
+
+/* dtab specific css overrides*/
+
+.panel {
+  background-color: transparent;
+}
+
+.panel-heading, .panel>.list-group:last-child .list-group-item:last-child {
+  border-radius: 0;
+}
+
+.dentry .dentry-part:hover {
+  background-color: #222;
+}

--- a/linkerd/admin/src/main/resources/io/buoyant/linkerd/admin/js/dashboard_delegate.js
+++ b/linkerd/admin/src/main/resources/io/buoyant/linkerd/admin/js/dashboard_delegate.js
@@ -1,0 +1,18 @@
+"use strict";
+
+$.when(
+  $.get("/files/template/dentry.template"),
+  $.get("/files/template/delegatenode.template"),
+  $.get("/files/template/error_modal.template"),
+  $.get("/files/template/delegator.template")
+).done(function(dentryRsp, nodeRsp, modalRsp, delegatorRsp){
+  var templates = {
+    dentry: Handlebars.compile(dentryRsp[0]),
+    node: Handlebars.compile(nodeRsp[0]),
+    errorModal: Handlebars.compile(modalRsp[0]),
+    delegator: Handlebars.compile(delegatorRsp[0])
+  }
+  var dtab = JSON.parse($("#data").html());
+  Delegator($(".delegator"), dtab, templates);
+
+});

--- a/linkerd/admin/src/main/resources/io/buoyant/linkerd/admin/js/delegator.js
+++ b/linkerd/admin/src/main/resources/io/buoyant/linkerd/admin/js/delegator.js
@@ -1,4 +1,5 @@
 var Delegator = (function() {
+  var templates;
 
   function renderAll(resp) {
     $('.result').html(renderNode(resp));
@@ -16,7 +17,8 @@ var Delegator = (function() {
     return templates.node(obj);
   }
 
-  return function($root, dtab, templates) {
+  return function($root, dtab, t) {
+    templates = t
     $root.html(templates.delegator({}));
 
     var dtabViewer = new DtabViewer(dtab, templates.dentry);
@@ -26,7 +28,9 @@ var Delegator = (function() {
       e.preventDefault();
       var path = $('#path-input').val();
       window.location.hash = encodeURIComponent(path);
-      var request = $.get("delegator.json?" + $.param({ n: path, d: dtabViewer.dtabStr() }), renderAll);
+      var request = $.get(
+        "/delegator.json?" + $.param({ n: path, d: dtabViewer.dtabStr() }),
+        renderAll.bind(this));
       request.fail(function( jqXHR ) {
         $(".error-modal").html(templates.errorModal(jqXHR.statusText));
         $('.error-modal').modal();

--- a/linkerd/admin/src/main/resources/io/buoyant/linkerd/admin/template/delegator.template
+++ b/linkerd/admin/src/main/resources/io/buoyant/linkerd/admin/template/delegator.template
@@ -9,7 +9,7 @@
     </div>
   </div>
 </div>
-<div class="well well-sm dtab">
+<div class="dtab">
   <h4 class="header">
     Dtab
     <button id="edit-dtab-btn" class="btn btn-info btn-sm">Edit</button>

--- a/linkerd/admin/src/main/scala/io/buoyant/linkerd/admin/DtabHandler.scala
+++ b/linkerd/admin/src/main/scala/io/buoyant/linkerd/admin/DtabHandler.scala
@@ -1,0 +1,47 @@
+package io.buoyant.linkerd.admin
+
+import com.twitter.finagle.http.{Request, Response, Status}
+import com.twitter.finagle.{Dtab, Service}
+import com.twitter.util.Future
+import io.buoyant.linkerd.admin.names.DelegateApiHandler
+
+private[admin] class DtabHandler(
+  dtabs: () => Future[Map[String, Dtab]]
+) extends Service[Request, Response] {
+
+  import DtabHandler._
+
+  override def apply(req: Request): Future[Response] = dtabs().flatMap { dtabMap =>
+    req.path match {
+      case rexp(routerName) => dtabMap.get(routerName) match {
+        case Some(dtab) => (AdminHandler.mkResponse(render(routerName, dtab)))
+        case None => Future.value(Response(Status.NotFound))
+      }
+      case _ =>
+        Future.value(Response(Status.NotFound))
+    }
+  }
+
+  def render(name: String, dtab: Dtab) =
+    AdminHandler.html(
+      content = s"""
+        <div class="row">
+          <div class="col-lg-6">
+            <h2 class="router-label-title">Router "$name"</h2>
+          </div>
+        </div>
+        <div class="delegator">
+        </div>
+      """,
+      tailContent = s"""
+        <script id="data" type="application/json">${DelegateApiHandler.Codec.writeStr(dtab)}</script>
+      """,
+      javaScripts = Seq("dtab_viewer.js", "delegator.js", "dashboard_delegate.js"),
+      csses = Seq("dashboard.css", "delegator.css"),
+      navbar = AdminHandler.version2NavBar
+    )
+}
+
+object DtabHandler {
+  val rexp = "/dtab/(.*)/?".r
+}

--- a/linkerd/admin/src/main/scala/io/buoyant/linkerd/admin/LinkerdAdmin.scala
+++ b/linkerd/admin/src/main/scala/io/buoyant/linkerd/admin/LinkerdAdmin.scala
@@ -33,6 +33,7 @@ class LinkerdAdmin(app: App, linker: Linker, config: LinkerConfig) extends Admin
     )),
     "/delegator" -> new DelegateHandler(AdminHandler, () => dtabs, linker.namers),
     "/delegator.json" -> new DelegateApiHandler(linker.namers),
+    "/dtab/" -> new DtabHandler(() => dtabs),
     "/metrics" -> MetricsHandler,
     "/config.json" -> new ConfigHandler(config, Linker.LoadedInitializers.iter)
   )


### PR DESCRIPTION
New route  `/dtab/http` vs. the old `/delegator?router=http`. MVP of delegate UI against dark bg (it's still ugly... maybe it'll get some designer time). Fixes a bug with reliance on globally defined templates var.

![screen shot 2016-03-28 at 1 21 53 pm](https://cloud.githubusercontent.com/assets/41829/14089997/ad4b3c5c-f4ec-11e5-95be-61958252e436.png)