### PR TITLE
Dtab delete

### DIFF
--- a/namerd/core/src/main/scala/io/buoyant/namerd/DtabStore.scala
+++ b/namerd/core/src/main/scala/io/buoyant/namerd/DtabStore.scala
@@ -18,6 +18,12 @@ trait DtabStore {
   def create(ns: String, dtab: Dtab): Future[Unit]
 
   /**
+   * Deletes a dtab.  Returns a DtabNamespaceDoesNotExistException if the
+   * namespace does not exist.
+   */
+  def delete(ns: String): Future[Unit]
+
+  /**
    * Update an existing dtab.  Returns a DtabVersionMismatchException if the
    * supplied version doesn't match the current version.
    */
@@ -38,6 +44,6 @@ object DtabStore {
     extends Exception(s"The dtab namespace $ns already exists")
   class DtabVersionMismatchException
     extends Exception("Could not update dtab: current version does not match provided version")
-  class DtabNamespaceDoesNotExist(ns: String)
+  class DtabNamespaceDoesNotExistException(ns: String)
     extends Exception(s"The dtab namespace $ns does not exist")
 }

--- a/namerd/core/src/test/scala/io/buoyant/namerd/NamerdConfigTest.scala
+++ b/namerd/core/src/test/scala/io/buoyant/namerd/NamerdConfigTest.scala
@@ -24,6 +24,7 @@ class TestDtabStore extends DtabStoreConfig {
     override def put(ns: String, dtab: Dtab): Future[Unit] = Future.Unit
     override def observe(ns: String): Activity[Option[VersionedDtab]] = Activity.pending
     override def create(ns: String, dtab: Dtab): Future[Unit] = Future.Unit
+    override def delete(ns: String): Future[Unit] = Future.Unit
   }
 }
 


### PR DESCRIPTION
* Add a `delete` method to the `DtabStore` interface
* Update in-memory and zk stores to implement delete
* Add a DELETE method to the http controller

Fixes #209