### PR TITLE
fix io.l5d.serverset name ids

### DIFF
--- a/namer/serversets/src/main/scala/io/buoyant/namer/serversets/ServersetNamer.scala
+++ b/namer/serversets/src/main/scala/io/buoyant/namer/serversets/ServersetNamer.scala
@@ -18,15 +18,14 @@ import com.twitter.util.{Activity, Var}
  * Endpoint names are delimited by the ':' character. For example
  *
  * {{{
- * /$/io.l5d.serversets/discovery/prod/foo:http
+ * /io.l5d.serversets/discovery/prod/foo:http
  * }}}
  *
  * is the endpoint `http` of serverset `/discovery/prod/foo`
  *
  * Cribbed from https://github.com/twitter/finagle/blob/develop/finagle-serversets/src/main/scala/com/twitter/serverset.scala
  */
-class ServersetNamer(zkHost: String) extends Namer {
-  val idPrefix = Path.Utf8("$", "io.l5d.serversets")
+class ServersetNamer(zkHost: String, idPrefix: Path) extends Namer {
 
   /** Resolve a resolver string to a Var[Addr]. */
   protected[this] def resolve(spec: String): Var[Addr] = Resolver.eval(spec) match {

--- a/namer/serversets/src/main/scala/io/l5d/serversets.scala
+++ b/namer/serversets/src/main/scala/io/l5d/serversets.scala
@@ -22,7 +22,7 @@ case class serversets(zkAddrs: Seq[ZkAddr]) extends NamerConfig {
   /**
    * Construct a namer.
    */
-  def newNamer(params: Stack.Params) = new ServersetNamer(connectString)
+  def newNamer(params: Stack.Params) = new ServersetNamer(connectString, prefix)
 }
 
 case class ZkAddr(host: String, port: Option[Port]) {


### PR DESCRIPTION
The ServersetNamer had a hardcoded idPrefix, `/$/io.l5d.serversets`.  This meant that config-specified prefixes were ignored.  Worse yet, the prefix included /$/, which caused resolutions of the id to be searched on the classpath (which failed, since io.l5d.serversets is a NamerInitializer and not a Namer).

Passing the idPrefix into the ServersetNamer constructor resolves this.

This did not cause problems when linkerd resolved serverset names, but made it impossible for serverset names to be resolved through namerd (since the id was not resolvable).

In doing this, we improved error logging in namerd's thrift interface.