### PR TITLE
Make NsCache immutable

### DIFF
--- a/k8s/src/test/scala/io/buoyant/k8s/EndpointsNamerTest.scala
+++ b/k8s/src/test/scala/io/buoyant/k8s/EndpointsNamerTest.scala
@@ -86,7 +86,7 @@ class EndpointsNamerTest extends FunSuite with Awaits {
 
         time.advance(1.millis)
         timer.tick()
-        assert(state == Activity.Pending)
+        assert(state == Activity.Failed(e))
 
         doInit = new Promise[Unit]
         doInit.setDone()


### PR DESCRIPTION
Based on https://github.com/BuoyantIO/linkerd/pull/322

Problem:
NsCache, SvcCache, and Port each contain a Var which results in multiple nested levels of mutability.  This is complex and difficult to reason about.

Solution:
Make NsCache, SvcCache, and Port immutable.  Methods such as `update` now return a modified copy.

Result:
`watch` now returns an `Activity[NsCache]`.  Mutability is isolated to the `watch` method and separated from the data structure.

Also, we refactor `retryToActivity` to use `Var.async`.