### PR TITLE
Add the http Host header to access logs

### DIFF
--- a/linkerd/protocol/http/src/main/scala/io/buoyant/linkerd/protocol/http/AccessLogger.scala
+++ b/linkerd/protocol/http/src/main/scala/io/buoyant/linkerd/protocol/http/AccessLogger.scala
@@ -14,13 +14,14 @@ case class AccessLogger(log: Logger) extends SimpleFilter[Request, Response] {
     val user = "-"
     val referer = reqHeaders.getOrElse("Referer", "-")
     val userAgent = reqHeaders.getOrElse("User-Agent", "-")
+    var hostHeader = reqHeaders.getOrElse("Host", "-")
     val reqResource = s"${req.method.toString.toUpperCase} ${req.uri} ${req.version}"
 
     svc(req).onSuccess { rsp =>
       val statusCode = rsp.statusCode
       val responseBytes = rsp.contentLength.map(_.toString).getOrElse("-")
       val requestEndTime = new TimeFormat("dd/MM/yyyy:HH:mm:ss Z").format(Time.now)
-      log.info(s"""$remoteHost $identd $user [$requestEndTime] "$reqResource" $statusCode $responseBytes "$referer" "$userAgent"""")
+      log.info(s"""$hostHeader $remoteHost $identd $user [$requestEndTime] "$reqResource" $statusCode $responseBytes "$referer" "$userAgent"""")
     }
   }
 }

--- a/linkerd/protocol/http/src/test/scala/io/buoyant/linkerd/protocol/http/AccessLoggerTest.scala
+++ b/linkerd/protocol/http/src/test/scala/io/buoyant/linkerd/protocol/http/AccessLoggerTest.scala
@@ -41,7 +41,7 @@ class AccessLoggerTest extends FunSuite with Awaits {
 
       val f = service(req)
       assert(StringLogger.getLoggedLines() ==
-        """0.0.0.0 - - [06/01/2016:21:21:26 +0000] "HEAD /foo?bar=bah HTTP/1.1" 402 304374 "-" "-"""")
+        """monkeys 0.0.0.0 - - [06/01/2016:21:21:26 +0000] "HEAD /foo?bar=bah HTTP/1.1" 402 304374 "-" "-"""")
     }
   }
 }


### PR DESCRIPTION
This helps with interpreting logs when routing to backend services by hostname.