### PR TITLE
Deduplicate entries in streaming responses.

### DIFF
--- a/namerd/core/src/main/scala/io/buoyant/namerd/package.scala
+++ b/namerd/core/src/main/scala/io/buoyant/namerd/package.scala
@@ -1,6 +1,6 @@
 package io.buoyant
 
-import com.twitter.util.{Future, Activity}
+import com.twitter.util._
 
 package object namerd {
   type Ns = String
@@ -8,5 +8,20 @@ package object namerd {
   implicit class RichActivity[T](val activity: Activity[T]) extends AnyVal {
     /** A Future representing the first non-pending value of this Activity */
     def toFuture: Future[T] = activity.values.toFuture.flatMap(Future.const)
+  }
+
+  implicit class RichEvent[T <: AnyRef](val event: Event[T]) extends AnyVal {
+    /** An Event which excludes consecutive duplicate values */
+    def dedup: Event[T] = new Event[T] {
+      override def register(s: Witness[T]): Closable = {
+        var current: T = null.asInstanceOf[T] // scala fails to prove Null <: T for some reason
+        event.respond { t =>
+          if (t != current) {
+            current = t
+            s.notify(t)
+          }
+        }
+      }
+    }
   }
 }

--- a/namerd/core/src/main/scala/io/buoyant/namerd/package.scala
+++ b/namerd/core/src/main/scala/io/buoyant/namerd/package.scala
@@ -1,6 +1,6 @@
 package io.buoyant
 
-import com.twitter.util._
+import com.twitter.util.{Future, Activity}
 
 package object namerd {
   type Ns = String
@@ -8,20 +8,5 @@ package object namerd {
   implicit class RichActivity[T](val activity: Activity[T]) extends AnyVal {
     /** A Future representing the first non-pending value of this Activity */
     def toFuture: Future[T] = activity.values.toFuture.flatMap(Future.const)
-  }
-
-  implicit class RichEvent[T <: AnyRef](val event: Event[T]) extends AnyVal {
-    /** An Event which excludes consecutive duplicate values */
-    def dedup: Event[T] = new Event[T] {
-      override def register(s: Witness[T]): Closable = {
-        var current: T = null.asInstanceOf[T] // scala fails to prove Null <: T for some reason
-        event.respond { t =>
-          if (t != current) {
-            current = t
-            s.notify(t)
-          }
-        }
-      }
-    }
   }
 }

--- a/namerd/iface/control-http/src/main/scala/io/buoyant/namerd/iface/HttpControlService.scala
+++ b/namerd/iface/control-http/src/main/scala/io/buoyant/namerd/iface/HttpControlService.scala
@@ -187,7 +187,7 @@ class HttpControlService(storage: DtabStore, delegate: Ns => NameInterpreter, na
     // calls to writer.write must be flatMapped together to ensure proper ordering and backpressure
     // writeFuture is an accumulator of those flatMapped Futures
     @volatile var writeFuture: Future[Unit] = Future.Unit
-    closable = values.respond {
+    closable = values.dedup.respond {
       case Return(t) =>
         writeFuture = writeFuture.before {
           val buf = render(t)


### PR DESCRIPTION
Problem:
If the underlying Event updates multiple times with the same value, we will print out duplicate entries in streaming responses.

Solution:
Add a `.dedup` method which creates an Event with consecutive duplicates removed.