### PR TITLE
Add a latency metrics table to the client display.

### DIFF
--- a/linkerd/admin/src/main/resources/io/buoyant/linkerd/admin/css/dashboard-shared.css
+++ b/linkerd/admin/src/main/resources/io/buoyant/linkerd/admin/css/dashboard-shared.css
@@ -24,3 +24,7 @@
   font-size: 12px;
   line-height: 16px;
 }
+
+.summary-metric-label {
+  font-weight: 700;
+}

--- a/linkerd/admin/src/main/resources/io/buoyant/linkerd/admin/template/router_client.template
+++ b/linkerd/admin/src/main/resources/io/buoyant/linkerd/admin/template/router_client.template
@@ -2,27 +2,57 @@
   {{client}}
 </div>
 
-<div class="client-metrics">
-  <dl>
-  {{#each metrics}}
-    <div class="col-md-2">
-      <dt>
-        {{description}}
-      </dt>
+<div class="client-medivics row">
+  <div class="col-md-2">
+    <dl>
+      <dt>Requests</dt>
+      <dd>{{requests}}</dd>
+
+      <dt>Successes</dt>
       <dd>
-        <span class="metric-medium">
-          {{#if rate}}
-            {{rate}}
-          {{else}}
-            {{#if value}}
-              {{value}}
-            {{else}}
-              0
-            {{/if}}
-          {{/if}}
-        </span>
+        {{#if successRate}}
+          {{successRate}}
+        {{else}}
+          {{success}}
+        {{/if}}
       </dd>
+    </dl>
+  </div>
+
+  <div class="col-md-2">
+    <dl>
+      <dt>Connections</dt>
+      <dd>{{connections}}</dd>
+
+      <dt>Failures</dt>
+      <dd>
+        {{#if failures}}
+          {{failures}}
+        {{else}}
+          0
+        {{/if}}
+      </dd>
+    </dl>
+  </div>
+
+  <div class="col-md-2">
+    <div class="summary-metric-label">Latencies</div>
+    <div class="router-latencies">
+      <div>
+        <span class="latency-label">Max</span><span class="pull-right latency-value">{{latencies.max}}</span>
+      </div>
+      <div>
+        <span class="latency-label">p999</span><span class="pull-right latency-value">{{latencies.p9990}}</span>
+      </div>
+      <div>
+        <span class="latency-label">p99</span><span class="pull-right latency-value">{{latencies.p99}}</span>
+      </div>
+      <div>
+        <span class="latency-label">p95</span><span class="pull-right latency-value">{{latencies.p95}}</span>
+      </div>
+      <div>
+        <span class="latency-label">p50</span><span class="pull-right latency-value">{{latencies.p50}}</span>
+      </div>
     </div>
-  {{/each}}
-  </dl>
+  </div>
 </div>


### PR DESCRIPTION
Get metrics from client.metrics.
Also updated display to new grid.

Fixes #185 
Part of #183

![screen shot 2016-04-05 at 4 05 04 pm](https://cloud.githubusercontent.com/assets/549258/14300881/380f66f4-fb48-11e5-919e-9adc9838039c.png)

