### PR TITLE
Introduce response classifiers

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -3,6 +3,8 @@
 * Add a `debugTrace` parameter to the `tracers` config section, which enables
   printing all traces to the console.
 * Add etcd backed dtab storage.
+* Introduce a default HTTP response classifier so that 5XX responses
+  are marked as failures.
 
 ## 0.4.0
 

--- a/linkerd/core/src/main/scala/io/buoyant/linkerd/Linker.scala
+++ b/linkerd/core/src/main/scala/io/buoyant/linkerd/Linker.scala
@@ -30,10 +30,11 @@ object Linker {
     interpreter: Seq[InterpreterInitializer] = Nil,
     tlsClient: Seq[TlsClientInitializer] = Nil,
     tracer: Seq[TracerInitializer] = Nil,
-    identifier: Seq[IdentifierInitializer] = Nil
+    identifier: Seq[IdentifierInitializer] = Nil,
+    classifier: Seq[ResponseClassifierInitializer] = Nil
   ) {
     def iter: Iterable[Seq[ConfigInitializer]] =
-      Seq(protocol, namer, interpreter, tlsClient, tracer, identifier)
+      Seq(protocol, namer, interpreter, tlsClient, tracer, identifier, classifier)
 
     def all: Seq[ConfigInitializer] = iter.flatten.toSeq
 
@@ -50,7 +51,8 @@ object Linker {
     LoadService[InterpreterInitializer] :+ DefaultInterpreterInitializer,
     LoadService[TlsClientInitializer],
     LoadService[TracerInitializer],
-    LoadService[IdentifierInitializer]
+    LoadService[IdentifierInitializer],
+    LoadService[ResponseClassifierInitializer]
   )
 
   def parse(

--- a/linkerd/core/src/main/scala/io/buoyant/linkerd/ResponseClassifierInitializer.scala
+++ b/linkerd/core/src/main/scala/io/buoyant/linkerd/ResponseClassifierInitializer.scala
@@ -1,0 +1,17 @@
+package io.buoyant.linkerd
+
+import com.fasterxml.jackson.annotation.{JsonIgnore, JsonTypeInfo}
+import com.twitter.finagle.service.ResponseClassifier
+import io.buoyant.config.ConfigInitializer
+
+trait ResponseClassifierInitializer extends ConfigInitializer
+
+@JsonTypeInfo(
+  use = JsonTypeInfo.Id.NAME,
+  include = JsonTypeInfo.As.PROPERTY,
+  property = "kind"
+)
+trait ResponseClassifierConfig {
+  @JsonIgnore
+  def mk: ResponseClassifier
+}

--- a/linkerd/core/src/main/scala/io/buoyant/linkerd/Router.scala
+++ b/linkerd/core/src/main/scala/io/buoyant/linkerd/Router.scala
@@ -156,9 +156,7 @@ trait RouterConfig {
 
   @JsonIgnore
   def responseClassifier: ResponseClassifier =
-    _responseClassifier.foldLeft(baseResponseClassifier) {
-      case (base, config) => config.mk orElse base
-    }
+    _responseClassifier.map(_.mk).getOrElse(PartialFunction.empty) orElse baseResponseClassifier
 
   @JsonIgnore
   def routerParams = Stack.Params.empty

--- a/linkerd/core/src/main/scala/io/buoyant/linkerd/Router.scala
+++ b/linkerd/core/src/main/scala/io/buoyant/linkerd/Router.scala
@@ -6,7 +6,7 @@ import com.twitter.conversions.time._
 import com.twitter.finagle._
 import com.twitter.finagle.buoyant.DstBindingFactory
 import com.twitter.finagle.client.DefaultPool
-import com.twitter.finagle.service.{FailFastFactory, TimeoutFilter}
+import com.twitter.finagle.service.{FailFastFactory, ResponseClassifier, TimeoutFilter}
 import com.twitter.util.Closable
 import io.buoyant.namer.{InterpreterConfig, DefaultInterpreterConfig}
 import io.buoyant.router.RoutingFactory
@@ -38,11 +38,15 @@ trait Router {
 
   def withParams(ps: Stack.Params): Router = {
     val r = _withParams(ps)
-    // Copy stats and tracing params from router to servers
+
+    // Copy selected params from router to servers
     val param.Stats(stats) = r.params[param.Stats]
-    val srvStats = param.Stats(stats.scope(label, "srv"))
-    val tracer = r.params[param.Tracer]
-    r.withServers(servers.map(_.configured(srvStats).configured(tracer)))
+    def configure(s: Server) = s
+      .configured(param.Stats(stats.scope(label, "srv")))
+      .configured(r.params[param.ResponseClassifier])
+      .configured(r.params[param.Tracer])
+
+    r.withServers(servers.map(configure(_)))
   }
 
   def configured[P: Stack.Param](p: P): Router = withParams(params + p)
@@ -90,6 +94,7 @@ object Router {
     server.configured(param.Label(s"$ip/$port"))
       .configured(Server.RouterLabel(routerLabel))
       .configured(param.Stats(stats.scope(routerLabel, "srv")))
+      .configured(router.params[param.ResponseClassifier])
       .configured(router.params[param.Tracer])
   }
 }
@@ -113,6 +118,10 @@ trait RouterConfig {
   @JsonIgnore
   def label = _label.getOrElse(protocol.name)
 
+  /*
+   * interpreter controls how names are bound.
+   */
+
   @JsonProperty("interpreter")
   var _interpreter: Option[InterpreterConfig] = None
 
@@ -123,11 +132,33 @@ trait RouterConfig {
   def interpreter: InterpreterConfig =
     _interpreter.getOrElse(defaultInterpreter)
 
+  /*
+   * bindingTimeoutMs limits name resolution.
+   */
+
   @JsonProperty("bindingTimeoutMs")
   var _bindingTimeoutMs: Option[Int] = None
 
   @JsonIgnore
   def bindingTimeout = _bindingTimeoutMs.map(_.millis).getOrElse(10.seconds)
+
+  /*
+   * responseClassifier categorizes responses to determine whether
+   * they are failures and if they are retryable.
+   */
+
+  @JsonProperty("responseClassifier")
+  var _responseClassifier: Option[ResponseClassifierConfig] = None
+
+  @JsonIgnore
+  def baseResponseClassifier: ResponseClassifier =
+    ResponseClassifier.Default
+
+  @JsonIgnore
+  def responseClassifier: ResponseClassifier =
+    _responseClassifier.foldLeft(baseResponseClassifier) {
+      case (base, config) => config.mk orElse base
+    }
 
   @JsonIgnore
   def routerParams = Stack.Params.empty
@@ -136,6 +167,7 @@ trait RouterConfig {
     .maybeWith(timeoutMs.map(timeout => TimeoutFilter.Param(timeout.millis)))
     .maybeWith(dstPrefix.map(pfx => RoutingFactory.DstPrefix(Path.read(pfx))))
     .maybeWith(client.map(_.clientParams)) +
+    param.ResponseClassifier(responseClassifier) +
     param.Label(label) +
     DstBindingFactory.BindingTimeout(bindingTimeout)
 

--- a/linkerd/examples/acceptance-test.yaml
+++ b/linkerd/examples/acceptance-test.yaml
@@ -47,6 +47,8 @@ routers:
   identifier:
     kind: default
     httpUriInDst: true
+  responseClassifier:
+    kind: retryableIdempotent5XX
   client:
     loadBalancer:
       kind: p2c

--- a/linkerd/protocol/http/src/e2e/scala/io/buoyant/linkerd/protocol/HttpEndToEndTest.scala
+++ b/linkerd/protocol/http/src/e2e/scala/io/buoyant/linkerd/protocol/HttpEndToEndTest.scala
@@ -209,7 +209,7 @@ class HttpEndToEndTest extends FunSuite with Awaits {
     }
   }
 
-  // TODO once repsonse classifiers are wired into requeues #361
+  // TODO once response classifiers are wired into requeues #361
   ignore("retries retryableIdempotent5XX") {
     val stats = new InMemoryStatsReceiver
     val tracer = NullTracer

--- a/linkerd/protocol/http/src/main/resources/META-INF/services/io.buoyant.linkerd.ResponseClassifierInitializer
+++ b/linkerd/protocol/http/src/main/resources/META-INF/services/io.buoyant.linkerd.ResponseClassifierInitializer
@@ -1,0 +1,3 @@
+io.buoyant.linkerd.protocol.http.NonRetryable5XXInitializer
+io.buoyant.linkerd.protocol.http.RetryableIdempotent5XXInitializer
+io.buoyant.linkerd.protocol.http.RetryableRead5XXInitializer

--- a/linkerd/protocol/http/src/main/scala/io/buoyant/linkerd/protocol/HttpInitializer.scala
+++ b/linkerd/protocol/http/src/main/scala/io/buoyant/linkerd/protocol/HttpInitializer.scala
@@ -53,7 +53,7 @@ case class HttpConfig(
 
   @JsonIgnore
   override def baseResponseClassifier =
-    ResponseClassifiers.NonRetryableFailures orElse super.baseResponseClassifier
+    ResponseClassifiers.NonRetryableServerFailures orElse super.baseResponseClassifier
 
   @JsonIgnore
   override val protocol: ProtocolInitializer = HttpInitializer

--- a/linkerd/protocol/http/src/main/scala/io/buoyant/linkerd/protocol/HttpInitializer.scala
+++ b/linkerd/protocol/http/src/main/scala/io/buoyant/linkerd/protocol/HttpInitializer.scala
@@ -4,7 +4,7 @@ package protocol
 import com.fasterxml.jackson.annotation.JsonIgnore
 import com.twitter.finagle.buoyant.linkerd.{Headers, HttpTraceInitializer}
 import com.twitter.finagle.{Path, Stack, StackBuilder}
-import io.buoyant.linkerd.protocol.http.AccessLogger
+import io.buoyant.linkerd.protocol.http.{AccessLogger, ResponseClassifiers}
 import io.buoyant.router.{Http, RoutingFactory}
 import io.l5d.HttpIdentifierConfig
 
@@ -52,7 +52,11 @@ case class HttpConfig(
   var servers: Seq[ServerConfig] = Nil
 
   @JsonIgnore
-  override def protocol: ProtocolInitializer = HttpInitializer
+  override def baseResponseClassifier =
+    ResponseClassifiers.NonRetryableFailures orElse super.baseResponseClassifier
+
+  @JsonIgnore
+  override val protocol: ProtocolInitializer = HttpInitializer
 
   @JsonIgnore
   override def routerParams: Stack.Params = super.routerParams

--- a/linkerd/protocol/http/src/main/scala/io/buoyant/linkerd/protocol/http/ResponseClassifiers.scala
+++ b/linkerd/protocol/http/src/main/scala/io/buoyant/linkerd/protocol/http/ResponseClassifiers.scala
@@ -1,0 +1,124 @@
+package io.buoyant.linkerd.protocol.http
+
+import com.twitter.finagle.http.{Method, Request, Response}
+import com.twitter.finagle.service.{ResponseClass, ReqRep, ResponseClassifier}
+import com.twitter.util.{NonFatal, Return, Throw}
+import io.buoyant.config.ConfigInitializer
+import io.buoyant.linkerd.{ResponseClassifierConfig, ResponseClassifierInitializer}
+
+object ResponseClassifiers {
+
+  object Requests {
+
+    case class ByMethod(methods: Set[Method]) {
+      def unapply(req: Request): Boolean = methods.contains(req.method)
+    }
+
+    /** Matches read-only requests */
+    val ReadOnly = ByMethod(Set(
+      Method.Get,
+      Method.Head,
+      Method.Options,
+      Method.Trace
+    ))
+
+    /**
+     * Matches idempotent requests.
+     *
+     * Per RFC2616:
+     *
+     *   Methods can also have the property of "idempotence" in that
+     *   (aside from error or expiration issues) the side-effects of N >
+     *   0 identical requests is the same as for a single request. The
+     *   methods GET, HEAD, PUT and DELETE share this property. Also,
+     *   the methods OPTIONS and TRACE SHOULD NOT have side effects, and
+     *   so are inherently idempotent.
+     */
+    val Idempotent = ByMethod(Set(
+      Method.Get,
+      Method.Head,
+      Method.Put,
+      Method.Delete,
+      Method.Options,
+      Method.Trace
+    ))
+  }
+
+  object Responses {
+
+    object Failure {
+      def unapply(rsp: Response): Boolean =
+        rsp.statusCode >= 500 && rsp.statusCode <= 599
+    }
+
+    object Retryable {
+      // There are porbably some (linkerd-generated) failures that aren't
+      // really retryable... For now just check if it's a failure.
+      def unapply(rsp: Response): Boolean = Failure.unapply(rsp)
+    }
+  }
+
+  /**
+   * Classifies 5XX responses as failures. If the method is idempotent
+   * (as described by RFC2616), it is classified as retryable.
+   */
+  val RetryableIdempotentFailures: ResponseClassifier =
+    ResponseClassifier.named("RetryableIdempotentFailures") {
+      case ReqRep(Requests.Idempotent(), Return(Responses.Retryable()) | Throw(NonFatal(_))) =>
+        ResponseClass.RetryableFailure
+    }
+
+  /**
+   * Classifies 5XX responses as failures. If the method is a read
+   * operation, it is classified as retryable.
+   */
+  val RetryableReadFailures: ResponseClassifier =
+    ResponseClassifier.named("RetryableReadFailures") {
+      case ReqRep(Requests.ReadOnly(), Return(Responses.Retryable()) | Throw(NonFatal(_))) =>
+        ResponseClass.RetryableFailure
+    }
+
+  /**
+   * Classifies 5XX responses and all exceptions as non-retryable
+   * failures.
+   */
+  val NonRetryableFailures: ResponseClassifier =
+    ResponseClassifier.named("NonRetryableFailures") {
+      case ReqRep(_, Return(Responses.Failure()) | Throw(NonFatal(_))) =>
+        ResponseClass.NonRetryableFailure
+    }
+
+}
+
+class RetryableIdempotent5XXConfig extends ResponseClassifierConfig {
+  def mk: ResponseClassifier = ResponseClassifiers.RetryableIdempotentFailures
+}
+
+class RetryableIdempotent5XXInitializer extends ResponseClassifierInitializer {
+  val configClass = classOf[RetryableIdempotent5XXConfig]
+  override val configId = "retryableIdempotent5XX"
+}
+
+object RetryableIdempotent5XXInitializer extends RetryableIdempotent5XXInitializer
+
+class RetryableRead5XXConfig extends ResponseClassifierConfig {
+  def mk: ResponseClassifier = ResponseClassifiers.RetryableReadFailures
+}
+
+class RetryableRead5XXInitializer extends ResponseClassifierInitializer {
+  val configClass = classOf[RetryableRead5XXConfig]
+  override val configId = "retryableRead5XX"
+}
+
+object RetryableRead5XXInitializer extends RetryableRead5XXInitializer
+
+class NonRetryable5XXConfig extends ResponseClassifierConfig {
+  def mk: ResponseClassifier = ResponseClassifiers.NonRetryableFailures
+}
+
+class NonRetryable5XXInitializer extends ResponseClassifierInitializer {
+  val configClass = classOf[NonRetryable5XXConfig]
+  override val configId = "nonRetryable5XX"
+}
+
+object NonRetryable5XXInitializer extends NonRetryable5XXInitializer

--- a/linkerd/protocol/http/src/test/scala/io/buoyant/linkerd/protocol/http/ResponseClassifiersTest.scala
+++ b/linkerd/protocol/http/src/test/scala/io/buoyant/linkerd/protocol/http/ResponseClassifiersTest.scala
@@ -85,7 +85,7 @@ class ResponseClassifiersTest extends FunSuite {
   }
 
   {
-    val classifier = ResponseClassifiers.NonRetryableFailures
+    val classifier = ResponseClassifiers.NonRetryableServerFailures
     for (method <- allMethods) {
       test(s"$classifier: ignores $method 1XX-4XX") {
         for (code <- 100 to 499)
@@ -100,15 +100,6 @@ class ResponseClassifiersTest extends FunSuite {
             Return(Status(code)),
             Some(ResponseClass.NonRetryableFailure)
           )
-      }
-
-      test(s"$classifier: fails $method error") {
-        testClassifier(
-          classifier,
-          method,
-          Throw(new Exception),
-          Some(ResponseClass.NonRetryableFailure)
-        )
       }
     }
   }

--- a/linkerd/protocol/http/src/test/scala/io/buoyant/linkerd/protocol/http/ResponseClassifiersTest.scala
+++ b/linkerd/protocol/http/src/test/scala/io/buoyant/linkerd/protocol/http/ResponseClassifiersTest.scala
@@ -1,0 +1,133 @@
+package io.buoyant.linkerd.protocol.http
+
+import com.twitter.finagle.http.{Method, Request, Response, Status}
+import com.twitter.finagle.service.{ResponseClass, ReqRep, ResponseClassifier}
+import com.twitter.finagle.util.LoadService
+import com.twitter.util.{Return, Throw, Try}
+import io.buoyant.config.Parser
+import io.buoyant.linkerd.{ResponseClassifierConfig, ResponseClassifierInitializer}
+import org.scalatest.FunSuite
+
+class ResponseClassifiersTest extends FunSuite {
+
+  def testClassifier(
+    classifier: ResponseClassifier,
+    method: Method,
+    status: Try[Status],
+    classification: Option[ResponseClass]
+  ): Unit = {
+    val key = ReqRep(Request(method, "/"), status.map(Response(_)))
+    classification match {
+      case None =>
+        assert(!classifier.isDefinedAt(key))
+      case Some(classification) =>
+        assert(classifier.isDefinedAt(key))
+        assert(classifier(key) == classification)
+    }
+  }
+
+  val allMethods = Set(
+    Method.Connect,
+    Method.Delete,
+    Method.Get,
+    Method.Head,
+    Method.Patch,
+    Method.Put,
+    Method.Options,
+    Method.Trace
+  )
+
+  for (
+    (classifier, retryMethods) <- Map(
+      ResponseClassifiers.RetryableIdempotentFailures ->
+        Set(Method.Get, Method.Head, Method.Put, Method.Delete, Method.Options, Method.Trace),
+      ResponseClassifiers.RetryableReadFailures ->
+        Set(Method.Get, Method.Head, Method.Options, Method.Trace)
+    )
+  ) {
+
+    for (method <- retryMethods) {
+      test(s"$classifier: ignores $method 1XX-4XX") {
+        for (code <- 100 to 499)
+          testClassifier(classifier, method, Return(Status(code)), None)
+      }
+
+      test(s"$classifier: retries $method 5XX") {
+        for (code <- 500 to 599)
+          testClassifier(
+            classifier,
+            method,
+            Return(Status(code)),
+            Some(ResponseClass.RetryableFailure)
+          )
+      }
+
+      test(s"$classifier: retries $method errors") {
+        testClassifier(
+          classifier,
+          method,
+          Throw(new Exception),
+          Some(ResponseClass.RetryableFailure)
+        )
+      }
+    }
+
+    for (method <- allMethods -- retryMethods) {
+      test(s"$classifier: ignores $method responses") {
+        for (code <- 100 to 599)
+          testClassifier(classifier, method, Return(Status(code)), None)
+      }
+
+      test(s"$classifier: fails $method error") {
+        testClassifier(classifier, method, Throw(new Exception), None)
+      }
+    }
+  }
+
+  {
+    val classifier = ResponseClassifiers.NonRetryableFailures
+    for (method <- allMethods) {
+      test(s"$classifier: ignores $method 1XX-4XX") {
+        for (code <- 100 to 499)
+          testClassifier(classifier, method, Return(Status(code)), None)
+      }
+
+      test(s"$classifier: fails $method 5XX") {
+        for (code <- 500 to 599)
+          testClassifier(
+            classifier,
+            method,
+            Return(Status(code)),
+            Some(ResponseClass.NonRetryableFailure)
+          )
+      }
+
+      test(s"$classifier: fails $method error") {
+        testClassifier(
+          classifier,
+          method,
+          Throw(new Exception),
+          Some(ResponseClass.NonRetryableFailure)
+        )
+      }
+    }
+  }
+
+  for (
+    (kind, init) <- Map(
+      "nonRetryable5XX" -> NonRetryable5XXInitializer,
+      "retryableIdempotent5XX" -> RetryableIdempotent5XXInitializer,
+      "retryableRead5XX" -> RetryableRead5XXInitializer
+    )
+  ) {
+    test(s"loads $kind") {
+      assert(LoadService[ResponseClassifierInitializer]().exists(_.configId == kind))
+    }
+
+    test(s"parse $kind") {
+      val yaml = s"kind: $kind"
+      val mapper = Parser.objectMapper(yaml, Iterable(Seq(init)))
+      assert(mapper.readValue[ResponseClassifierConfig](yaml) != null)
+    }
+  }
+}


### PR DESCRIPTION
By default, finagle treats all non-exceptional responses as a "success".  This
means that, for instance, 5XX http responses do not compute in success rates.
We introduce response classifiers to mark 5XX responses as failures.

Furthermore, we can use response classifiers to mark some failures as retryable
(i.e. depending on the request type). Unfortunately, Finagle doesn't yet honor
response classification when retrying requests.

Initially, response classification can be used simply to inform success rate
calculation. Later (#361), this classification may be used to automatically
retry some class of requests.

This change introduces a protocol-specific base response classifier and, for
http, marks all 5XX responses as failures. A response classifier plugin type is
introduced to allow this logic to be configurable, but this is of marginal
utility until requeues are supported.

Fixes #335