### PR TITLE
Add per client assigned colors to the dashboard graphs

### DIFF
--- a/admin/src/main/resources/io/buoyant/admin/css/dashboard.css
+++ b/admin/src/main/resources/io/buoyant/admin/css/dashboard.css
@@ -133,4 +133,22 @@ nav ul.navbar-nav {
 
 .router-servers-title {
   border-bottom: 1px solid grey;
+  font-size: 18px;
+}
+
+/**
+* Router clients
+*/
+
+.router-clients {
+  border-bottom: 1px solid grey;
+  margin-bottom: 30px;
+}
+
+.router-graph {
+  margin-bottom: 30px;
+}
+
+.chart-container {
+  padding-top: 40px;
 }

--- a/admin/src/main/resources/io/buoyant/admin/js/combined_client_graph.js
+++ b/admin/src/main/resources/io/buoyant/admin/js/combined_client_graph.js
@@ -4,11 +4,12 @@ var CombinedClientGraph = (function() {
   }
 
   return function(metricsCollector, routerName, $root, colors) {
+    var clientColors = colors;
     var query = Query.clientQuery().withRouter(routerName).withMetric("requests").build();
 
-    var timeseriesParams = function() {
+    function timeseriesParams(name) {
       return {
-        strokeStyle: colors[colorIdx++ % colors.length],
+        strokeStyle: clientColors[name.match(Query.clientQuery().build())[2]].color,
         lineWidth: 2
       };
     };
@@ -37,14 +38,16 @@ var CombinedClientGraph = (function() {
     );
 
     var desiredMetrics = _.map(Query.filter(query, metricsCollector.getCurrentMetrics()), clientToMetric);
-    var colorIdx = 0;
-
     chart.setMetrics(desiredMetrics, timeseriesParams, true);
 
     metricsCollector.registerListener(function(data) {
       var filteredData = Query.filter(query, data.specific);
       chart.updateMetrics(filteredData);
     }, function(metrics) { return Query.filter(query, metrics); });
-    return {};
+    return {
+      updateColors: function(newColors) {
+        clientColors = newColors;
+      }
+    };
   };
 })();

--- a/admin/src/main/resources/io/buoyant/admin/js/dashboard.js
+++ b/admin/src/main/resources/io/buoyant/admin/js/dashboard.js
@@ -9,17 +9,19 @@ $.when(
   $.get("/files/template/router_container.template"),
   $.get("/files/template/router_server.template"),
   $.get("/files/template/router_client.template"),
+  $.get("/files/template/router_client_container.template"),
   $.get("/files/template/router_summary.template"),
   $.get("/files/template/process_info.template"),
   $.get("/files/template/request_totals.template"),
   $.get("/admin/metrics.json")
-).done(function(routerContainerRsp, routerServerRsp, routerClientRsp, routerSummaryRsp, overviewStatsRsp, requestTotalsRsp, metricsJson) {
+).done(function(routerContainerRsp, routerServerRsp, routerClientRsp, routerClientContainerRsp, routerSummaryRsp, overviewStatsRsp, requestTotalsRsp, metricsJson) {
   var selectedRouter = getSelectedRouter(); // TODO: update this to avoid passing params in urls #198
   var routerTemplates = {
     summary: Handlebars.compile(routerSummaryRsp[0]),
     container: Handlebars.compile(routerContainerRsp[0]),
     server: Handlebars.compile(routerServerRsp[0]),
-    client: Handlebars.compile(routerClientRsp[0])
+    client: Handlebars.compile(routerClientRsp[0]),
+    clientContainer: Handlebars.compile(routerClientContainerRsp[0])
   }
 
   var metricsCollector = MetricsCollector(metricsJson[0]);

--- a/admin/src/main/resources/io/buoyant/admin/js/router_controller.js
+++ b/admin/src/main/resources/io/buoyant/admin/js/router_controller.js
@@ -5,21 +5,21 @@ var RouterController = (function () {
     yellows: {
       light: "#FFE7B3",
       tint: "#FAD78A",
-      yellow: "#ED9E64",
+      neutral: "#ED9E64",
       shade: "#D85B00",
       dark: "#B84D00"
     },
     greys : {
       light: "#F2F2F2",
       tint: '#C9C9C9',
-      grey: "#878787",
+      neutral: "#878787",
       shade: "#424242",
       dark: "#2B2B2B"
     },
     blues: {
       light: "#D1E2FB",
       tint: "#A4C4F1",
-      blue: "#709DDD",
+      neutral: "#709DDD",
       shade: "#4076C4",
       dark: "#163F79",
       night: "#0F2A50"
@@ -27,7 +27,7 @@ var RouterController = (function () {
     purples: {
       light: "#E1D1F6",
       tint: "#CAA2EA",
-      purple: "#9B4AD8",
+      neutral: "#9B4AD8",
       shade: "#6A18A4",
       dark: "#430880",
       night: "#2A084C"
@@ -35,32 +35,38 @@ var RouterController = (function () {
     greens: {
       light: "#D1F6E8",
       tint: "#A2EACF",
-      green: "#4AD8AC",
+      neutral: "#4AD8AC",
       shade: "#18A478",
       dark: "#08805B"
     },
     reds: {
       light: "#F6D1D1",
       tint: "#EAA2A2",
-      red: "#D84A4A",
+      neutral: "#D84A4A",
       shade: "#A41818",
       dark: "#800808"
     }
   }
 
-  //TODO: assign colorOrder colors to clients by client name
-  var colorOrder = [
-    colors.purples.purple,
-    colors.yellows.yellow,
-    colors.blues.blue,
-    colors.greens.green,
-    colors.reds.red,
-    colors.purples.shade,
-    colors.yellows.shade,
-    colors.blues.shade,
-    colors.greens.shade,
-    colors.reds.shade
+  var baseColorOrder = [
+    "purples.neutral",
+    "yellows.neutral",
+    "blues.neutral",
+    "greens.neutral",
+    "reds.neutral",
+    "purples.shade",
+    "yellows.shade",
+    "blues.shade",
+    "greens.shade",
+    "reds.shade"
   ];
+
+  var colorOrder = _.map(baseColorOrder, function(colorName) {
+    return {
+      color: _.property(colorName)(colors),
+      colorFamily: colors[colorName.split(".")[0]]
+    }
+  });
 
   function initializeRouterContainers(selectedRouter, routers, $parentContainer, template) {
     var routerData = !selectedRouter ? routers.data : { router: routers.data[selectedRouter] };
@@ -84,10 +90,9 @@ var RouterController = (function () {
       var $serversEl = $(container.find(".servers")[0]);
       var $clientsEl = $(container.find(".clients")[0]);
 
-      CombinedClientGraph(metricsCollector, router, container.find(".router-graph"), colorOrder);
       RouterSummary(metricsCollector, templates.summary, $summaryEl, router);
       RouterServers(metricsCollector, routers, $serversEl, router, templates.server);
-      RouterClients(metricsCollector, routers, $clientsEl, router , templates.client, colorOrder);
+      RouterClients(metricsCollector, routers, $clientsEl, router , templates.client, templates.clientContainer, colorOrder);
     });
 
     return {};

--- a/admin/src/main/resources/io/buoyant/admin/template/router_client.template
+++ b/admin/src/main/resources/io/buoyant/admin/template/router_client.template
@@ -39,19 +39,34 @@
     <div class="summary-metric-label">Latencies</div>
     <div class="router-latencies">
       <div>
-        <span class="latency-label">Max</span><span class="pull-right latency-value">{{latencies.max}}</span>
+        <span class="latency-label">
+          <span class="latency-legend" style="background-color:{{legend.max}};">&nbsp;</span>Max
+        </span>
+        <span class="pull-right latency-value">{{latencies.max}}</span>
       </div>
       <div>
-        <span class="latency-label">p999</span><span class="pull-right latency-value">{{latencies.p9990}}</span>
+        <span class="latency-label">
+          <span class="latency-legend" style="background-color:{{legend.p9990}};">&nbsp;</span>p999
+        </span>
+        <span class="pull-right latency-value">{{latencies.p9990}}</span>
       </div>
       <div>
-        <span class="latency-label">p99</span><span class="pull-right latency-value">{{latencies.p99}}</span>
+        <span class="latency-label">
+          <span class="latency-legend" style="background-color:{{legend.p99}};">&nbsp;</span>p99
+        </span>
+        <span class="pull-right latency-value">{{latencies.p99}}</span>
       </div>
       <div>
-        <span class="latency-label">p95</span><span class="pull-right latency-value">{{latencies.p95}}</span>
+        <span class="latency-label">
+          <span class="latency-legend" style="background-color:{{legend.p95}};">&nbsp;</span>p95
+        </span>
+        <span class="pull-right latency-value">{{latencies.p95}}</span>
       </div>
       <div>
-        <span class="latency-label">p50</span><span class="pull-right latency-value">{{latencies.p50}}</span>
+        <span class="latency-label">
+          <span class="latency-legend" style="background-color:{{legend.p50}};">&nbsp;</span>p50
+        </span>
+        <span class="pull-right latency-value">{{latencies.p50}}</span>
       </div>
     </div>
   </div>

--- a/admin/src/main/resources/io/buoyant/admin/template/router_client_container.template
+++ b/admin/src/main/resources/io/buoyant/admin/template/router_client_container.template
@@ -1,0 +1,4 @@
+<div class="client-container clearfix" style="border-top:2px solid {{clientColor}};">
+  <div class="metrics-container col-md-6"></div>
+  <div class="chart-container col-md-6"></div>
+</div>

--- a/admin/src/main/resources/io/buoyant/admin/template/router_container.template
+++ b/admin/src/main/resources/io/buoyant/admin/template/router_container.template
@@ -1,8 +1,10 @@
 {{#each routers}}
   <div class="router router-{{this}}" data-router="{{this}}">
     <div class="summary row"></div>
-    <canvas class="router-graph" height="181"></canvas>
-    <div class="clients router-clients row"><div>Clients</div></div>
+    <div class="clients router-clients row">
+      <canvas class="router-graph" height="181"></canvas>
+      <div>Clients</div>
+    </div>
     <div class="servers router-servers row">
       <div class="router-servers-title">Servers</div>
     </div>


### PR DESCRIPTION
I also moved the CombinedClientGraph into RouterClients for easier control of colours.
The colours go as follows:
Each new client of a router gets the next colour off the preferred colour list.  The latency graph for that client then gets the shades of this colour.

Adding new clients is a little messy, because we have to assign a colour to the new client, and both the CombinedClientGraph and the RouterClient need to know which colour that is.  So the parent (RouterClients) calls an updateColors(newClientToColorMapping) with the new mapping of which clients are assigned which colours.  For now, I regenerate the color mapping for /all/ clients when new clients are added, as this was the most straightforward.  Can definitely change it though. 

Both RouterClient and RouterClients are getting long.  In another review I will split out the latency graph from RouterClient, and move RouterClients to its own file.

Questions: should we be getting latency metrics from `metrics.json` rather than from `/metrics`?

Fixes #242
![screen shot 2016-04-07 at 11 03 41 am](https://cloud.githubusercontent.com/assets/549258/14361804/884fbac8-fcb1-11e5-8951-b0976dfafbe4.png)

![screen shot 2016-04-07 at 11 40 28 am](https://cloud.githubusercontent.com/assets/549258/14362707/9b038092-fcb5-11e5-893e-4ef55b946e2c.png)
