### PR TITLE
linkerd-admin: Calculate success rate over success + failure

### DIFF
--- a/admin/src/main/resources/io/buoyant/admin/js/router_clients.js
+++ b/admin/src/main/resources/io/buoyant/admin/js/router_clients.js
@@ -64,7 +64,7 @@ var RouterClient = (function() {
       return mem;
     }, {});
 
-    var successRate = new SuccessRate(summary.requests, summary.success, summary.failures);
+    var successRate = new SuccessRate(summary.success || 0, summary.failures || 0);
     summary.successRate = successRate.prettyRate();
 
     return summary;

--- a/admin/src/main/resources/io/buoyant/admin/js/router_server.js
+++ b/admin/src/main/resources/io/buoyant/admin/js/router_server.js
@@ -18,7 +18,7 @@ var RouterServer = (function() {
         metricSuffix: "success",
         query: Query.serverQuery().withRouter(routerName).withServer(serverName).withMetric("success").build(),
         getRate: function(data) {
-          var successRate = new SuccessRate(data.requests, data.success, data.failures);
+          var successRate = new SuccessRate(data.success || 0, data.failures || 0);
           return successRate.prettyRate();
         }
       },

--- a/admin/src/main/resources/io/buoyant/admin/js/router_summary.js
+++ b/admin/src/main/resources/io/buoyant/admin/js/router_summary.js
@@ -20,8 +20,7 @@ var RouterSummary = (function() {
 
   function getSuccessAndFailureRate(result) {
     if (_.isUndefined(result.failures)) result.failures = null;
-    var successRate = new SuccessRate(result.requests, result.success, result.failures);
-
+    var successRate = new SuccessRate(result.success || 0, result.failures || 0);
     return {
       successRate: successRate.prettyRate(),
       failureRate: getFailureRate(result)

--- a/admin/src/main/resources/io/buoyant/admin/js/summary.js
+++ b/admin/src/main/resources/io/buoyant/admin/js/summary.js
@@ -151,14 +151,13 @@ var Interfaces = (function() {
   //   ...
   // ]
   function prepInterface(iface) {
-    var requests = iface.metrics["requests"] || 0,
-        success  = iface.metrics["success"]  || 0,
+    var success  = iface.metrics["success"]  || 0,
         failures = iface.metrics["failures"] || 0,
-        successRate = new SuccessRate(requests, success, failures);
+        successRate = new SuccessRate(success, failures);
     return {
       name: (iface.router ? iface.router+"/" : "") + iface.label,
       requestsKey: iface.prefix + "requests",
-      requests: requests,
+      requests: success + failures,
       success: success,
       failures: failures,
       connections: iface.metrics["connections"] || 0,

--- a/admin/src/main/resources/io/buoyant/admin/js/utils.js
+++ b/admin/src/main/resources/io/buoyant/admin/js/utils.js
@@ -53,8 +53,8 @@ BytesToStringConverter.prototype.convert = function(b) {
  * Success Rate Utils
  */
 
-function SuccessRate(requests, success, failures) {
-  this.requests = requests;
+function SuccessRate(success, failures) {
+  this.requests = success + failures;
   this.success = success;
   this.failures = failures;
 


### PR DESCRIPTION
`requests` is measured in a different place from `success` and `failures`. `requests` counts the number of requests sent, whereas `success` and `failures` measure _responses received_.  Because of this, `success` can easily be greater than `requests`, which leads to odd success rate measurements.

This is easily fixed by calculating total requests as `success + failure`.