### PR TITLE
Log which tracer we're loading, replace util-codec Base64

### DIFF
--- a/linkerd/core/src/main/scala/io/buoyant/linkerd/Linker.scala
+++ b/linkerd/core/src/main/scala/io/buoyant/linkerd/Linker.scala
@@ -4,6 +4,7 @@ import com.twitter.finagle.buoyant.DstBindingFactory
 import com.twitter.finagle.{param, Path, Namer, Stack}
 import com.twitter.finagle.tracing.{NullTracer, DefaultTracer, BroadcastTracer, Tracer}
 import com.twitter.finagle.util.LoadService
+import com.twitter.logging.Logger
 import io.buoyant.admin.AdminConfig
 import io.buoyant.config._
 import io.buoyant.namer.Param.Namers
@@ -21,6 +22,7 @@ trait Linker {
 }
 
 object Linker {
+  private[this] val log = Logger()
 
   private[linkerd] case class Initializers(
     protocol: Seq[ProtocolInitializer] = Nil,
@@ -82,6 +84,8 @@ object Linker {
         case Some(tracers) => BroadcastTracer(tracers)
         case None => DefaultTracer
       }
+
+      log.info(s"Loading tracer: $tracer")
 
       val namerParams = Stack.Params.empty + param.Tracer(tracer)
       val namersByPrefix = namers.getOrElse(Nil).reverse.map { namer =>

--- a/linkerd/protocol/http/src/main/scala/com/twitter/finagle/buoyant/linkerd/Headers.scala
+++ b/linkerd/protocol/http/src/main/scala/com/twitter/finagle/buoyant/linkerd/Headers.scala
@@ -4,7 +4,8 @@ import com.twitter.finagle.{Name, Path, Service, ServiceFactory, SimpleFilter, S
 import com.twitter.finagle.buoyant.{Dst => BuoyantDst}
 import com.twitter.finagle.http._
 import com.twitter.finagle.tracing._
-import com.twitter.util.{Base64StringEncoder, Try}
+import com.twitter.util.Try
+import java.util.Base64
 
 // all of this based on com.twitter.finagle.http.Codec
 
@@ -24,7 +25,7 @@ object Headers {
      *   ''reqId:8 parentId:8 traceId:8 flags:8''
      */
     def get(b64: String): Try[TraceId] =
-      Try(Base64StringEncoder.decode(b64)).flatMap(TraceId.deserialize)
+      Try(Base64.getDecoder.decode(b64)).flatMap(TraceId.deserialize)
 
     def get(headers: HeaderMap): Option[TraceId] =
       for {
@@ -34,7 +35,7 @@ object Headers {
 
     def set(headers: HeaderMap, id: TraceId): Unit = {
       val bytes = TraceId.serialize(id)
-      val b64 = Base64StringEncoder.encode(bytes)
+      val b64 = Base64.getEncoder().encodeToString(bytes)
       headers.set(Key, b64)
     }
 


### PR DESCRIPTION
Apache's Base64 codec was the top allocator of byte[] based on profiling from load tests as the buffer size was wrong for our use case. Because it's not overridable, I replaced our use of it with the Java 8-only Base64. If we're not ok with asking users for Java 8, then we shouldn't merge this.