### PR TITLE
Start setting rpc annotations on traces

### DIFF
--- a/router/core/src/main/scala/io/buoyant/router/RoutingFactory.scala
+++ b/router/core/src/main/scala/io/buoyant/router/RoutingFactory.scala
@@ -80,7 +80,9 @@ class RoutingFactory[Req, Rsp](
     override def close(d: Time) = conn.close(d)
 
     def apply(req: Req): Future[Rsp] = {
+      // we treat the router label as the rpc name for this span
       Trace.recordRpc(label)
+      Trace.recordBinary("router.label", label)
       for {
         dst <- getDst(req).rescue {
           case e: Throwable =>

--- a/router/core/src/main/scala/io/buoyant/router/RoutingFactory.scala
+++ b/router/core/src/main/scala/io/buoyant/router/RoutingFactory.scala
@@ -80,7 +80,7 @@ class RoutingFactory[Req, Rsp](
     override def close(d: Time) = conn.close(d)
 
     def apply(req: Req): Future[Rsp] = {
-      Trace.recordBinary("router.label", label)
+      Trace.recordRpc(label)
       for {
         dst <- getDst(req).rescue {
           case e: Throwable =>

--- a/router/core/src/test/scala/io/buoyant/router/RoutingFactoryTest.scala
+++ b/router/core/src/test/scala/io/buoyant/router/RoutingFactoryTest.scala
@@ -65,10 +65,14 @@ class RoutingFactoryTest extends FunSuite with Awaits {
     Trace.letTracer(tracer) {
       val service = mkService(label = "customlabel")
       await(service(Request()))
-      val annotations = tracer.annotations.collect {
-        case a: Rpc => a
-      }
-      assert(annotations.exists(_.name == "customlabel"))
+      assert(tracer.annotations.exists {
+        case Rpc(name) => name == "customlabel"
+        case _ => false
+      })
+      assert(tracer.annotations.exists {
+        case BinaryAnnotation(key, value) => key == "router.label" && value == "customlabel"
+        case _ => false
+      })
     }
   }
 

--- a/router/core/src/test/scala/io/buoyant/router/RoutingFactoryTest.scala
+++ b/router/core/src/test/scala/io/buoyant/router/RoutingFactoryTest.scala
@@ -2,7 +2,7 @@ package io.buoyant.router
 
 import com.twitter.finagle._
 import com.twitter.finagle.buoyant._
-import com.twitter.finagle.tracing.Annotation.BinaryAnnotation
+import com.twitter.finagle.tracing.Annotation.{BinaryAnnotation, Rpc}
 import com.twitter.finagle.tracing._
 import com.twitter.util.{Future, Time}
 import io.buoyant.test.Awaits
@@ -66,11 +66,9 @@ class RoutingFactoryTest extends FunSuite with Awaits {
       val service = mkService(label = "customlabel")
       await(service(Request()))
       val annotations = tracer.annotations.collect {
-        case a: BinaryAnnotation => a
+        case a: Rpc => a
       }
-      assert(annotations.exists { a =>
-        a.key == "router.label" && a.value == "customlabel"
-      })
+      assert(annotations.exists(_.name == "customlabel"))
     }
   }
 

--- a/router/http/src/test/scala/io/buoyant/router/http/TracingFilterTest.scala
+++ b/router/http/src/test/scala/io/buoyant/router/http/TracingFilterTest.scala
@@ -29,25 +29,26 @@ class TracingFilterTest extends FunSuite with Awaits {
     req.contentLength = 94114
 
     Trace.letTracer(tracer) {
-      service(req)
+      val f = service(req)
 
       val reqEvents = tracer.iterator.toSeq
       assert(reqEvents.exists(_.annotation == Annotation.Rpc("HEAD")))
-      assert(reqEvents.exists(_.annotation == Annotation.BinaryAnnotation("http.method", "HEAD")))
       assert(reqEvents.exists(_.annotation == Annotation.BinaryAnnotation("http.uri", "/foo?bar=bah")))
-      assert(reqEvents.exists(_.annotation == Annotation.BinaryAnnotation("http.host", "monkeys")))
-      assert(reqEvents.exists(_.annotation == Annotation.BinaryAnnotation("req.http.version", "HTTP/1.1")))
-      assert(reqEvents.exists(_.annotation == Annotation.BinaryAnnotation("req.http.content-type", "text/plain")))
-      assert(reqEvents.exists(_.annotation == Annotation.BinaryAnnotation("req.http.content-length", 94114)))
+      assert(reqEvents.exists(_.annotation == Annotation.BinaryAnnotation("http.req.method", "HEAD")))
+      assert(reqEvents.exists(_.annotation == Annotation.BinaryAnnotation("http.req.host", "monkeys")))
+      assert(reqEvents.exists(_.annotation == Annotation.BinaryAnnotation("http.req.version", "HTTP/1.1")))
+      assert(reqEvents.exists(_.annotation == Annotation.BinaryAnnotation("http.req.content-type", "text/plain")))
+      assert(reqEvents.exists(_.annotation == Annotation.BinaryAnnotation("http.req.content-length", 94114)))
 
       tracer.clear()
       done.setDone()
+      await(f)
 
       val rspEvents = tracer.iterator.toSeq
-      assert(rspEvents.exists(_.annotation == Annotation.BinaryAnnotation("http.status", Status.PaymentRequired.code)))
-      assert(rspEvents.exists(_.annotation == Annotation.BinaryAnnotation("rsp.http.version", "HTTP/1.1")))
-      assert(rspEvents.exists(_.annotation == Annotation.BinaryAnnotation("rsp.http.content-type", "application/json")))
-      assert(rspEvents.exists(_.annotation == Annotation.BinaryAnnotation("rsp.http.content-length", 304374)))
+      assert(rspEvents.exists(_.annotation == Annotation.BinaryAnnotation("http.rsp.status", Status.PaymentRequired.code)))
+      assert(rspEvents.exists(_.annotation == Annotation.BinaryAnnotation("http.rsp.version", "HTTP/1.1")))
+      assert(rspEvents.exists(_.annotation == Annotation.BinaryAnnotation("http.rsp.content-type", "application/json")))
+      assert(rspEvents.exists(_.annotation == Annotation.BinaryAnnotation("http.rsp.content-length", 304374)))
     }
   }
 }

--- a/router/http/src/test/scala/io/buoyant/router/http/TracingFilterTest.scala
+++ b/router/http/src/test/scala/io/buoyant/router/http/TracingFilterTest.scala
@@ -5,7 +5,6 @@ import com.twitter.finagle.http._
 import com.twitter.finagle.tracing.{Annotation, BufferingTracer, Trace}
 import com.twitter.util.{Future, Promise}
 import io.buoyant.test.Awaits
-import java.net.SocketAddress
 import org.scalatest.FunSuite
 
 class TracingFilterTest extends FunSuite with Awaits {
@@ -27,25 +26,28 @@ class TracingFilterTest extends FunSuite with Awaits {
     req.uri = "/foo?bar=bah"
     req.host = "monkeys"
     req.contentType = "text/plain"
+    req.contentLength = 94114
 
     Trace.letTracer(tracer) {
-      val f = service(req)
+      service(req)
 
       val reqEvents = tracer.iterator.toSeq
-      assert(reqEvents.exists(_.annotation == Annotation.BinaryAnnotation("http.version", "HTTP/1.1")))
+      assert(reqEvents.exists(_.annotation == Annotation.Rpc("HEAD")))
       assert(reqEvents.exists(_.annotation == Annotation.BinaryAnnotation("http.method", "HEAD")))
       assert(reqEvents.exists(_.annotation == Annotation.BinaryAnnotation("http.uri", "/foo?bar=bah")))
       assert(reqEvents.exists(_.annotation == Annotation.BinaryAnnotation("http.host", "monkeys")))
-      assert(reqEvents.exists(_.annotation == Annotation.BinaryAnnotation("http.content-type", "text/plain")))
+      assert(reqEvents.exists(_.annotation == Annotation.BinaryAnnotation("req.http.version", "HTTP/1.1")))
+      assert(reqEvents.exists(_.annotation == Annotation.BinaryAnnotation("req.http.content-type", "text/plain")))
+      assert(reqEvents.exists(_.annotation == Annotation.BinaryAnnotation("req.http.content-length", 94114)))
 
       tracer.clear()
       done.setDone()
 
       val rspEvents = tracer.iterator.toSeq
-      assert(rspEvents.exists(_.annotation == Annotation.BinaryAnnotation("http.version", "HTTP/1.1")))
       assert(rspEvents.exists(_.annotation == Annotation.BinaryAnnotation("http.status", Status.PaymentRequired.code)))
-      assert(rspEvents.exists(_.annotation == Annotation.BinaryAnnotation("http.content-type", "application/json")))
-      assert(rspEvents.exists(_.annotation == Annotation.BinaryAnnotation("http.content-length", 304374)))
+      assert(rspEvents.exists(_.annotation == Annotation.BinaryAnnotation("rsp.http.version", "HTTP/1.1")))
+      assert(rspEvents.exists(_.annotation == Annotation.BinaryAnnotation("rsp.http.content-type", "application/json")))
+      assert(rspEvents.exists(_.annotation == Annotation.BinaryAnnotation("rsp.http.content-length", 304374)))
     }
   }
 }


### PR DESCRIPTION
Previously in linkerd we haven't been emitting [Rpc](https://github.com/twitter/finagle/blob/develop/finagle-core/src/main/scala/com/twitter/finagle/tracing/Tracer.scala#L51) trace annotations, but Zipkin relies on those heavily in its web UI.  I'm adding them where appropriate.  Before this change:

![ef01b0be-f73e-11e5-955f-a42dfc7ab1cc-1](https://cloud.githubusercontent.com/assets/9226/14302534/dab8e02a-fb56-11e5-857a-b039282b4973.png)

With this change:

![screen shot 2016-04-05 at 5 49 47 pm](https://cloud.githubusercontent.com/assets/9226/14302537/e9ee1bb4-fb56-11e5-8b11-3d4a4b97771f.png)

I'm also fixing a small issue where we were duplicating annotations on http spans, resulting in a loss of some data.

Fixes #221. Relates to #140.
