### PR TITLE
Simplify address observation

### DIFF
--- a/namerd/iface/interpreter-thrift/src/main/scala/io/buoyant/namerd/iface/ThriftNamerInterface.scala
+++ b/namerd/iface/interpreter-thrift/src/main/scala/io/buoyant/namerd/iface/ThriftNamerInterface.scala
@@ -100,15 +100,14 @@ object ThriftNamerInterface {
     protected[this] def nextStamp(): Stamp
 
     protected[this] final def update(v: Try[T]): Unit = {
-      if (!current.exists(_.value == v)) {
-        val obs = Observation(nextStamp(), v)
-        val promise = synchronized {
+      synchronized {
+        if (!current.exists(_.value == v)) {
+          val obs = Observation(nextStamp(), v)
           val previous = pending
           current = Some(obs)
           pending = new Promise[Observation]
-          previous
+          previous.setValue(obs)
         }
-        promise.setValue(obs)
       }
     }
 

--- a/namerd/iface/interpreter-thrift/src/test/scala/io/buoyant/namerd/iface/ThriftNamerEndToEndTest.scala
+++ b/namerd/iface/interpreter-thrift/src/test/scala/io/buoyant/namerd/iface/ThriftNamerEndToEndTest.scala
@@ -74,8 +74,7 @@ class ThriftNamerEndToEndTest extends FunSuite with Eventually with IntegrationP
     serverState() = Activity.Ok(NameTree.Neg)
     eventually { assert(clientState == serverState.sample()) }
 
-    // XXX should this happen?
-    //eventually { assert(clientAddr0 == Addr.Neg) }
+    eventually { assert(clientAddr0 == Addr.Neg) }
 
     val serverAddr1 = Var[Addr](Addr.Pending)
     serverState() = Activity.Ok(NameTree.Leaf(Name.Bound(serverAddr1, id)))
@@ -85,7 +84,6 @@ class ThriftNamerEndToEndTest extends FunSuite with Eventually with IntegrationP
 
     @volatile var clientAddr1: Addr = Addr.Pending
     bound1.addr.changes.respond(clientAddr1 = _)
-    assert(clientAddr0 == Addr.Pending)
 
     serverAddr1() = Addr.Bound(Address("127.1", 5432))
     eventually { assert(clientAddr1 == serverAddr1.sample()) }

--- a/namerd/iface/interpreter-thrift/src/test/scala/io/buoyant/namerd/iface/ThriftNamerEndToEndTest.scala
+++ b/namerd/iface/interpreter-thrift/src/test/scala/io/buoyant/namerd/iface/ThriftNamerEndToEndTest.scala
@@ -1,0 +1,96 @@
+package io.buoyant.namerd.iface
+
+import com.twitter.conversions.time._
+import com.twitter.finagle.{Addr, Address, Dtab, Name, Namer, NameTree, Path}
+import com.twitter.finagle.naming.NameInterpreter
+import com.twitter.util._
+import java.net.{InetAddress, InetSocketAddress}
+import java.util.concurrent.atomic.AtomicLong
+import org.scalatest.FunSuite
+import org.scalatest.concurrent.{Eventually, IntegrationPatience}
+import org.scalatest.time._
+
+class ThriftNamerEndToEndTest extends FunSuite with Eventually with IntegrationPatience {
+  import ThriftNamerInterface._
+
+  implicit override val patienceConfig = PatienceConfig(
+    timeout = scaled(Span(5, Seconds)),
+    interval = scaled(Span(100, Milliseconds))
+  )
+
+  def retryIn() = 1.second
+  val clientId = Path.empty
+  val ns = "testns"
+
+  def newStamper = {
+    val stampCounter = new AtomicLong(1)
+    () => Stamp.mk(stampCounter.getAndIncrement)
+  }
+
+  test("service resurrection") {
+    val serverState = Var[Activity.State[NameTree[Name.Bound]]](Activity.Pending)
+    @volatile var clientState: Activity.State[NameTree[Name.Bound]] = Activity.Pending
+
+    val reqDtab = Dtab.read("/woop => /w00t")
+    val reqPath = Path.read("/woop/woop")
+    val id = Path.read("/io.l5d.w00t/woop")
+    val namer = new Namer {
+      def lookup(path: Path) = path match {
+        case Path.Utf8("woop") => Activity(serverState)
+        case _ => Activity.exception(new Exception)
+      }
+    }
+    def interpreter(ns: String) = new NameInterpreter {
+      def bind(dtab: Dtab, path: Path) =
+        if (dtab == reqDtab && path == reqPath) Activity(serverState)
+        else Activity.exception(new Exception)
+    }
+    val namers = Map(Path.read("/io.l5d.w00t") -> namer)
+    val service = new ThriftNamerInterface(interpreter, namers, newStamper, retryIn)
+    val client = new ThriftNamerClient(service, ns, clientId)
+
+    val act = client.bind(reqDtab, reqPath)
+    val obs = act.states.respond { s =>
+      clientState = s
+    }
+    assert(clientState == Activity.Pending)
+
+    val serverAddr0 = Var[Addr](Addr.Pending)
+    serverState() = Activity.Ok(NameTree.Leaf(Name.Bound(serverAddr0, id)))
+    eventually { assert(clientState == serverState.sample()) }
+    val Activity.Ok(NameTree.Leaf(bound0)) = clientState
+    assert(bound0.id == id)
+
+    @volatile var clientAddr0: Addr = Addr.Pending
+    bound0.addr.changes.respond(clientAddr0 = _)
+    assert(clientAddr0 == Addr.Pending)
+
+    serverAddr0() = Addr.Bound(Address("127.1", 4321))
+    eventually { assert(clientAddr0 == serverAddr0.sample()) }
+
+    serverAddr0() = Addr.Bound(Address("127.1", 5432))
+    eventually { assert(clientAddr0 == serverAddr0.sample()) }
+
+    serverState() = Activity.Ok(NameTree.Neg)
+    eventually { assert(clientState == serverState.sample()) }
+
+    // XXX should this happen?
+    //eventually { assert(clientAddr0 == Addr.Neg) }
+
+    val serverAddr1 = Var[Addr](Addr.Pending)
+    serverState() = Activity.Ok(NameTree.Leaf(Name.Bound(serverAddr1, id)))
+    eventually { assert(clientState == serverState.sample()) }
+    val Activity.Ok(NameTree.Leaf(bound1)) = clientState
+    assert(bound1.id == id)
+
+    @volatile var clientAddr1: Addr = Addr.Pending
+    bound1.addr.changes.respond(clientAddr1 = _)
+    assert(clientAddr0 == Addr.Pending)
+
+    serverAddr1() = Addr.Bound(Address("127.1", 5432))
+    eventually { assert(clientAddr1 == serverAddr1.sample()) }
+
+    serverAddr1() = Addr.Bound(Address("127.1", 6543))
+    eventually { assert(clientAddr1 == serverAddr1.sample()) }
+  }
+}


### PR DESCRIPTION
Since address observations are a `flatMap` of `bind` with the `Var[Addr]`, they
should always be correct, even if the `NameTree` becomes `Neg` and then comes back
with a new `Var[Addr]` (as in the case where a concrete name is deleted and then
recreated).  This means we can simplify the code by not evicting cached
observations when the `NameTree` becomes `Neg`.