### PR TITLE
Revert "allow ⭐️ , 👍, and 🚢  in pullapprove (#307)"

### DIFF
--- a/.pullapprove.yml
+++ b/.pullapprove.yml
@@ -1,5 +1,5 @@
 approve_by_comment: true
-approve_regex: '^(Approved|lgtm|LGTM|:shipit:|:star:|:\+1:|:ship:|⭐|👍|🚢)'
+approve_regex: '^(Approved|lgtm|LGTM|:shipit:|:star:|:\+1:|:ship:)'
 reject_regex: ^Rejected
 reset_on_push: false
 reviewers:


### PR DESCRIPTION
This reverts commit 3112d0f0ea7dc48b735bfe11d265a31ab3047fe5.

Sadly, I think this broke our pullapprove integration - all branches now
indicate a pullapprove failure.

See https://pullapprove.com/BuoyantIO/linkerd/pull-request/247/ for the problem.