### PR TITLE
Change default k8s master host

### DIFF
--- a/linkerd/docs/config.md
+++ b/linkerd/docs/config.md
@@ -593,7 +593,7 @@ experimental.
 
 The Kubernetes namer is configured with kind `io.l5d.experimental.k8s`, and these parameters:
 
-* *host* -- the Kubernetes master host. (default: kubernetes.default.cluster.local)
+* *host* -- the Kubernetes master host. (default: kubernetes.default.svc.cluster.local)
 * *port* -- the Kubernetes master port. (default: 443)
 * *tls* -- Whether TLS should be used in communicating with the Kubernetes master. (default: true)
 * *tlsWithoutValidation* -- Whether certificate-checking should be disabled. (default: false)
@@ -604,7 +604,7 @@ For example:
 ```yaml
 namers:
 - kind: io.l5d.experimental.k8s
-  host: kubernetes.default.cluster.local
+  host: kubernetes.default.svc.cluster.local
   port: 443
   tls: true
   authTokenFile: /var/run/secrets/kubernetes.io/serviceaccount/token

--- a/linkerd/examples/acceptance-test.yaml
+++ b/linkerd/examples/acceptance-test.yaml
@@ -23,7 +23,7 @@ namers:
   port: 2181
 
 - kind: io.l5d.experimental.k8s
-  host: kubernetes.default.cluster.local
+  host: kubernetes.default.svc.cluster.local
   port: 443
   tls: true
   authTokenFile: linkerd/examples/io.l5d.k8s/kube_token

--- a/namer/k8s/src/main/scala/io/l5d/k8s.scala
+++ b/namer/k8s/src/main/scala/io/l5d/k8s.scala
@@ -38,7 +38,7 @@ case class k8s(
   @JsonIgnore
   override def defaultPrefix: Path = Path.read("/io.l5d.k8s")
 
-  private[this] def getHost = host.getOrElse("kubernetes.default.cluster.local")
+  private[this] def getHost = host.getOrElse("kubernetes.default.svc.cluster.local")
 
   private[this] def getPort = port match {
     case Some(p) => p.port


### PR DESCRIPTION
The default k8s config namer host value was using a deprecated kube-dns format that was removed in kubernetes 1.2.  Updating our default and documentation accordingly.  More info here:

https://github.com/kubernetes/kubernetes/tree/master/cluster/addons/dns#backwards-compatibility