### PR TITLE
Add test that bound id will bind to itself

### DIFF
--- a/namer/core/src/test/scala/io/buoyant/namer/NamerTestUtil.scala
+++ b/namer/core/src/test/scala/io/buoyant/namer/NamerTestUtil.scala
@@ -1,0 +1,26 @@
+package io.buoyant.namer
+
+import com.twitter.finagle.{Name, NameTree, Namer, Path}
+import com.twitter.util.{Await, Future}
+import org.scalatest.FunSuite
+
+trait NamerTestUtil { self: FunSuite =>
+
+  protected def assertBoundIdAutobinds(namer: Namer, path: Path, prefix: Path): Unit = {
+    def lookup(p: Path) = {
+      assert(p.startsWith(prefix))
+      val pathWithoutPrefix = p.drop(prefix.size)
+      Await.result(namer.lookup(pathWithoutPrefix).values.toFuture.flatMap(Future.const))
+    }
+
+    val nameTree = lookup(path)
+    val boundNames = nameTree.eval.toSet.flatten.collect {
+      case bound: Name.Bound => bound
+    }
+    for (bound <- boundNames) {
+      val idPath = bound.id.asInstanceOf[Path]
+      val NameTree.Leaf(rebound: Name.Bound) = lookup(idPath)
+      assert(rebound.id == bound.id)
+    }
+  }
+}

--- a/namer/fs/src/test/scala/io/l5d/FsTest.scala
+++ b/namer/fs/src/test/scala/io/l5d/FsTest.scala
@@ -1,16 +1,16 @@
 package io.l5d
 
-import com.twitter.finagle.Stack
 import com.twitter.finagle.util.LoadService
-import io.buoyant.namer.{NamerConfig, NamerInitializer}
+import com.twitter.finagle.{Path, Stack}
 import io.buoyant.config.Parser
 import io.buoyant.config.types.Directory
-import java.io.File
+import io.buoyant.namer.{NamerConfig, NamerInitializer, NamerTestUtil}
+import java.io.{File, PrintWriter}
 import java.nio.file.Paths
 import org.scalatest.FunSuite
 import scala.sys.process._
 
-class FsTest extends FunSuite {
+class FsTest extends FunSuite with NamerTestUtil {
 
   test("sanity") {
     // ensure it doesn't totally blowup
@@ -34,5 +34,31 @@ class FsTest extends FunSuite {
       val fs = mapper.readValue[NamerConfig](yaml).asInstanceOf[fs]
       assert(fs.rootDir.path == dir.toPath)
     } finally (Seq("rm", "-rf", dir.getPath).!)
+  }
+
+  test("id is bound name") {
+    val path = Path.read("/io.l5d.fs/default")
+
+    val dir = new File("mktemp -d -t disco.XXX".!!.stripLineEnd)
+    try {
+
+      val default = new File(dir, "default")
+      val writer = new PrintWriter(default)
+      writer.println("127.0.0.1 8080")
+      writer.close()
+
+      val yaml = s"""
+                    |kind: io.l5d.fs
+                    |rootDir: ${dir.getAbsolutePath}
+      """.stripMargin
+
+      val mapper = Parser.objectMapper(yaml, Iterable(Seq(FsInitializer)))
+      val fs = mapper.readValue[NamerConfig](yaml)
+      val namer = fs.newNamer(Stack.Params.empty)
+
+      assertBoundIdAutobinds(namer, path, fs.prefix)
+
+    } finally (Seq("rm", "-rf", dir.getPath).!)
+
   }
 }

--- a/namer/serversets/src/test/scala/io/l5d/ServersetNamerTest.scala
+++ b/namer/serversets/src/test/scala/io/l5d/ServersetNamerTest.scala
@@ -2,11 +2,12 @@ package io.l5d
 
 import com.twitter.finagle._
 import com.twitter.util.Var
+import io.buoyant.namer.NamerTestUtil
 import io.buoyant.namer.serversets.ServersetNamer
 import java.net.{InetAddress, InetSocketAddress}
 import org.scalatest.FunSuite
 
-class ServersetNamerTest extends FunSuite {
+class ServersetNamerTest extends FunSuite with NamerTestUtil {
 
   test("falls back to path prefixes") {
     namer("/foo/bar").lookup(Path.read("/foo/bar/x/y/z")).sample() match {
@@ -39,6 +40,11 @@ class ServersetNamerTest extends FunSuite {
         assert(name.path == Path.read("/x/y/z"))
       case _ => fail("failed to bind")
     }
+  }
+
+  test("id is bound name") {
+    val testNamer = namer("/test")
+    assertBoundIdAutobinds(testNamer, Path.read("/$/io.l5d.serversets/test"), testNamer.idPrefix)
   }
 
   def namer(path: String) = new ServersetNamer("host") {

--- a/project/LinkerdBuild.scala
+++ b/project/LinkerdBuild.scala
@@ -83,7 +83,7 @@ object LinkerdBuild extends Base {
       .withTests()
 
     val fs = projectDir("namer/fs")
-      .dependsOn(core)
+      .dependsOn(core % "compile->compile;test->test")
       .withTests()
 
     val k8s = projectDir("namer/k8s")


### PR DESCRIPTION
We always assume that the `id` field of a `Bound.Name` is a `Path` that resolves to the same `Bound.Name`.  
 
* Add a test mixin that adds an assertion to check that this is true
* Add tests that exercise this assertion in the namers that have tests (fs and serversets)