### PR TITLE
Tear-down address observations properly

### DIFF
--- a/namerd/core/src/main/scala/io/buoyant/namerd/InterfaceConfig.scala
+++ b/namerd/core/src/main/scala/io/buoyant/namerd/InterfaceConfig.scala
@@ -23,7 +23,7 @@ trait InterfaceConfig {
   @JsonIgnore
   protected def defaultAddr: InetSocketAddress
 
-  def mk(store: DtabStore, namers: Seq[(Path, Namer)]): Servable
+  def mk(store: DtabStore, namers: Map[Path, Namer]): Servable
 }
 
 trait InterfaceInitializer extends ConfigInitializer

--- a/namerd/core/src/main/scala/io/buoyant/namerd/InterpreterInterfaceConfig.scala
+++ b/namerd/core/src/main/scala/io/buoyant/namerd/InterpreterInterfaceConfig.scala
@@ -7,11 +7,11 @@ import io.buoyant.config.ConfigInitializer
 
 trait InterpreterInterfaceConfig extends InterfaceConfig {
   @JsonIgnore
-  final def mk(store: DtabStore, namers: Seq[(Path, Namer)]): Servable =
-    mk(ns => ConfiguredDtabNamer(store.observe(ns).map(extractDtab), namers))
+  final def mk(store: DtabStore, namers: Map[Path, Namer]): Servable =
+    mk(ns => ConfiguredDtabNamer(store.observe(ns).map(extractDtab), namers.toSeq), namers)
 
   @JsonIgnore
-  protected def mk(namers: Ns => NameInterpreter): Servable
+  protected def mk(delegate: Ns => NameInterpreter, namers: Map[Path, Namer]): Servable
 
   @JsonIgnore
   private[this] def extractDtab(versioned: Option[VersionedDtab]): Dtab =

--- a/namerd/core/src/main/scala/io/buoyant/namerd/NamerdConfig.scala
+++ b/namerd/core/src/main/scala/io/buoyant/namerd/NamerdConfig.scala
@@ -1,9 +1,9 @@
 package io.buoyant.namerd
 
-import com.twitter.finagle.Stack
+import com.twitter.finagle.{Path, Namer, Stack}
 import com.twitter.finagle.util.LoadService
 import io.buoyant.admin.AdminConfig
-import io.buoyant.config.{ConfigInitializer, Parser}
+import io.buoyant.config.{ConfigError, ConfigInitializer, Parser}
 import io.buoyant.namer.{NamerConfig, NamerInitializer}
 
 case class NamerdConfig(
@@ -23,8 +23,13 @@ case class NamerdConfig(
   }
 
   private[this] def mkInterfaces(dtabStore: DtabStore): Seq[Servable] = {
-    val namersByPfx = namers.map { config =>
-      config.prefix -> config.newNamer(Stack.Params.empty)
+    val namersByPfx = namers.foldLeft(Map.empty[Path, Namer]) {
+      case (namers, config) =>
+        for (prefix <- namers.keys)
+          if (prefix.startsWith(config.prefix) || config.prefix.startsWith(prefix))
+            throw NamerdConfig.ConflictingNamers(prefix, config.prefix)
+
+        namers + (config.prefix -> config.newNamer(Stack.Params.empty))
     }
 
     // TODO: validate the absence of port conflicts
@@ -33,6 +38,11 @@ case class NamerdConfig(
 }
 
 object NamerdConfig {
+
+  case class ConflictingNamers(prefix0: Path, prefix1: Path) extends ConfigError {
+    lazy val message =
+      s"Namers must not have overlapping prefixes: ${prefix0.show} & ${prefix1.show}"
+  }
 
   private[namerd] case class Initializers(
     namer: Seq[NamerInitializer] = Nil,

--- a/namerd/core/src/main/scala/io/buoyant/namerd/NamerdConfig.scala
+++ b/namerd/core/src/main/scala/io/buoyant/namerd/NamerdConfig.scala
@@ -25,6 +25,9 @@ case class NamerdConfig(
   private[this] def mkInterfaces(dtabStore: DtabStore): Seq[Servable] = {
     val namersByPfx = namers.foldLeft(Map.empty[Path, Namer]) {
       case (namers, config) =>
+        if (config.prefix.isEmpty)
+          throw NamerdConfig.EmptyNamerPrefix
+
         for (prefix <- namers.keys)
           if (prefix.startsWith(config.prefix) || config.prefix.startsWith(prefix))
             throw NamerdConfig.ConflictingNamers(prefix, config.prefix)
@@ -42,6 +45,10 @@ object NamerdConfig {
   case class ConflictingNamers(prefix0: Path, prefix1: Path) extends ConfigError {
     lazy val message =
       s"Namers must not have overlapping prefixes: ${prefix0.show} & ${prefix1.show}"
+  }
+
+  object EmptyNamerPrefix extends ConfigError {
+    lazy val message = s"Namers must not have an empty prefix"
   }
 
   private[namerd] case class Initializers(

--- a/namerd/core/src/test/scala/io/buoyant/namerd/TestNamerInterface.scala
+++ b/namerd/core/src/test/scala/io/buoyant/namerd/TestNamerInterface.scala
@@ -1,13 +1,14 @@
 package io.buoyant.namerd
 
-import com.twitter.finagle.NullServer
+import com.twitter.finagle.{Path, Namer, NullServer}
 import com.twitter.finagle.naming.NameInterpreter
 import java.net.InetSocketAddress
 
 class TestInterpreterInterfaceConfig extends InterpreterInterfaceConfig {
   val defaultAddr: InetSocketAddress = new InetSocketAddress(0)
 
-  def mk(namers: Ns => NameInterpreter): Servable = TestNamerInterfaceServable
+  def mk(interpreters: Ns => NameInterpreter, namers: Map[Path, Namer]): Servable =
+    TestNamerInterfaceServable
 }
 
 object TestNamerInterfaceServable extends Servable {

--- a/namerd/iface/control-http/src/main/scala/io/buoyant/namerd/iface/HttpControlServiceConfig.scala
+++ b/namerd/iface/control-http/src/main/scala/io/buoyant/namerd/iface/HttpControlServiceConfig.scala
@@ -6,7 +6,7 @@ import java.net.{InetAddress, InetSocketAddress}
 
 class HttpControlServiceConfig extends InterfaceConfig {
   // note that `namers` is currently ignored here, but we may later wish to expose them via this interface
-  def mk(store: DtabStore, namers: Seq[(Path, Namer)]) = HttpControlServable(addr, store)
+  def mk(store: DtabStore, namers: Map[Path, Namer]) = HttpControlServable(addr, store)
   def defaultAddr = HttpControlServiceConfig.defaultAddr
 }
 

--- a/namerd/iface/interpreter-thrift/src/test/scala/io/buoyant/namerd/iface/ThriftNamerInterfaceTest.scala
+++ b/namerd/iface/interpreter-thrift/src/test/scala/io/buoyant/namerd/iface/ThriftNamerInterfaceTest.scala
@@ -13,22 +13,21 @@ import org.scalatest.FunSuite
 class ThriftNamerInterfaceTest extends FunSuite {
   import ThriftNamerInterface._
 
-  test("simple binding") {
-    val states = Var[Activity.State[NameTree[Name.Bound]]](Activity.Pending)
-    val interpreter = new NameInterpreter { def bind(dtab: Dtab, path: Path) = Activity(states) }
-    val namer = new Namer { def lookup(path: Path) = Activity(states) }
-    val namers = Map(Path.Utf8("atl") -> namer)
+  def retryIn() = 1.second
+  val clientId = TPath(Path.empty)
+  val ns = "testns"
 
+  test("bind") {
+    val states = Var[Activity.State[NameTree[Name.Bound]]](Activity.Pending)
+    def interpreter(ns: String) = new NameInterpreter {
+      def bind(dtab: Dtab, path: Path) = Activity(states)
+    }
     val stampCounter = new AtomicLong(1)
     def stamper() = Stamp.mk(stampCounter.getAndIncrement)
-
-    def retry() = 1.second
-
-    val service = new ThriftNamerInterface(_ => interpreter, namers, stamper, retry)
-    val clientId = TPath(Path.empty)
+    val service = new ThriftNamerInterface(interpreter, Map.empty, stamper, retryIn)
 
     // The first request before the tree has been refined -- no value initially
-    val initName = thrift.NameRef(TStamp.empty, TPath("ysl", "thugger"), "testns")
+    val initName = thrift.NameRef(TStamp.empty, TPath("ysl", "thugger"), ns)
     val initF = service.bind(thrift.BindReq(TDtab.empty, initName, clientId))
     assert(!initF.isDefined)
 
@@ -42,7 +41,7 @@ class ThriftNamerInterfaceTest extends FunSuite {
     ))
 
     assert(initF.isDefined)
-    val init = Await.result(initF)
+    val init = Await.result(initF, 1.second)
     assert(init.tree.root.isInstanceOf[thrift.BoundNode.Alt])
     init.tree.root match {
       case thrift.BoundNode.Alt(Seq(id0, id1)) =>
@@ -65,49 +64,85 @@ class ThriftNamerInterfaceTest extends FunSuite {
     }
   }
 
-  test("binding") {
+  trait AddrCtx {
+    def interpreter(ns: String): NameInterpreter = ???
+    val pfx = Path.Utf8("atl")
     val states = Var[Activity.State[NameTree[Name.Bound]]](Activity.Pending)
-    val interpreter = new NameInterpreter { def bind(dtab: Dtab, path: Path) = Activity(states) }
-    val namer = new Namer { def lookup(path: Path) = Activity(states) }
-    val namers = Map(Path.Utf8("atl") -> namer)
-
+    val namers = Map(pfx -> new Namer { def lookup(path: Path) = Activity(states) })
     val stampCounter = new AtomicLong(1)
     def stamper() = Stamp.mk(stampCounter.getAndIncrement)
+    val service = new ThriftNamerInterface(interpreter, namers, stamper, retryIn)
+  }
 
-    def retry() = 1.second
-
-    val service = new ThriftNamerInterface(_ => interpreter, namers, stamper, retry)
-    val clientId = TPath.empty
-
-    val initName = thrift.NameRef(TStamp.empty, TPath("ysl", "thugger"), "testns")
-    val initF = service.bind(thrift.BindReq(TDtab.empty, initName, clientId))
+  test("addr")(new AddrCtx {
+    val initRef = thrift.NameRef(TStamp.empty, TPath("atl", "slime", "season"), ns)
+    val initF = service.addr(thrift.AddrReq(initRef, clientId))
     assert(!initF.isDefined)
 
     val addrs = Var[Addr](Addr.Pending)
-    val boundLeaf = NameTree.Leaf(Name.Bound(addrs, Path.Utf8("atl", "slime", "season"), Path.Utf8("3")))
-    states() = Activity.Ok(boundLeaf)
-
-    assert(initF.isDefined)
-    val init = Await.result(initF)
-    assert(init.tree.root == thrift.BoundNode.Leaf(thrift.BoundName(
-      TPath("atl", "slime", "season"),
-      TPath("3")
-    )))
-    assert(init.tree.nodes.isEmpty)
-
-    val addrName = thrift.NameRef(TStamp.empty, TPath("atl", "slime", "season"), "testns")
-    val addrF = service.addr(thrift.AddrReq(addrName, clientId))
-    assert(!addrF.isDefined)
+    val leaf = NameTree.Leaf(Name.Bound(addrs, Path.Utf8("atl", "slime", "season")))
+    states() = Activity.Ok(leaf)
+    assert(!initF.isDefined) // addrs still pending
 
     val isa = new InetSocketAddress("8.8.8.8", 4949)
     addrs() = Addr.Bound(Address(isa))
-    assert(addrF.isDefined)
+    assert(initF.isDefined)
+    val init = Await.result(initF, 1.second)
 
     val boundAddr = {
       val ip = ByteBuffer.wrap(isa.getAddress.getAddress)
       val taddrs = Set(thrift.TransportAddress(ip, isa.getPort))
-      thrift.Addr(TStamp.mk(2), thrift.AddrVal.Bound(thrift.BoundAddr(taddrs)))
+      thrift.Addr(TStamp.mk(1), thrift.AddrVal.Bound(thrift.BoundAddr(taddrs)))
     }
-    assert(Await.result(addrF) == boundAddr)
-  }
+    assert(Await.result(initF, 1.second) == boundAddr)
+  })
+
+  test("addr: deleted and re-created")(new AddrCtx {
+    val id = TPath("atl", "slime", "season")
+    val rsp0 = service.addr(thrift.AddrReq(thrift.NameRef(TStamp.empty, id, ns), clientId))
+    assert(!rsp0.isDefined)
+
+    val addrs0 = Var[Addr](Addr.Pending)
+    val leaf = NameTree.Leaf(Name.Bound(addrs0, ThriftNamerInterface.mkPath(id)))
+    states() = Activity.Ok(leaf)
+    assert(!rsp0.isDefined) // addrs still pending
+
+    val isa = new InetSocketAddress("8.8.8.8", 4949)
+    addrs0() = Addr.Bound(Address(isa))
+    assert(rsp0.isDefined)
+
+    val boundAddr0 = {
+      val ip = ByteBuffer.wrap(isa.getAddress.getAddress)
+      val taddrs = Set(thrift.TransportAddress(ip, isa.getPort))
+      thrift.Addr(TStamp.mk(1), thrift.AddrVal.Bound(thrift.BoundAddr(taddrs)))
+    }
+    assert(Await.result(rsp0, 1.second) == boundAddr0)
+
+    val ref1 = thrift.NameRef(TStamp.mk(1), id, ns)
+    val rsp1 = service.addr(thrift.AddrReq(ref1, clientId))
+    assert(!rsp1.isDefined)
+
+    addrs0() = Addr.Neg
+    states() = Activity.Ok(NameTree.Neg)
+    assert(rsp1.isDefined)
+    assert(Await.result(rsp1, 1.second) ==
+      thrift.Addr(TStamp.mk(2), thrift.AddrVal.Neg(thrift.Void())))
+
+    val rsp2 = service.addr(thrift.AddrReq(thrift.NameRef(TStamp.mk(2), id, ns), clientId))
+    assert(!rsp2.isDefined)
+
+    val addrs1 = Var[Addr](Addr.Pending)
+    states() = Activity.Ok(NameTree.Leaf(Name.Bound(addrs1, ThriftNamerInterface.mkPath(id))))
+    assert(!rsp2.isDefined)
+    addrs1() = Addr.Bound(Address(isa))
+    assert(rsp2.isDefined)
+
+    val boundAddr1 = {
+      val ip = ByteBuffer.wrap(isa.getAddress.getAddress)
+      val taddrs = Set(thrift.TransportAddress(ip, isa.getPort))
+      thrift.Addr(TStamp.mk(3), thrift.AddrVal.Bound(thrift.BoundAddr(taddrs)))
+    }
+    assert(Await.result(rsp2, 1.second) == boundAddr1)
+  })
+
 }


### PR DESCRIPTION
namerd's thrift interface has no mechanism to release observations. This is
troublesome, because there is no way to obtain a reference to a *new* address
if a service is deleted and re-created.

In order to fix this, we simplify the thrift interface in the following ways:
- Do not cache Addr observations when `bind`-ing a name.
- Bind concrete names passed to the `addr` call if not cached.
- `addr` observations now take NameTree state into account.  When a concrete
  name becomes anything other than a `NameTree.Leaf`, its observation is torn
  down and removed from cache.

Fixes #237