### PR TITLE
Introduce DtabStore.Proxy type to support store-agnostic validation

### DIFF
--- a/namerd/core/src/main/scala/io/buoyant/namerd/DtabStore.scala
+++ b/namerd/core/src/main/scala/io/buoyant/namerd/DtabStore.scala
@@ -4,18 +4,19 @@ import com.twitter.finagle.Dtab
 import com.twitter.io.Buf
 import com.twitter.util.{Activity, Future}
 
-case class VersionedDtab(dtab: Dtab, version: Buf)
+case class VersionedDtab(dtab: Dtab, version: DtabStore.Version)
 
 trait DtabStore {
+  import DtabStore.Namespace
 
   /** List all namespaces */
-  def list(): Future[Set[String]]
+  def list(): Future[Set[Namespace]]
 
   /**
    * Create a new dtab.  Returns a DtabNamespaceAlreadyExistsException if a
    * dtab already exists with that namespace.
    */
-  def create(ns: String, dtab: Dtab): Future[Unit]
+  def create(ns: Namespace, dtab: Dtab): Future[Unit]
 
   /**
    * Deletes a dtab.  Returns a DtabNamespaceDoesNotExistException if the
@@ -27,23 +28,53 @@ trait DtabStore {
    * Update an existing dtab.  Returns a DtabVersionMismatchException if the
    * supplied version doesn't match the current version.
    */
-  def update(ns: String, dtab: Dtab, version: Buf): Future[Unit]
+  def update(ns: Namespace, dtab: Dtab, version: DtabStore.Version): Future[Unit]
 
   /**
    * Update an existing dtab regardless of the current version or create a new
    * dtab if one doesn't already exist.
    */
-  def put(ns: String, dtab: Dtab): Future[Unit]
+  def put(ns: Namespace, dtab: Dtab): Future[Unit]
 
   /** Watch a dtab and it's version. */
-  def observe(ns: String): Activity[Option[VersionedDtab]]
+  def observe(ns: Namespace): Activity[Option[VersionedDtab]]
 }
 
 object DtabStore {
-  class DtabNamespaceAlreadyExistsException(ns: String)
+  type Namespace = String
+  type Version = Buf
+
+  class DtabNamespaceAlreadyExistsException(ns: Namespace)
     extends Exception(s"The dtab namespace $ns already exists")
+
   class DtabVersionMismatchException
     extends Exception("Could not update dtab: current version does not match provided version")
-  class DtabNamespaceDoesNotExistException(ns: String)
+
+  class DtabNamespaceDoesNotExistException(ns: Namespace)
     extends Exception(s"The dtab namespace $ns does not exist")
+
+  class Proxy(underlying: DtabStore) extends DtabStore {
+    protected[this] val self = underlying
+
+    def list(): Future[Set[String]] = self.list()
+    def create(ns: Namespace, dtab: Dtab): Future[Unit] = self.create(ns, dtab)
+    def update(ns: Namespace, dtab: Dtab, version: Buf): Future[Unit] = self.update(ns, dtab, version)
+    def put(ns: Namespace, dtab: Dtab): Future[Unit] = self.put(ns, dtab)
+    def observe(ns: Namespace): Activity[Option[VersionedDtab]] = self.observe(ns)
+  }
+
+  abstract class Validator(underlying: DtabStore) extends Proxy(underlying) {
+    /** Fails if the provided dtab cannot be validated. */
+    protected[this] def validate(ns: Namespace, dtab: Dtab): Future[Unit]
+
+    override def create(ns: Namespace, dtab: Dtab): Future[Unit] =
+      validate(ns, dtab) before self.create(ns, dtab)
+
+    override def update(ns: Namespace, dtab: Dtab, version: Buf): Future[Unit] =
+      validate(ns, dtab) before self.update(ns, dtab, version)
+
+    override def put(ns: Namespace, dtab: Dtab): Future[Unit] =
+      validate(ns, dtab) before self.put(ns, dtab)
+  }
+
 }

--- a/namerd/core/src/main/scala/io/buoyant/namerd/DtabStore.scala
+++ b/namerd/core/src/main/scala/io/buoyant/namerd/DtabStore.scala
@@ -7,7 +7,7 @@ import com.twitter.util.{Activity, Future}
 case class VersionedDtab(dtab: Dtab, version: DtabStore.Version)
 
 trait DtabStore {
-  import DtabStore.Namespace
+  import DtabStore.{Namespace, Version}
 
   /** List all namespaces */
   def list(): Future[Set[Namespace]]
@@ -28,7 +28,7 @@ trait DtabStore {
    * Update an existing dtab.  Returns a DtabVersionMismatchException if the
    * supplied version doesn't match the current version.
    */
-  def update(ns: Namespace, dtab: Dtab, version: DtabStore.Version): Future[Unit]
+  def update(ns: Namespace, dtab: Dtab, version: Version): Future[Unit]
 
   /**
    * Update an existing dtab regardless of the current version or create a new

--- a/namerd/core/src/main/scala/io/buoyant/namerd/DtabStore.scala
+++ b/namerd/core/src/main/scala/io/buoyant/namerd/DtabStore.scala
@@ -7,73 +7,73 @@ import com.twitter.util.{Activity, Future}
 case class VersionedDtab(dtab: Dtab, version: DtabStore.Version)
 
 trait DtabStore {
-  import DtabStore.{Namespace, Version}
+  import DtabStore.Version
 
   /** List all namespaces */
-  def list(): Future[Set[Namespace]]
+  def list(): Future[Set[Ns]]
 
   /**
    * Create a new dtab.  Returns a DtabNamespaceAlreadyExistsException if a
    * dtab already exists with that namespace.
    */
-  def create(ns: Namespace, dtab: Dtab): Future[Unit]
+  def create(ns: Ns, dtab: Dtab): Future[Unit]
 
   /**
    * Deletes a dtab.  Returns a DtabNamespaceDoesNotExistException if the
    * namespace does not exist.
    */
-  def delete(ns: String): Future[Unit]
+  def delete(ns: Ns): Future[Unit]
 
   /**
    * Update an existing dtab.  Returns a DtabVersionMismatchException if the
    * supplied version doesn't match the current version.
    */
-  def update(ns: Namespace, dtab: Dtab, version: Version): Future[Unit]
+  def update(ns: Ns, dtab: Dtab, version: Version): Future[Unit]
 
   /**
    * Update an existing dtab regardless of the current version or create a new
    * dtab if one doesn't already exist.
    */
-  def put(ns: Namespace, dtab: Dtab): Future[Unit]
+  def put(ns: Ns, dtab: Dtab): Future[Unit]
 
   /** Watch a dtab and it's version. */
-  def observe(ns: Namespace): Activity[Option[VersionedDtab]]
+  def observe(ns: Ns): Activity[Option[VersionedDtab]]
 }
 
 object DtabStore {
-  type Namespace = String
   type Version = Buf
 
-  class DtabNamespaceAlreadyExistsException(ns: Namespace)
+  class DtabNamespaceAlreadyExistsException(ns: Ns)
     extends Exception(s"The dtab namespace $ns already exists")
 
   class DtabVersionMismatchException
     extends Exception("Could not update dtab: current version does not match provided version")
 
-  class DtabNamespaceDoesNotExistException(ns: Namespace)
+  class DtabNamespaceDoesNotExistException(ns: Ns)
     extends Exception(s"The dtab namespace $ns does not exist")
 
   class Proxy(underlying: DtabStore) extends DtabStore {
     protected[this] val self = underlying
 
     def list(): Future[Set[String]] = self.list()
-    def create(ns: Namespace, dtab: Dtab): Future[Unit] = self.create(ns, dtab)
-    def update(ns: Namespace, dtab: Dtab, version: Buf): Future[Unit] = self.update(ns, dtab, version)
-    def put(ns: Namespace, dtab: Dtab): Future[Unit] = self.put(ns, dtab)
-    def observe(ns: Namespace): Activity[Option[VersionedDtab]] = self.observe(ns)
+    def create(ns: Ns, dtab: Dtab): Future[Unit] = self.create(ns, dtab)
+    def delete(ns: Ns): Future[Unit] = self.delete(ns)
+    def update(ns: Ns, dtab: Dtab, version: Buf): Future[Unit] = self.update(ns, dtab, version)
+    def put(ns: Ns, dtab: Dtab): Future[Unit] = self.put(ns, dtab)
+    def observe(ns: Ns): Activity[Option[VersionedDtab]] = self.observe(ns)
   }
 
   abstract class Validator(underlying: DtabStore) extends Proxy(underlying) {
     /** Fails if the provided dtab cannot be validated. */
-    protected[this] def validate(ns: Namespace, dtab: Dtab): Future[Unit]
+    protected[this] def validate(ns: Ns, dtab: Dtab): Future[Unit]
 
-    override def create(ns: Namespace, dtab: Dtab): Future[Unit] =
+    override def create(ns: Ns, dtab: Dtab): Future[Unit] =
       validate(ns, dtab) before self.create(ns, dtab)
 
-    override def update(ns: Namespace, dtab: Dtab, version: Buf): Future[Unit] =
+    override def update(ns: Ns, dtab: Dtab, version: Buf): Future[Unit] =
       validate(ns, dtab) before self.update(ns, dtab, version)
 
-    override def put(ns: Namespace, dtab: Dtab): Future[Unit] =
+    override def put(ns: Ns, dtab: Dtab): Future[Unit] =
       validate(ns, dtab) before self.put(ns, dtab)
   }
 

--- a/namerd/core/src/test/scala/io/buoyant/namerd/DtabStoreTest.scala
+++ b/namerd/core/src/test/scala/io/buoyant/namerd/DtabStoreTest.scala
@@ -9,34 +9,38 @@ import org.scalatest.FunSuite
 class DtabStoreTest extends FunSuite {
 
   object FailStore extends DtabStore {
-    def create(ns: DtabStore.Namespace, dtab: Dtab) =
+    def create(ns: Ns, dtab: Dtab) =
       fail("unexpected create")
 
-    def update(ns: DtabStore.Namespace, dtab: Dtab, v: DtabStore.Version) =
+    def delete(ns: Ns) =
+      fail("unexpected delete")
+
+    def update(ns: Ns, dtab: Dtab, v: DtabStore.Version) =
       fail("unexpected update")
 
-    def put(ns: DtabStore.Namespace, dtab: Dtab) =
+    def put(ns: Ns, dtab: Dtab) =
       fail("unexpected put")
 
     def list() =
       fail("unexpected list")
 
-    def observe(ns: DtabStore.Namespace) =
+    def observe(ns: Ns) =
       fail("unexpected observe")
   }
 
   object OkStore extends DtabStore {
-    def create(ns: DtabStore.Namespace, dtab: Dtab) = Future.Unit
-    def update(ns: DtabStore.Namespace, dtab: Dtab, v: DtabStore.Version) = Future.Unit
-    def put(ns: DtabStore.Namespace, dtab: Dtab) = Future.Unit
+    def create(ns: Ns, dtab: Dtab) = Future.Unit
+    def delete(ns: Ns) = Future.Unit
+    def update(ns: Ns, dtab: Dtab, v: DtabStore.Version) = Future.Unit
+    def put(ns: Ns, dtab: Dtab) = Future.Unit
     def list() = Future.value(Set.empty)
-    def observe(ns: DtabStore.Namespace) = Activity.pending
+    def observe(ns: Ns) = Activity.pending
   }
 
   class Invalid extends Throwable
   def validate(store: DtabStore): DtabStore =
     new DtabStore.Validator(store) {
-      protected[this] def validate(ns: DtabStore.Namespace, dtab: Dtab) = ns match {
+      protected[this] def validate(ns: Ns, dtab: Dtab) = ns match {
         case "bad" => Future.exception(new Invalid)
         case _ => Future.Unit
       }

--- a/namerd/core/src/test/scala/io/buoyant/namerd/DtabStoreTest.scala
+++ b/namerd/core/src/test/scala/io/buoyant/namerd/DtabStoreTest.scala
@@ -1,0 +1,75 @@
+package io.buoyant.namerd
+
+import com.twitter.conversions.time._
+import com.twitter.finagle._
+import com.twitter.io.Buf
+import com.twitter.util._
+import org.scalatest.FunSuite
+
+class DtabStoreTest extends FunSuite {
+
+  object FailStore extends DtabStore {
+    def create(ns: DtabStore.Namespace, dtab: Dtab) =
+      fail("unexpected create")
+
+    def update(ns: DtabStore.Namespace, dtab: Dtab, v: DtabStore.Version) =
+      fail("unexpected update")
+
+    def put(ns: DtabStore.Namespace, dtab: Dtab) =
+      fail("unexpected put")
+
+    def list() =
+      fail("unexpected list")
+
+    def observe(ns: DtabStore.Namespace) =
+      fail("unexpected observe")
+  }
+
+  object OkStore extends DtabStore {
+    def create(ns: DtabStore.Namespace, dtab: Dtab) = Future.Unit
+    def update(ns: DtabStore.Namespace, dtab: Dtab, v: DtabStore.Version) = Future.Unit
+    def put(ns: DtabStore.Namespace, dtab: Dtab) = Future.Unit
+    def list() = Future.value(Set.empty)
+    def observe(ns: DtabStore.Namespace) = Activity.pending
+  }
+
+  class Invalid extends Throwable
+  def validate(store: DtabStore): DtabStore =
+    new DtabStore.Validator(store) {
+      protected[this] def validate(ns: DtabStore.Namespace, dtab: Dtab) = ns match {
+        case "bad" => Future.exception(new Invalid)
+        case _ => Future.Unit
+      }
+    }
+
+  test("validates create: ok") {
+    assert(Await.result(validate(OkStore).create("ok", Dtab.empty).liftToTry).isReturn)
+  }
+
+  test("validates create: invalid") {
+    intercept[Invalid] {
+      Await.result(validate(FailStore).create("bad", Dtab.empty))
+    }
+  }
+
+  test("validates update: ok") {
+    assert(Await.result(validate(OkStore).update("ok", Dtab.empty, Buf.Empty).liftToTry).isReturn)
+  }
+
+  test("validates update: invalid") {
+    intercept[Invalid] {
+      Await.result(validate(FailStore).update("bad", Dtab.empty, Buf.Empty))
+    }
+  }
+
+  test("validates put: ok") {
+    assert(Await.result(validate(OkStore).put("ok", Dtab.empty).liftToTry).isReturn)
+  }
+
+  test("validates put: invalid") {
+    intercept[Invalid] {
+      Await.result(validate(FailStore).put("bad", Dtab.empty))
+    }
+  }
+
+}


### PR DESCRIPTION
We'll need to be perform write validation in an interface- and store-agnostic
way.

In order to support this, a DtabStore.Proxy type can be used to wrap DtabStores
with behavior. A special DtabStore.Validator type is introduced to provide a
basis for write validation.

Furthermore, type aliases are introduced to make the interface somewhat purer -- the interface should talk about Namespaces and Versions not Strings and Bufs.