### PR TITLE
Add auth and acl support to ZkDtabStore

### DIFF
--- a/namerd/core/src/main/scala/io/buoyant/namerd/DtabStore.scala
+++ b/namerd/core/src/main/scala/io/buoyant/namerd/DtabStore.scala
@@ -52,6 +52,8 @@ object DtabStore {
   class DtabNamespaceDoesNotExistException(ns: Ns)
     extends Exception(s"The dtab namespace $ns does not exist")
 
+  object Forbidden extends Exception("You do not have sufficient permissions")
+
   class Proxy(underlying: DtabStore) extends DtabStore {
     protected[this] val self = underlying
 

--- a/namerd/docs/config.md
+++ b/namerd/docs/config.md
@@ -59,6 +59,16 @@ Stores the dtab in ZooKeeper.  Supports the following options
 "/dtabs")
 * *sessionTimeoutMs* -- Optional.  ZooKeeper session timeout in milliseconds.
 (default: 10000)
+* *authInfo* -- Optional.  An object containing the authentication information to use when logging
+in ZooKeeper:
+  * *scheme* -- Required.  The ZooKeeper auth scheme to use.
+  * *auth* -- Required.  The ZooKeeper auth value to use.
+* *acls* -- Optional.  A list of ACLs to set on each dtab znode created.  Each ACL is an object
+containing:
+  * *scheme* -- Required.  The ACL auth scheme to use.
+  * *id* -- Required.  The ACL id to use.
+  * *perms* -- Required.  A subset of the string "crwda" representing the permissions of this ACL.
+  The characters represent create, read, write, delete, and admin, respectively.
 
 ## Namers
 

--- a/namerd/examples/zk.yaml
+++ b/namerd/examples/zk.yaml
@@ -3,6 +3,13 @@ storage:
   pathPrefix: /dtabs
   hosts:
   - localhost:2181
+  authInfo:
+    scheme: digest
+    auth: user_123:password_123
+  acls:
+  - scheme: auth
+    id: ""
+    perms: crwda 
 interfaces:
 - kind: thriftNameInterpreter
 - kind: httpController


### PR DESCRIPTION
Add a authInfo section to the zk dtab storage config where ZooKeeper
authenticaiton can be configured.  Add a acls section as well to configure
how ACLs are set on created znodes.

Fixes #249