### PR TITLE
recursively create missing zk paths on dtab create

### DIFF
--- a/namerd/docs/config.md
+++ b/namerd/docs/config.md
@@ -55,8 +55,9 @@ Stores the dtab in memory.  Not suitable for production use.
 Stores the dtab in ZooKeeper.  Supports the following options
 
 * *hosts* -- Required.  A list of hosts where ZooKeeper is running.
-* *pathPrefix* -- Optional.  The ZooKeeper path under which dtabs should be stored.  (default:
-"/dtabs")
+* *pathPrefix* -- Optional.  The ZooKeeper path under which dtabs should be stored.
+Note that if `pathPrefix` does not exist in ZooKeeper, namerd will attempt to create it with global-writability.
+(default: "/dtabs")
 * *sessionTimeoutMs* -- Optional.  ZooKeeper session timeout in milliseconds.
 (default: 10000)
 

--- a/namerd/examples/zk.yaml
+++ b/namerd/examples/zk.yaml
@@ -2,6 +2,7 @@ storage:
   kind: io.buoyant.namerd.storage.experimental.zk
   hosts:
   - localhost:2181
+  pathPrefix: /dtabs
 interfaces:
 - kind: thriftNameInterpreter
 - kind: httpController

--- a/namerd/storage/zk/src/main/scala/com/twitter/finagle/serverset2/ZkDtabStore.scala
+++ b/namerd/storage/zk/src/main/scala/com/twitter/finagle/serverset2/ZkDtabStore.scala
@@ -55,9 +55,7 @@ class ZkDtabStore(
       None,
       Seq(Data.ACL.AnyoneAllUnsafe),
       CreateMode.Persistent
-    ).rescue {
-        case KeeperException.NodeExists(_) => Future.Unit
-      }.unit
+    ).unit.handle { case KeeperException.NodeExists(_) => }
   }
 
   def list(): Future[Set[String]] = actNs.values.toFuture.flatMap(Future.const)


### PR DESCRIPTION
if the zk pathPrefix does not exist, namerd will fail. this recursively creates pathPrefix when the user attempts to add a new dtab.

considered using `creatingParentsIfNeeded()`, but that requires the curator api:
https://github.com/twitter/finagle/blob/develop/finagle-benchmark/src/main/scala/com/twitter/finagle/serverset2/LocalServerSetService.scala#L101