### PR TITLE
switch /admin/metrics usage from GET to POST

### DIFF
--- a/admin/src/main/resources/io/buoyant/admin/js/metrics_collector.js
+++ b/admin/src/main/resources/io/buoyant/admin/js/metrics_collector.js
@@ -5,16 +5,16 @@
 */
 var MetricsCollector = (function() {
   var generalUpdateUri = "/admin/metrics.json";
-  var metricsUpdateUri = "/admin/metrics?";
+  var metricsUpdateUri = "/admin/metrics";
   var listeners = [];
 
-  function url(listeners, defaultMetrics) {
+  function requestBody(listeners, defaultMetrics) {
     var params = _(listeners)
       .map(function(listener){ return listener.metrics(defaultMetrics); })
       .flatten()
       .uniq()
       .value();
-    return metricsUpdateUri + $.param({ m: params }, true);
+    return $.param({ m: params }, true);
   }
 
   /**
@@ -46,7 +46,9 @@ var MetricsCollector = (function() {
       });
 
       var metricSpecific = $.ajax({
-        url: url(listeners, defaultMetrics),
+        url: metricsUpdateUri,
+        type: "POST",
+        data: requestBody(listeners, defaultMetrics),
         dataType: "json",
         cache: false
       });

--- a/admin/src/main/resources/io/buoyant/admin/js/process_info.js
+++ b/admin/src/main/resources/io/buoyant/admin/js/process_info.js
@@ -44,17 +44,19 @@ var ProcInfo = (function() {
   return function(metricsCollector, $root, t, buildVersion) {
     template = t
     stats[0].value = buildVersion;
-    var url = refreshUri + "?";
 
+    var requestBody = "";
     _.map(stats, function(stat) {
       if (stat.dataKey)
-        url += "&m="+stat.dataKey;
+        requestBody += "&m="+stat.dataKey;
     });
 
     function update() {
       $.ajax({
-        url: url,
+        url: refreshUri,
+        type: "POST",
         dataType: "json",
+        data: requestBody,
         cache: false,
         success: function(data) {
           render($root, data);

--- a/admin/src/main/resources/io/buoyant/admin/js/summary.js
+++ b/admin/src/main/resources/io/buoyant/admin/js/summary.js
@@ -55,8 +55,8 @@ var BigBoard = (function() {
   );
   var metricsParams = [];
 
-  function url() {
-    return "/admin/metrics?" + $.param({m: metricsParams}, true);
+  function requestBody() {
+    return $.param({m: metricsParams}, true);
   }
 
   function clientToMetric(client) {
@@ -101,8 +101,10 @@ var BigBoard = (function() {
 
     function update() {
       $.ajax({
-        url: url(),
+        url: "/admin/metrics",
+        type: "POST",
         dataType: "json",
+        data: requestBody(),
         cache: false,
         success: function(data) {
           _.map(summaryKeys, function(key) {

--- a/admin/src/main/resources/io/buoyant/admin/js/utils.js
+++ b/admin/src/main/resources/io/buoyant/admin/js/utils.js
@@ -175,8 +175,10 @@ UpdateableChart.prototype._resize = function() {
 UpdateableChart.prototype._getMetrics = function() {
   if (this.metrics.length) {
     $.ajax({
-      url: "/admin/metrics?" + $.param({m: this.metrics}, true), //use shallow/traditional encoding
+      url: "/admin/metrics",
+      type: "POST",
       dataType: "json",
+      data: $.param({m: this.metrics}, true), //use shallow/traditional encoding
       cache: false,
       success: (function(data) {
         this.updateMetrics(data);

--- a/admin/src/main/scala/io/buoyant/admin/Admin.scala
+++ b/admin/src/main/scala/io/buoyant/admin/Admin.scala
@@ -29,7 +29,7 @@ class Admin(app: TApp) {
     "/admin/shutdown" -> new ShutdownHandler(app),
     "/admin/tracing" -> new TracingHandler,
     "/admin/logging" -> new LoggingHandler,
-    "/admin/metrics" -> new MetricQueryHandler,
+    "/admin/metrics" -> new MetricsQueryHandler,
     Path.Clients -> new ClientRegistryHandler(Path.Clients),
     Path.Servers -> new ServerRegistryHandler(Path.Servers),
     "/admin/files/" -> ResourceHandler.fromJar(

--- a/admin/src/main/scala/io/buoyant/admin/MetricsQueryHandler.scala
+++ b/admin/src/main/scala/io/buoyant/admin/MetricsQueryHandler.scala
@@ -1,0 +1,14 @@
+package io.buoyant.admin
+
+import com.twitter.finagle.http.{Method, Request, Response}
+import com.twitter.server.handler.MetricQueryHandler
+import com.twitter.util.Future
+
+class MetricsQueryHandler extends MetricQueryHandler {
+  override def apply(req: Request): Future[Response] = {
+    if (req.method == Method.Post) {
+      req.uri = s"/admin/metrics?${req.contentString}"
+    }
+    super.apply(req)
+  }
+}

--- a/linkerd/admin/src/main/scala/io/buoyant/linkerd/admin/SummaryHandler.scala
+++ b/linkerd/admin/src/main/scala/io/buoyant/linkerd/admin/SummaryHandler.scala
@@ -50,7 +50,7 @@ private object SummaryHandler {
     AdminHandler.html(
       content = s"""
         <div class="row text-center">
-          <div id="process-info" data-refresh-uri="/admin/metrics">
+          <div id="process-info">
             <ul class="list-inline topline-stats">
               $statsHtml
             </ul>

--- a/linkerd/admin/src/test/scala/io/buoyant/linkerd/admin/LinkerdAdminTest.scala
+++ b/linkerd/admin/src/test/scala/io/buoyant/linkerd/admin/LinkerdAdminTest.scala
@@ -14,6 +14,7 @@ class BuoyantMainTest extends TwitterServer {
   def main() {}
 }
 
+// TODO: these tests are not getting run
 class LinkerdAdminTest extends FunSuite with Awaits {
 
   test("serves buoyant admin at /")(new BuoyantMainTest {

--- a/linkerd/admin/src/test/scala/io/buoyant/linkerd/admin/MetricsQueryHandlerTest.scala
+++ b/linkerd/admin/src/test/scala/io/buoyant/linkerd/admin/MetricsQueryHandlerTest.scala
@@ -1,0 +1,37 @@
+package io.buoyant.linkerd.admin
+
+import com.twitter.finagle.{Http => FHttp}
+import com.twitter.finagle.http._
+import com.twitter.finagle.{Status => _, _}
+import com.twitter.server.TwitterServer
+import io.buoyant.admin._
+import io.buoyant.test.Awaits
+import java.net.InetSocketAddress
+import org.scalatest.FunSuite
+
+class MetricsMainTest extends TwitterServer {
+  val port = adminHttpServer.boundAddress.asInstanceOf[InetSocketAddress].getPort
+  val client = FHttp.newService(s"localhost:$port")
+
+  def main() {}
+}
+
+class MetricsQueryHandlerTest extends FunSuite with Awaits {
+
+  test("GET request results in 200") {
+    val web = new MetricsQueryHandler()
+    val req = Request()
+    req.uri = s"/admin/metrics"
+    val rsp = await(web(req))
+    assert(rsp.status == Status.Ok)
+  }
+
+  test("POST request results in 200") {
+    val web = new MetricsQueryHandler()
+    val req = Request()
+    req.method = Method.Post
+    req.uri = s"/admin/metrics"
+    val rsp = await(web(req))
+    assert(rsp.status == Status.Ok)
+  }
+}


### PR DESCRIPTION
setting a request body on POST, allowing more metrics params than a GET
query string

fixes #265