### PR TITLE
namerd: notify clients when addr observation is released

### DIFF
--- a/namerd/iface/interpreter-thrift-idl/src/main/thrift/namer.thrift
+++ b/namerd/iface/interpreter-thrift-idl/src/main/thrift/namer.thrift
@@ -101,6 +101,7 @@ struct BoundAddr {
 union AddrVal {
   1: BoundAddr bound
   2: Void neg
+  3: Void released
 }
 
 struct Addr {

--- a/namerd/iface/interpreter-thrift/src/main/scala/io/buoyant/namerd/iface/ThriftNamerInterface.scala
+++ b/namerd/iface/interpreter-thrift/src/main/scala/io/buoyant/namerd/iface/ThriftNamerInterface.scala
@@ -4,6 +4,7 @@ import com.twitter.finagle.naming.NameInterpreter
 import com.twitter.finagle.tracing.Trace
 import com.twitter.finagle.{Addr, Address, Dentry, Dtab, Name, Namer, NameTree, Path}
 import com.twitter.io.Buf
+import com.twitter.logging.Logger
 import com.twitter.util._
 import io.buoyant.namerd.iface.{thriftscala => thrift}
 import io.buoyant.namerd.Ns
@@ -238,6 +239,8 @@ class ThriftNamerInterface(
 ) extends thrift.Namer.FutureIface {
   import ThriftNamerInterface._
 
+  private[this] val log = Logger.get(getClass.getName)
+
   /*
    * We keep a cache of observations.  Each observer keeps track of
    * the most recently observed state, and provides a Future that will
@@ -271,15 +274,15 @@ class ThriftNamerInterface(
 
         val bindingObserver = observeBind(ns, dtab, path)
         bindingObserver(reqStamp).transform {
-          case Throw(e) =>
-            Trace.recordBinary("namerd.srv/bind.fail", e.toString)
-            val failure = thrift.BindFailure(e.getMessage, retryIn().inSeconds, ref, ns)
-            Future.exception(failure)
-
           case Return((TStamp(tstamp), nameTree)) =>
             Trace.recordBinary("namerd.srv/bind.tree", nameTree.show)
             val (root, nodes, _) = mkTree(nameTree)
             Future.value(thrift.Bound(tstamp, thrift.BoundTree(root, nodes), ns))
+
+          case Throw(e) =>
+            Trace.recordBinary("namerd.srv/bind.fail", e.toString)
+            val failure = thrift.BindFailure(e.getMessage, retryIn().inSeconds, ref, ns)
+            Future.exception(failure)
         }
     }
   }

--- a/namerd/iface/interpreter-thrift/src/test/scala/io/buoyant/namerd/iface/ThriftNamerEndToEndTest.scala
+++ b/namerd/iface/interpreter-thrift/src/test/scala/io/buoyant/namerd/iface/ThriftNamerEndToEndTest.scala
@@ -74,8 +74,7 @@ class ThriftNamerEndToEndTest extends FunSuite with Eventually with IntegrationP
     serverState() = Activity.Ok(NameTree.Neg)
     eventually { assert(clientState == serverState.sample()) }
 
-    // XXX should this happen?
-    //eventually { assert(clientAddr0 == Addr.Neg) }
+    eventually { assert(clientAddr0 == Addr.Neg) }
 
     val serverAddr1 = Var[Addr](Addr.Pending)
     serverState() = Activity.Ok(NameTree.Leaf(Name.Bound(serverAddr1, id)))
@@ -85,7 +84,7 @@ class ThriftNamerEndToEndTest extends FunSuite with Eventually with IntegrationP
 
     @volatile var clientAddr1: Addr = Addr.Pending
     bound1.addr.changes.respond(clientAddr1 = _)
-    assert(clientAddr0 == Addr.Pending)
+    assert(clientAddr1 == Addr.Pending)
 
     serverAddr1() = Addr.Bound(Address("127.1", 5432))
     eventually { assert(clientAddr1 == serverAddr1.sample()) }

--- a/namerd/iface/interpreter-thrift/src/test/scala/io/buoyant/namerd/iface/ThriftNamerEndToEndTest.scala
+++ b/namerd/iface/interpreter-thrift/src/test/scala/io/buoyant/namerd/iface/ThriftNamerEndToEndTest.scala
@@ -1,0 +1,96 @@
+package io.buoyant.namerd.iface
+
+import com.twitter.conversions.time._
+import com.twitter.finagle.{Addr, Address, Dtab, Name, Namer, NameTree, Path}
+import com.twitter.finagle.naming.NameInterpreter
+import com.twitter.util._
+import java.net.{InetAddress, InetSocketAddress}
+import java.util.concurrent.atomic.AtomicLong
+import org.scalatest.FunSuite
+import org.scalatest.concurrent.{Eventually, IntegrationPatience}
+import org.scalatest.time._
+
+class ThriftNamerEndToEndTest extends FunSuite with Eventually with IntegrationPatience {
+  import ThriftNamerInterface._
+
+  implicit override val patienceConfig = PatienceConfig(
+    timeout = scaled(Span(5, Seconds)),
+    interval = scaled(Span(100, Milliseconds))
+  )
+
+  def retryIn() = 1.second
+  val clientId = Path.empty
+  val ns = "testns"
+
+  def newStamper = {
+    val stampCounter = new AtomicLong(1)
+    () => Stamp.mk(stampCounter.getAndIncrement)
+  }
+
+  test("service resurrection") {
+    val serverState = Var[Activity.State[NameTree[Name.Bound]]](Activity.Pending)
+    @volatile var clientState: Activity.State[NameTree[Name.Bound]] = Activity.Pending
+
+    val reqDtab = Dtab.read("/woop => /w00t")
+    val reqPath = Path.read("/woop/woop")
+    val id = Path.read("/io.l5d.w00t/woop")
+    val namer = new Namer {
+      def lookup(path: Path) = path match {
+        case Path.Utf8("woop") => Activity(serverState)
+        case _ => Activity.exception(new Exception)
+      }
+    }
+    def interpreter(ns: String) = new NameInterpreter {
+      def bind(dtab: Dtab, path: Path) =
+        if (dtab == reqDtab && path == reqPath) Activity(serverState)
+        else Activity.exception(new Exception)
+    }
+    val namers = Map(Path.read("/io.l5d.w00t") -> namer)
+    val service = new ThriftNamerInterface(interpreter, namers, newStamper, retryIn)
+    val client = new ThriftNamerClient(service, ns, clientId)
+
+    val act = client.bind(reqDtab, reqPath)
+    val obs = act.states.respond { s =>
+      clientState = s
+    }
+    assert(clientState == Activity.Pending)
+
+    val serverAddr0 = Var[Addr](Addr.Pending)
+    serverState() = Activity.Ok(NameTree.Leaf(Name.Bound(serverAddr0, id)))
+    eventually { assert(clientState == serverState.sample()) }
+    val Activity.Ok(NameTree.Leaf(bound0)) = clientState
+    assert(bound0.id == id)
+
+    @volatile var clientAddr0: Addr = Addr.Pending
+    bound0.addr.changes.respond(clientAddr0 = _)
+    assert(clientAddr0 == Addr.Pending)
+
+    serverAddr0() = Addr.Bound(Address("127.1", 4321))
+    eventually { assert(clientAddr0 == serverAddr0.sample()) }
+
+    serverAddr0() = Addr.Bound(Address("127.1", 5432))
+    eventually { assert(clientAddr0 == serverAddr0.sample()) }
+
+    serverState() = Activity.Ok(NameTree.Neg)
+    eventually { assert(clientState == serverState.sample()) }
+
+    // XXX should this happen?
+    //eventually { assert(clientAddr0 == Addr.Neg) }
+
+    val serverAddr1 = Var[Addr](Addr.Pending)
+    serverState() = Activity.Ok(NameTree.Leaf(Name.Bound(serverAddr1, id)))
+    eventually { assert(clientState == serverState.sample()) }
+    val Activity.Ok(NameTree.Leaf(bound1)) = clientState
+    assert(bound1.id == id)
+
+    @volatile var clientAddr1: Addr = Addr.Pending
+    bound1.addr.changes.respond(clientAddr1 = _)
+    assert(clientAddr0 == Addr.Pending)
+
+    serverAddr1() = Addr.Bound(Address("127.1", 5432))
+    eventually { assert(clientAddr1 == serverAddr1.sample()) }
+
+    serverAddr1() = Addr.Bound(Address("127.1", 6543))
+    eventually { assert(clientAddr1 == serverAddr1.sample()) }
+  }
+}


### PR DESCRIPTION
namerd thrift clients had no mechanism of knowing whether the server had stopped observing an address, and so the behavior described in #237 wasn't entirely resolved because the client's addr cache could not be invalidated.

In order to fix this, a new Addr.Released response type is added to the thrift protocol so that clients may remove references to defunct addr states.

Furthermore, this introduces a thrift end-to-end test, which should make it much easier to validate client-server interactions.

Fixes #292