### PR TITLE
Display the linkerd version in the dashboard header

### DIFF
--- a/linkerd/admin/src/main/scala/io/buoyant/linkerd/admin/AdminHandler.scala
+++ b/linkerd/admin/src/main/scala/io/buoyant/linkerd/admin/AdminHandler.scala
@@ -4,6 +4,7 @@ import com.twitter.finagle.http.{MediaType, Request, Response}
 import com.twitter.finagle.{Service, SimpleFilter}
 import com.twitter.util.Future
 import io.buoyant.admin.HtmlView
+import io.buoyant.linkerd.Build
 
 object AdminHandler extends HtmlView {
 
@@ -57,7 +58,7 @@ object AdminHandler extends HtmlView {
             <li>router overview</li>
           </ul>
           <ul class="nav navbar-nav navbar-right">
-            <li>version 2.0</li>
+            <li>version ${Build.load().version}</li>
           </ul>
         </div>
       </div>


### PR DESCRIPTION
Currently it displays a hardcoded "2.0" meaning version 2.0 of the dashboard, but @wmorgan mentioned that this is confusing.

Now it shows the linkerd version:
![screen shot 2016-04-13 at 12 33 06 pm](https://cloud.githubusercontent.com/assets/549258/14506729/1a8fc330-0174-11e6-99b1-4bcae4036ec0.png)