### PR TITLE
Query util for clientside metrics gathering

### DIFF
--- a/linkerd/admin/src/main/resources/io/buoyant/linkerd/admin/js/dashboard.js
+++ b/linkerd/admin/src/main/resources/io/buoyant/linkerd/admin/js/dashboard.js
@@ -23,13 +23,11 @@ $.when(
 
   var procInfo = ProcInfo();
   var dashboard = Dashboard();
-  var requestTotals = RequestTotals($(".request-totals"), Handlebars.compile(requestTotalsRsp[0]), routers);
+  var requestTotals = RequestTotals($(".request-totals"), Handlebars.compile(requestTotalsRsp[0]), _.keys(metricsJson[0]));
   var routerDisplays = RouterController(selectedRouter, routers, routerTemplates, $(".dashboard-container"));
 
   var metricsListeners = [procInfo, dashboard, requestTotals, routerDisplays];
   var metricsCollector = MetricsCollector(metricsListeners);
-
-
 
   $(function() {
     metricsCollector.start(UPDATE_INTERVAL);

--- a/linkerd/admin/src/main/resources/io/buoyant/linkerd/admin/js/query.js
+++ b/linkerd/admin/src/main/resources/io/buoyant/linkerd/admin/js/query.js
@@ -1,0 +1,112 @@
+/**
+ * Util for building regexes that map over specifically formatted metric names.
+ * `Query.clientQuery().build()` matches all possible client metrics.
+ *  Use defined helpers to make the query more specific.
+ */
+
+var Query = function() {
+  function escape(string) {
+    return string.replace(/[-\/\\^$*+?.()|[\]{}]/g, '\\$&');
+  }
+
+  function toR(arr) {
+    if (arr === "*" || !arr || arr.length === 0) {
+      return "(.*)";
+    } else {
+      return "(" + _.map(arr, escape).join("|") + ")";
+    }
+  }
+
+  var generalQuery = function() {
+    var query = {
+      routerLabels: [],
+      metricNames: []
+    };
+    query.allRouters = function() {
+      query.routerLabels = "*";
+      return query;
+    }
+    query.withRouter = function(router) {
+      if (_.isArray(query.routerLabels))
+        query.routerLabels.push(router);
+      return query;
+    }
+    query.withRouters = function(routers) {
+      if (_.isArray(query.routerLabels))
+        query.routerLabels.concat(routers);
+      return query;
+    }
+    query.allMetrics = function() {
+      query.metricNames = "*";
+      return query;
+    }
+    query.withMetric = function(metric) {
+      if (_.isArray(query.metricNames))
+        query.metricNames.push(metric);
+      return query;
+    }
+    query.withMetrics = function(metric) {
+      if (_.isArray(query.metricNames))
+        query.metricNames.concat(metrics);
+      return query;
+    }
+    return query;
+  }
+
+  var clientQuery = function() {
+    var q = generalQuery();
+    q.clientLabels = [];
+
+    q.allClients = function() {
+      q.clientLabels = "*";
+      return q;
+    }
+    q.withClient = function(client) {
+      if (_.isArray(query.clientLabels))
+        query.clientLabels.push(client);
+      return q;
+    }
+    q.withClients = function(clients) {
+      if (_.isArray(query.clientLabels))
+        query.clientLabels.concat(clients);
+      return q;
+    }
+    q.build = function() {
+      return new RegExp(
+        ["^rt\/", toR(q.routerLabels), "\/dst\/id\/", toR(q.clientLabels), "\/", toR(q.metricNames), "$"].join(""));
+    }
+
+    return q;
+  }
+
+  var serverQuery = function() {
+    var q = generalQuery();
+    q.serverLabels = [];
+
+    q.allServers = function() {
+      q.serverLabels = "*";
+      return q;
+    }
+    q.withServer = function(server) {
+      if (_.isArray(query.serverLabels))
+        query.serverLabels.push(server);
+      return q;
+    }
+    q.withServers = function(servers) {
+      if (_.isArray(query.serverLabels))
+        query.serverLabels.concat(servers);
+      return q;
+    }
+    q.build = function() {
+      return new RegExp(["^rt\/", toR(q.routerLabels), "\/srv\/", toR(q.serverLabels), "\/", toR(q.metricNames), "$"].join(""));
+    }
+
+    return q;
+  }
+
+  return {
+    serverQuery: serverQuery,
+    clientQuery: clientQuery
+  };
+
+}();

--- a/linkerd/admin/src/main/resources/io/buoyant/linkerd/admin/js/routers.js
+++ b/linkerd/admin/src/main/resources/io/buoyant/linkerd/admin/js/routers.js
@@ -33,8 +33,8 @@
  */
 var Routers = (function() {
 
-  var clientRE = /^rt\/(.+)\/dst\/id\/(.*)\/requests$/,
-      serverRE = /^rt\/(.+)\/srv\/([^/]+)\/(\d+)\/requests$/;
+  var clientRE = Query.clientQuery().withMetric("requests").build(),
+      serverRE = Query.serverQuery().withMetric("requests").build();
 
   var mkColor = function() {
     var colorIdx = 0;

--- a/linkerd/admin/src/main/scala/io/buoyant/linkerd/admin/AdminHandler.scala
+++ b/linkerd/admin/src/main/scala/io/buoyant/linkerd/admin/AdminHandler.scala
@@ -109,6 +109,7 @@ object AdminHandler extends HtmlView {
           <script src="/files/js/lib/lodash.min.js"></script>
           <script src="/files/js/lib/handlebars-v4.0.5.js"></script>
           <script src="/files/js/admin.js"></script>
+          <script src="/files/js/query.js"></script>
           $javaScriptsHtml
         </body>
       </html>


### PR DESCRIPTION
While routers.js does a great job of creating a hierarchical view
of routers, servers, and clients, we're finding an increasing need
to make requests for metrics across these boundaries, which results in
a lot of mapping/filtering that is not always very readable.

This change introduces a module that builds a regex for querying
across a list of metrics. Simplifies request_totals as a result.