### PR TITLE
modify namerd /delegate endpoint to accept a dtab

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,6 +27,28 @@ centrally managing routing policy and fronting service discovery.
 * [linkerd](linkerd/README.md)
 * [namerd](namerd/README.md)
 
+## Quickstart ##
+
+### Boot linkerd ###
+
+```
+$ ./sbt linkerd-examples/http:run # build and run linkerd
+$ open http://localhost:9990      # open linkerd's admin interface in a browser
+```
+
+More details at [linkerd's quickstart](linkerd/README.md#quickstart)
+
+
+### Boot namerd ###
+
+```
+$ ./sbt namerd-examples/basic:run # build and run namerd
+$ open http://localhost:9991      # open namerd's admin interface in a browser
+$ curl :4180/api/1/dtabs          # test namerd's http interface
+```
+
+More details at [namerd's quickstart](namerd/README.md#quickstart)
+
 ## Working in this repository ##
 
 [sbt][sbt] is used to build and test linkerd. Developers should not
@@ -42,57 +64,10 @@ $ ./sbt
 >
 ```
 
-The sbt project consists of many sub-projects:
+The sbt project consists of many sub-projects. To list all projects run:
 
 ```
 > projects
-[info] In file:.../linkerd/
-[info]     admin
-[info]   * all
-[info]     config
-[info]     consul
-[info]     interpreter-namerd
-[info]     k8s
-[info]     linkerd
-[info]     linkerd-admin
-[info]     linkerd-core
-[info]     linkerd-examples
-[info]     linkerd-identifier
-[info]     linkerd-identifier-http
-[info]     linkerd-main
-[info]     linkerd-protocol
-[info]     linkerd-protocol-benchmark
-[info]     linkerd-protocol-http
-[info]     linkerd-protocol-mux
-[info]     linkerd-protocol-thrift
-[info]     linkerd-tls
-[info]     marathon
-[info]     namer
-[info]     namer-consul
-[info]     namer-core
-[info]     namer-fs
-[info]     namer-k8s
-[info]     namer-marathon
-[info]     namer-serversets
-[info]     namerd
-[info]     namerd-core
-[info]     namerd-examples
-[info]     namerd-iface
-[info]     namerd-iface-control-http
-[info]     namerd-iface-interpreter-thrift
-[info]     namerd-iface-interpreter-thrift-idl
-[info]     namerd-main
-[info]     namerd-storage
-[info]     namerd-storage-in-memory
-[info]     namerd-storage-zk
-[info]     router
-[info]     router-core
-[info]     router-http
-[info]     router-mux
-[info]     router-thrift
-[info]     router-thrift-idl
-[info]     test-util
-[info]     validator
 ```
 
 These projects are configured in

--- a/admin/src/main/resources/io/buoyant/admin/js/delegator.js
+++ b/admin/src/main/resources/io/buoyant/admin/js/delegator.js
@@ -29,7 +29,7 @@ var Delegator = (function() {
       var path = $('#path-input').val();
       window.location.hash = encodeURIComponent(path);
       var request = $.get(
-        "/delegator.json?" + $.param({ n: path, d: dtabViewer.dtabStr() }),
+        "/delegator.json?" + $.param({ path: path, dtab: dtabViewer.dtabStr() }),
         renderAll.bind(this));
       request.fail(function( jqXHR ) {
         $(".error-modal").html(templates.errorModal(jqXHR.statusText));

--- a/linkerd/admin/src/test/scala/io/buoyant/linkerd/admin/names/DelegateApiHandlerTest.scala
+++ b/linkerd/admin/src/test/scala/io/buoyant/linkerd/admin/names/DelegateApiHandlerTest.scala
@@ -35,7 +35,7 @@ class DelegateApiHandlerTest extends FunSuite with Awaits {
   test("/delegate response") {
     val web = new DelegateApiHandler(linker.namers)
     val req = Request()
-    req.uri = s"/delegate?n=/boo/humbug&d=${URLEncoder.encode(dtab.show, "UTF-8")}"
+    req.uri = s"/delegate?path=/boo/humbug&dtab=${URLEncoder.encode(dtab.show, "UTF-8")}"
     val rsp = await(web(req))
     assert(rsp.status == Status.Ok)
     assert(rsp.contentString == """{
@@ -60,7 +60,7 @@ class DelegateApiHandlerTest extends FunSuite with Awaits {
   test("invalid path results in 400") {
     val web = new DelegateApiHandler(linker.namers)
     val req = Request()
-    req.uri = s"/delegate?n=invalid-param&d=${URLEncoder.encode(dtab.show, "UTF-8")}"
+    req.uri = s"/delegate?path=invalid-param&dtab=${URLEncoder.encode(dtab.show, "UTF-8")}"
     val rsp = await(web(req))
     assert(rsp.status == Status.BadRequest)
   }
@@ -68,7 +68,7 @@ class DelegateApiHandlerTest extends FunSuite with Awaits {
   test("invalid dtab results in 400") {
     val web = new DelegateApiHandler(linker.namers)
     val req = Request()
-    req.uri = s"/delegate?n=/boo/humbug&d=invalid-param"
+    req.uri = s"/delegate?path=/boo/humbug&dtab=invalid-param"
     val rsp = await(web(req))
     assert(rsp.status == Status.BadRequest)
   }

--- a/namerd/README.md
+++ b/namerd/README.md
@@ -39,3 +39,47 @@ or
 ```
 ./sbt 'namerd-main:run path/to/config.yml'
 ```
+
+## Http Control Interface ##
+
+namerd provides an http interface to create, update and retrieve Dtabs, as
+defined in `HttpControlService`.
+
+For a command-line tool which wraps this interface, try
+[namerctl](https://github.com/BuoyantIO/namerctl)
+
+Primary interface endpoints:
+
+```
+$ export NAMERD_URL=http://localhost:4180
+```
+
+Get all dtab namespaces:
+
+```
+$ curl $NAMERD_URL/api/1/dtabs
+```
+
+Get a dtab for the `default` namespace:
+
+```
+$ curl $NAMERD_URL/api/1/dtabs/default
+```
+
+Create or update a dtab namespace:
+
+```
+$ curl -v -X PUT -d"/foo => /bar" -H "Content-Type: application/dtab" $NAMERD_URL/api/1/dtabs/baz
+```
+
+Evaluate a path against a known dtab namespace:
+
+```
+$ curl -v $NAMERD_URL/api/1/delegate/baz?path=/foo
+```
+
+Evaluate a path against an arbitrary dtab:
+
+```
+$ curl -v "$NAMERD_URL/api/1/delegate?dtab=/foo=>/bar&path=/foo"
+```

--- a/namerd/iface/control-http/src/main/scala/io/buoyant/namerd/iface/HttpControlServiceConfig.scala
+++ b/namerd/iface/control-http/src/main/scala/io/buoyant/namerd/iface/HttpControlServiceConfig.scala
@@ -11,7 +11,7 @@ class HttpControlServiceConfig extends InterpreterInterfaceConfig {
     delegate: Ns => NameInterpreter,
     namers: Map[Path, Namer],
     store: DtabStore
-  ): Servable = HttpControlServable(addr, store, delegate)
+  ): Servable = HttpControlServable(addr, store, delegate, namers)
 
   @JsonIgnore
   def defaultAddr = HttpControlServiceConfig.defaultAddr
@@ -25,10 +25,11 @@ object HttpControlServiceConfig {
 case class HttpControlServable(
   addr: InetSocketAddress,
   store: DtabStore,
-  delegate: Ns => NameInterpreter
+  delegate: Ns => NameInterpreter,
+  namers: Map[Path, Namer]
 ) extends Servable {
   def kind = HttpControlServiceConfig.kind
-  def serve(): ListeningServer = Http.serve(addr, new HttpControlService(store, delegate))
+  def serve(): ListeningServer = Http.serve(addr, new HttpControlService(store, delegate, namers))
 }
 
 class HttpControlServiceInitializer extends InterfaceInitializer {


### PR DESCRIPTION
also includes readme cleanup, and a refactor to share code between these
three endpoints:
admin /delegator.json
namerd /delegate/namespace
namerd /delegate?dtab=

@adleong: I'd appreciate your eyes on the changes in `HttpControlService.scala`, as it may affect work you are doing in that area.