### PR TITLE
Move proc_info.js to use proc_info.template

### DIFF
--- a/linkerd/admin/src/main/resources/io/buoyant/linkerd/admin/js/dashboard.js
+++ b/linkerd/admin/src/main/resources/io/buoyant/linkerd/admin/js/dashboard.js
@@ -12,8 +12,6 @@ $.when(
   $.get("/files/template/request_totals.template"),
   $.get("/admin/metrics.json")
 ).done(function(routerContainerRsp, routerSummaryRsp, overviewStatsRsp, requestTotalsRsp, metricsJson) {
-  appendOverviewSection();
-
   var selectedRouter = getSelectedRouter(); // TODO: update this to avoid passing params in urls #198
   var routers = Routers(metricsJson[0]);
   var routerTemplates = {
@@ -21,7 +19,8 @@ $.when(
     container: Handlebars.compile(routerContainerRsp[0])
   }
 
-  var procInfo = ProcInfo();
+  var buildVersion = $(".server-data").data("linkerd-version");
+  var procInfo = ProcInfo($(".proc-info"), Handlebars.compile(overviewStatsRsp[0]), buildVersion);
   var dashboard = Dashboard();
   var requestTotals = RequestTotals($(".request-totals"), Handlebars.compile(requestTotalsRsp[0]), routers);
   var routerDisplays = RouterController(selectedRouter, routers, routerTemplates, $(".dashboard-container"));
@@ -34,29 +33,6 @@ $.when(
   $(function() {
     metricsCollector.start(UPDATE_INTERVAL);
   });
-
-  function appendOverviewSection() {
-    var overviewTemplate = Handlebars.compile(overviewStatsRsp[0]);
-    var compiledHtml = overviewTemplate(getOverviewStatsData());
-
-    var $overviewStats = $('<div />').html(compiledHtml);
-    $overviewStats.appendTo("body");
-  }
-
-  function getOverviewStatsData() {
-    // todo: move to process_info.js after old dashboard is killed #198
-    var buildVersion = $(".server-data").data("linkerd-version");
-
-    return {
-      stats: [
-        { description: "linkerd version", dataKey: "",  elemId: "linkerd-version", value: buildVersion },
-        { description: "uptime", dataKey: "jvm/uptime",  elemId: "jvm-uptime", value: "0s" },
-        { description: "thread count", dataKey: "jvm/thread/count", elemId: "jvm-thread-count", value: "0" },
-        { description: "memory used", dataKey: "jvm/mem/current/used", elemId: "jvm-mem-current-used", value: "0MB" },
-        { description: "gc", dataKey: "jvm/gc/msec",  elemId: "jvm-gc-msec", value: "1ms" }
-      ]
-    }
-  }
 });
 
 var Dashboard = (function() {

--- a/linkerd/admin/src/main/resources/io/buoyant/linkerd/admin/js/summary.js
+++ b/linkerd/admin/src/main/resources/io/buoyant/linkerd/admin/js/summary.js
@@ -18,10 +18,11 @@ Handlebars.registerHelper('pluralize', function(number, single, plural) {
  * - Interfaces: client and server widgets
  */
 $.when(
+  $.get("/files/template/process_info.template"),
   $.get("/files/template/interfaces.template"),
   $.get("/files/template/request_stats.template"),
   $.get("/admin/metrics.json")
-).done(function(interfacesRsp, requestStatsRsp, metricsJson) {
+).done(function(processInfoRsp, interfacesRsp, requestStatsRsp, metricsJson) {
   var ifacesTemplate = Handlebars.compile(interfacesRsp[0]),
       summaryTemplate = Handlebars.compile(requestStatsRsp[0]),
       routers = Routers(metricsJson[0]),
@@ -29,7 +30,7 @@ $.when(
 
   $(function() {
     var selectedRouter = getSelectedRouter();
-    var procInfo = ProcInfo(),
+    var procInfo = ProcInfo($("#process-info"), Handlebars.compile(processInfoRsp[0]), $("#linkerd-version").text()),
         bigBoard = BigBoard(selectedRouter, routers, summaryTemplate),
         interfaces = Interfaces(selectedRouter, routers, namers, ifacesTemplate);
 

--- a/linkerd/admin/src/main/scala/io/buoyant/linkerd/admin/DashboardHandler.scala
+++ b/linkerd/admin/src/main/scala/io/buoyant/linkerd/admin/DashboardHandler.scala
@@ -22,6 +22,8 @@ private[admin] class DashboardHandler extends Service[Request, Response] {
         <div class="server-data" data-linkerd-version="${Build.load().version}" style="visibility:hidden"></div>
         <div class="text-center dashboard-container"></div>
         <hr>
+        <div class="row text-center proc-info">
+        </div>
       """,
       csses = Seq("dashboard.css"),
       javaScripts = Seq(


### PR DESCRIPTION
Instead of using jquery to add render process metrics, we now can
use the proc_info.template that rmars added.