### PR TITLE
Add a timeout to path binding

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,5 +1,8 @@
 ## x.x.x
 
+* Add a `bindingTimeoutMs` router parameter to configure the maximum amount of
+  time to spend binding a path.
+
 ## 0.3.1
 
 * Add beta version of linkerd dashboard version 2.0.  Try it out at

--- a/linkerd/docs/config.md
+++ b/linkerd/docs/config.md
@@ -143,7 +143,8 @@ Each router must be configured as an object with the following params:
 * *failFast* -- If `true`, connection failures are punished more aggressively.
   Should not be used with small destination pools. (default: false)
 * *timeoutMs* -- Per-request timeout in milliseconds. (default: no timeout)
-
+* *bindingTimeoutMs* -- Optional.  The maximum amount of time in milliseconds to
+  spend binding a path.  (default: 10 seconds)
 
 <!-- TODO router capacity  -->
 

--- a/router/core/src/main/scala/io/buoyant/router/Router.scala
+++ b/router/core/src/main/scala/io/buoyant/router/Router.scala
@@ -228,7 +228,8 @@ trait StdStackRouter[Req, Rsp, This <: StdStackRouter[Req, Rsp, This]]
           boundMk _,
           namer,
           stats.scope("bindcache"),
-          params[DstBindingFactory.Capacity]
+          params[DstBindingFactory.Capacity],
+          params[DstBindingFactory.BindingTimeout]
         )
 
         Stack.Leaf(role, new RoutingFactory(newIdentifier(), cache, label))


### PR DESCRIPTION
Add a configurable timeout to binding a path.  Requests will now no longer hang
forever if there is an error during binding and will instead fail with an error
message.

Fixes #273