### PR TITLE
Breaking namerd thrift change: string-encode Dtabs

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -4,6 +4,8 @@
   time to spend binding a path.
 * Add experimental support for storing dtabs in Kubernetes via the
   ThirdPartyResource API (which must be enabled in your cluster).
+* **Breaking api change** in namerd: dtabs are now string-encoded
+  rather than thrift-encoded.
 
 ## 0.3.1
 

--- a/namerd/iface/interpreter-thrift-idl/src/main/thrift/namer.thrift
+++ b/namerd/iface/interpreter-thrift-idl/src/main/thrift/namer.thrift
@@ -22,11 +22,7 @@ struct NameRef {
  * Produces a NameTree[Name.Bound]
  */
 
-struct Dentry {
-  1: Path prefix
-  2: string dst
-}
-typedef list<Dentry> Dtab
+typedef string Dtab
 
 struct BindReq {
   1: Dtab dtab

--- a/namerd/iface/interpreter-thrift/src/main/scala/io/buoyant/namerd/iface/ThriftNamerClient.scala
+++ b/namerd/iface/interpreter-thrift/src/main/scala/io/buoyant/namerd/iface/ThriftNamerClient.scala
@@ -52,7 +52,7 @@ class ThriftNamerClient(
   }
 
   private[this] def watchName(dtab: Dtab, path: Path): Activity[NameTree[Name.Bound]] = {
-    val tdtab = TDtab(dtab)
+    val tdtab = dtab.show
     val tpath = TPath(path)
 
     val states = Var.async[Activity.State[NameTree[Name.Bound]]](Activity.Pending) { states =>

--- a/namerd/iface/interpreter-thrift/src/test/scala/io/buoyant/namerd/iface/ThriftNamerClientTest.scala
+++ b/namerd/iface/interpreter-thrift/src/test/scala/io/buoyant/namerd/iface/ThriftNamerClientTest.scala
@@ -25,7 +25,7 @@ class ThriftNamerClientTest extends FunSuite {
 
     def bind(req: thrift.BindReq): Future[thrift.Bound] = {
       val thrift.BindReq(tdtab, thrift.NameRef(stamp, name, ns), cid) = req
-      val dtab = mkDtab(tdtab)
+      val dtab = Dtab.read(tdtab)
       assert(mkPath(cid) == clientId)
       bindingsMu.synchronized {
         val k = (ns, mkPath(name), dtab, stamp)

--- a/namerd/iface/interpreter-thrift/src/test/scala/io/buoyant/namerd/iface/ThriftNamerInterfaceTest.scala
+++ b/namerd/iface/interpreter-thrift/src/test/scala/io/buoyant/namerd/iface/ThriftNamerInterfaceTest.scala
@@ -28,7 +28,7 @@ class ThriftNamerInterfaceTest extends FunSuite {
 
     // The first request before the tree has been refined -- no value initially
     val initName = thrift.NameRef(TStamp.empty, TPath("ysl", "thugger"), ns)
-    val initF = service.bind(thrift.BindReq(TDtab.empty, initName, clientId))
+    val initF = service.bind(thrift.BindReq("", initName, clientId))
     assert(!initF.isDefined)
 
     val ss2Addr, imupAddr, ss3Addr = Var[Addr](Addr.Pending)


### PR DESCRIPTION
The thrift interface contains thrift-encoded dtab types. These types must be
mapped to/from finagle's types internally.

In the next finagle release, dtabs are changing to support wildcard prefixes.
Rather than reflect this change in the thrift structure, I propose that we
simply move to string-encoded dtabs.