### PR TITLE
Retry the initial request to the k8s endpoint API if it fails

### DIFF
--- a/k8s/src/main/scala/io/buoyant/k8s/EndpointsNamer.scala
+++ b/k8s/src/main/scala/io/buoyant/k8s/EndpointsNamer.scala
@@ -62,19 +62,19 @@ class EndpointsNamer(
     def watches = _watches
 
     /**
-      * Returns an Activity backed by a Future.  The resultant Activity is pending until the
-      * original future is satisfied.  When the Future is successful, the Activity becomes
-      * an Activity.Ok with a fixed value from the Future.  If the Future fails, the Activity
-      * becomes an Activity.Failed and the Future is retried with the given backoff schedule.
-      * Therefore, the legal state transitions are:
-      *
-      * Pending -> Ok
-      * Pending -> Failed
-      * Failed -> Failed
-      * Failed -> Ok
-      */
+     * Returns an Activity backed by a Future.  The resultant Activity is pending until the
+     * original future is satisfied.  When the Future is successful, the Activity becomes
+     * an Activity.Ok with a fixed value from the Future.  If the Future fails, the Activity
+     * becomes an Activity.Failed and the Future is retried with the given backoff schedule.
+     * Therefore, the legal state transitions are:
+     *
+     * Pending -> Ok
+     * Pending -> Failed
+     * Failed -> Failed
+     * Failed -> Ok
+     */
     private[this] def retryToActivity[T](go: => Future[T]): Activity[T] = {
-      val state = Var(Activity.Pending: Activity.State[T])
+      val state = Var[Activity.State[T]](Activity.Pending)
       _retryToActivity(backoff, state)(go)
       Activity(state)
     }
@@ -101,7 +101,7 @@ class EndpointsNamer(
         case Some(ns) => ns
         case None =>
           val ns = new NsCache(name)
-          val closable = retryToActivity(watch(name, ns))
+          val closable = retryToActivity { watch(name, ns) }
           _watches += (name -> closable)
           caches += (name -> ns)
           ns

--- a/k8s/src/test/scala/io/buoyant/k8s/EndpointsNamerTest.scala
+++ b/k8s/src/test/scala/io/buoyant/k8s/EndpointsNamerTest.scala
@@ -46,7 +46,7 @@ class EndpointsNamerTest extends FunSuite with Awaits {
     val namer = new EndpointsNamer(Path.read("/test"), api.withNamespace, Stream.continually(1.millis))(timer)
 
     @volatile var state: Activity.State[NameTree[Name]] = Activity.Pending
-    val obs = namer.lookup(Path.read("/srv/http/sessions")).states respond { s =>
+    val _ = namer.lookup(Path.read("/srv/http/sessions")).states.respond { s =>
       state = s
     }
     def assertHas(n: Int): Unit =


### PR DESCRIPTION
Problem:
If the initial request to the k8s endpoint API failed, no watch is created and the NsCache is never populated.

Solution:
Infinitely retry the initial request to the k8s endpoint API.

Fixes #289 