### PR TITLE
Move the CombinedClientGraph into RouterClients

### DIFF
--- a/linkerd/admin/src/main/resources/io/buoyant/linkerd/admin/js/router_clients.js
+++ b/linkerd/admin/src/main/resources/io/buoyant/linkerd/admin/js/router_clients.js
@@ -45,7 +45,8 @@ var RouterClient = (function() {
   return function (metricsCollector, routers, client, $clientEl, routerName, clientTemplate) {
     template = clientTemplate;
     var metricDefinitions = getMetricDefinition(routerName, client.label);
-    var latencyKeys = Query.filter(/^request_latency_ms\..*/, _.keys(client.metrics));
+    var desiredLatencies = ["max","p9990", "p99", "p95", "p50"];
+    var latencyKeys = _.map(desiredLatencies, function(key) { return "request_latency_ms." + key; });
 
     var metricsHandler = function(data) {
       var filteredData = _.filter(data.specific, function (d) { return d.name.indexOf(routerName) !== -1 });

--- a/linkerd/admin/src/main/resources/io/buoyant/linkerd/admin/js/router_clients.js
+++ b/linkerd/admin/src/main/resources/io/buoyant/linkerd/admin/js/router_clients.js
@@ -68,7 +68,9 @@ var RouterClient = (function() {
 })();
 
 var RouterClients = (function() {
-  return function (metricsCollector, routers, $clientEl, routerName, clientTemplate) {
+  return function (metricsCollector, routers, $clientEl, routerName, clientTemplate, colorOrder) {
+    CombinedClientGraph(metricsCollector, routerName, $clientEl.find(".router-graph"), colorOrder);
+
     var clients = routers.clients(routerName);
     routers.onAddedClients(addClients);
 

--- a/linkerd/admin/src/main/resources/io/buoyant/linkerd/admin/js/router_controller.js
+++ b/linkerd/admin/src/main/resources/io/buoyant/linkerd/admin/js/router_controller.js
@@ -84,10 +84,9 @@ var RouterController = (function () {
       var $serversEl = $(container.find(".servers")[0]);
       var $clientsEl = $(container.find(".clients")[0]);
 
-      CombinedClientGraph(metricsCollector, router, container.find(".router-graph"), colorOrder);
       RouterSummary(metricsCollector, templates.summary, $summaryEl, router);
       RouterServers(metricsCollector, routers, $serversEl, router, templates.server);
-      RouterClients(metricsCollector, routers, $clientsEl, router , templates.client);
+      RouterClients(metricsCollector, routers, $clientsEl, router , templates.client, colorOrder);
     });
 
     return {};

--- a/linkerd/admin/src/main/resources/io/buoyant/linkerd/admin/template/router_container.template
+++ b/linkerd/admin/src/main/resources/io/buoyant/linkerd/admin/template/router_container.template
@@ -1,8 +1,10 @@
 {{#each routers}}
   <div class="router router-{{this}}" data-router="{{this}}">
     <div class="summary"></div>
-    <canvas class="router-graph" height="181"></canvas>
-    <div class="clients router-clients clearfix"><div>Clients</div></div>
+    <div class="clients router-clients clearfix">
+      <canvas class="router-graph" height="181"></canvas>
+      <div>Clients</div>
+    </div>
     <div class="servers router-servers clearfix">
       <div class="router-servers-title">Servers</div>
     </div>


### PR DESCRIPTION
In the upcoming colours branch, each RouterClient in RouterClients has a consistent color scheme that matches the main color in the CombinedColorsGraph.

Letting RouterClients manage them makes it much easier/cleaner to handle color updates when new clients are added, otherwise the parent (RouterController) has to go in and update the combined graph as well as the router clients.