### PR TITLE
Move metrics collector registration to be private

### DIFF
--- a/linkerd/admin/src/main/resources/io/buoyant/linkerd/admin/js/dashboard.js
+++ b/linkerd/admin/src/main/resources/io/buoyant/linkerd/admin/js/dashboard.js
@@ -19,33 +19,15 @@ $.when(
     container: Handlebars.compile(routerContainerRsp[0])
   }
 
-  var buildVersion = $(".server-data").data("linkerd-version");
-  var procInfo = ProcInfo($(".proc-info"), Handlebars.compile(overviewStatsRsp[0]), buildVersion);
-  var dashboard = Dashboard();
-  var requestTotals = RequestTotals($(".request-totals"), Handlebars.compile(requestTotalsRsp[0]), _.keys(metricsJson[0]));
-  var routerDisplays = RouterController(selectedRouter, routers, routerTemplates, $(".dashboard-container"));
+  var metricsCollector = MetricsCollector();
 
-  var metricsListeners = [procInfo, dashboard, requestTotals, routerDisplays];
-  var metricsCollector = MetricsCollector(metricsListeners);
+  var buildVersion = $(".server-data").data("linkerd-version");
+  var procInfo = ProcInfo(metricsCollector, $(".proc-info"), Handlebars.compile(overviewStatsRsp[0]), buildVersion);
+  var requestTotals = RequestTotals(metricsCollector, $(".request-totals"), Handlebars.compile(requestTotalsRsp[0]), _.keys(metricsJson[0]));
+  var routerDisplays = RouterController(metricsCollector, selectedRouter, routers, routerTemplates, $(".dashboard-container"));
 
   $(function() {
     metricsCollector.start(UPDATE_INTERVAL);
   });
 });
 
-var Dashboard = (function() {
-
-  function render(data) {
-  }
-
-  return function() {
-    return {
-      onMetricsUpdate: function(data) {
-        render(data.general);
-      },
-      desiredMetrics: function() {
-        return [];
-      }
-    };
-  };
-})();

--- a/linkerd/admin/src/main/resources/io/buoyant/linkerd/admin/js/metrics_collector.js
+++ b/linkerd/admin/src/main/resources/io/buoyant/linkerd/admin/js/metrics_collector.js
@@ -2,49 +2,41 @@
   A module to consolidate our backend metric requests. Collects all metrics that
   we need and gets them in two requests - one to metrics.json and one to metrics
   with the desired params.
-
-  Register a listener to receive metric updates. Each listener needs to implement:
-    - onMetricsUpdate(data) - to handle new incoming data
-      data is of the form:
-      {
-        general: {}, // data obtained from /metrics.json
-        specific: {} // data obtained from /metrics?m=...
-      }
-    - desiredMetrics() - returns a list of metrics the listener wants
 */
 var MetricsCollector = (function() {
   var generalUpdateUri = "/admin/metrics.json";
   var metricsUpdateUri = "/admin/metrics?";
   var listeners = [];
 
-  function url(listeners) {
-    var params = _.reduce(listeners, function(mem, listener) {
-      return mem.concat(listener.desiredMetrics())
-    }, []);
-
+  function url(listeners, defaultMetrics) {
+    var params = _(listeners)
+      .map(function(listener){ return listener.metrics(defaultMetrics); })
+      .flatten()
+      .uniq()
+      .value();
     return metricsUpdateUri + $.param({ m: params }, true);
   }
 
-  function validateListener(listener) {
-    if (!listener.onMetricsUpdate || !listener.desiredMetrics) {
-      console.error("This listener needs to implement onMetricsUpdate and desiredMetrics");
-      return false;
-    }
-    return true;
-  }
-
-  function registerListener(listener) {
-    validateListener(listener);
-    listeners.push(listener);
+  /**
+    Register a listener to receive metric updates.
+    handler: function called with incoming data of the form:
+      {
+        general: {}, // data obtained from /metrics.json
+        specific: {} // data obtained from /metrics?m=...
+      }
+    metrics: returns a list of metrics the listener wants.
+      Called with a list of metric names to choose from.
+  */
+  function registerListener(handler, metrics) {
+    listeners.push({handler: handler, metrics: metrics});
   }
 
   function deregisterListener(listener) {
-    _.remove(listeners, function(l) { return l === listener; });
+    _.remove(listeners, function(l) { return l.handler === listener; });
   }
 
-  return function(initialListeners) {
-    _.each(initialListeners, validateListener);
-    listeners = listeners.concat(initialListeners);
+  return function(initialMetrics) {
+    var defaultMetrics = _.keys(initialMetrics);
 
     function update() {
       var general = $.ajax({
@@ -54,7 +46,7 @@ var MetricsCollector = (function() {
       });
 
       var metricSpecific = $.ajax({
-        url: url(listeners),
+        url: url(listeners, defaultMetrics),
         dataType: "json",
         cache: false
       });
@@ -65,8 +57,10 @@ var MetricsCollector = (function() {
           specific: metricSpecificData[0]
         }
 
+        defaultMetrics = _.keys(data.general);
+
         _.each(listeners, function(listener) {
-          listener.onMetricsUpdate(data);
+          listener.handler(data);
         });
       });
     }

--- a/linkerd/admin/src/main/resources/io/buoyant/linkerd/admin/js/process_info.js
+++ b/linkerd/admin/src/main/resources/io/buoyant/linkerd/admin/js/process_info.js
@@ -41,7 +41,7 @@ var ProcInfo = (function() {
   /**
    * Returns a function that may be called to trigger an update.
    */
-  return function($root, t, buildVersion) {
+  return function(metricsCollector, $root, t, buildVersion) {
     template = t
     stats[0].value = buildVersion;
     var url = refreshUri + "?";
@@ -62,14 +62,14 @@ var ProcInfo = (function() {
       });
     }
 
+    if (metricsCollector) {
+      metricsCollector.registerListener(
+        function(data){ render($root, data.specific); },
+        function() { return _.map(stats, "dataKey"); });
+    }
+
     return {
-      start: function(interval) { setInterval(update, interval); }, // TODO: #198 remove once linkerd#183 is complete
-      onMetricsUpdate: function(data) {
-        render($root, data.specific);
-      },
-      desiredMetrics: function() {
-        return _.map(stats, "dataKey");
-      }
+      start: function(interval) { setInterval(update, interval); } // TODO: #198 remove once linkerd#183 is complete
     };
   };
 })();

--- a/linkerd/admin/src/main/resources/io/buoyant/linkerd/admin/js/query.js
+++ b/linkerd/admin/src/main/resources/io/buoyant/linkerd/admin/js/query.js
@@ -33,7 +33,7 @@ var Query = function() {
     }
     query.withRouters = function(routers) {
       if (_.isArray(query.routerLabels))
-        query.routerLabels.concat(routers);
+        query.routerLabels = query.routerLabels.concat(routers);
       return query;
     }
     query.allMetrics = function() {
@@ -45,9 +45,9 @@ var Query = function() {
         query.metricNames.push(metric);
       return query;
     }
-    query.withMetrics = function(metric) {
+    query.withMetrics = function(metrics) {
       if (_.isArray(query.metricNames))
-        query.metricNames.concat(metrics);
+        query.metricNames = query.metricNames.concat(metrics);
       return query;
     }
     return query;
@@ -68,7 +68,7 @@ var Query = function() {
     }
     q.withClients = function(clients) {
       if (_.isArray(query.clientLabels))
-        query.clientLabels.concat(clients);
+        query.clientLabels = query.clientLabels.concat(clients);
       return q;
     }
     q.build = function() {
@@ -104,9 +104,27 @@ var Query = function() {
     return q;
   }
 
+  function matchesQuery(metricName, q) {
+    return metricName.search(q) >= 0;
+  }
+
+  function find(query, metrics) {
+    return _.find(metrics, function(m) {
+      return matchesQuery(m.name ? m.name : m, query);
+    });
+  }
+
+  function filter(query, metrics) {
+    return _.filter(metrics, function(m) {
+      return matchesQuery(m.name ? m.name : m, query);
+    });
+  }
+
   return {
     serverQuery: serverQuery,
-    clientQuery: clientQuery
+    clientQuery: clientQuery,
+    find: find,
+    filter: filter
   };
 
 }();

--- a/linkerd/admin/src/main/resources/io/buoyant/linkerd/admin/js/router_controller.js
+++ b/linkerd/admin/src/main/resources/io/buoyant/linkerd/admin/js/router_controller.js
@@ -15,32 +15,7 @@ var RouterController = (function () {
     return routerContainers;
   }
 
-  function processResponses(rawData) {
-    // group raw data by router, extract metric names
-    return _.chain(rawData)
-      .filter(isRouter)
-      .groupBy(getRouterName)
-      .mapValues(function(data, router) {
-        var result = { router: router };
-        _.each(data, function(datum) {
-          var keyParts = datum.name.split("/");
-          var metric = keyParts[keyParts.length - 1];
-          result[metric] = datum;
-        });
-        return result;
-      })
-      .value();
-  }
-
-  function isRouter(datum) {
-    return datum.name.indexOf("rt/") === 0;
-  }
-
-  function getRouterName(datum) {
-    return datum.name.split("/")[1];
-  }
-
-  return function(selectedRouter, routers, templates, $parentContainer) {
+  return function(metricsCollector, selectedRouter, routers, templates, $parentContainer) {
     var routerContainerEls = initializeRouterContainers(selectedRouter, routers, $parentContainer, templates.container);
 
     var routerSummaries = [];
@@ -50,31 +25,10 @@ var RouterController = (function () {
       var $summaryEl = $(container.find(".summary")[0]);
       var $serverEl = $(container.find(".server")[0]);
 
-      routerSummaries.push(RouterSummary(routers, templates.summary, $summaryEl, router));
+      routerSummaries.push(RouterSummary(metricsCollector, routers, templates.summary, $summaryEl, router));
       routerServers.push(RouterServer(routers, $serverEl, router));
     });
 
-    return {
-      onMetricsUpdate: function(data) {
-        routers.update(data.general);
-        var transformedData = processResponses(data.specific);
-
-        _.each(routerSummaries, function(routerSummary) {
-          var routerData = transformedData[routerSummary.getRouterName()];
-          if (!_.isEmpty(routerData)) routerSummary.onMetricsUpdate(routerData);
-        });
-
-        _.each(routerServers, function(routerServer) {
-          routerServer.onMetricsUpdate();
-        });
-      },
-      desiredMetrics: function() {
-        var metrics = _.chain(_.concat(routerSummaries, routerServers))
-          .map(function(ea) { return ea.desiredMetrics() })
-          .flatten().value();
-
-        return metrics;
-      }
-    };
+    return {};
   };
 })();

--- a/linkerd/admin/src/main/resources/io/buoyant/linkerd/admin/js/summary.js
+++ b/linkerd/admin/src/main/resources/io/buoyant/linkerd/admin/js/summary.js
@@ -30,7 +30,7 @@ $.when(
 
   $(function() {
     var selectedRouter = getSelectedRouter();
-    var procInfo = ProcInfo($("#process-info"), Handlebars.compile(processInfoRsp[0]), $("#linkerd-version").text()),
+    var procInfo = ProcInfo(null, $("#process-info"), Handlebars.compile(processInfoRsp[0]), $("#linkerd-version").text()),
         bigBoard = BigBoard(selectedRouter, routers, summaryTemplate),
         interfaces = Interfaces(selectedRouter, routers, namers, ifacesTemplate);
 


### PR DESCRIPTION
Going forward I'd like each module to set up its own listening, querying, & filtering behavior. In order to achieve this I'm passing `metricsCollector` in the init of each module (previously it was the opposite: modules were passed into the collector).

I also introduce `Query.find` and `Query.filter` to simplify data transformations

Also removed Dashboard as it looked unused