### PR TITLE
Make new dashboard default

### DIFF
--- a/admin/src/main/resources/io/buoyant/admin/css/dashboard-shared.css
+++ b/admin/src/main/resources/io/buoyant/admin/css/dashboard-shared.css
@@ -17,10 +17,6 @@
   line-height: 12px;
 }
 
-.metric-large, .metric-small {
-  font-weight: 600;
-}
-
 .success-metric-container {
   border-left: 1px solid #4AD8AC;
 }

--- a/admin/src/main/resources/io/buoyant/admin/css/dashboard.css
+++ b/admin/src/main/resources/io/buoyant/admin/css/dashboard.css
@@ -1,5 +1,6 @@
 body {
   font-family: "Source Sans Pro","Helvetica Neue",sans-serif;
+  font-weight: 400;
   background-image: radial-gradient(54% 23%, #161963 0%, #090B34 97%);
   background-size: cover;
   background-repeat: no-repeat;
@@ -36,18 +37,17 @@ body {
 
 nav {
   font-size: 18px;
-  font-weight: 100;
+  font-weight: 300;
   line-height: 1.1;
 }
 
 .navbar-container {
-  padding: 9px 27px;
+  padding: 20px 27px 9px 27px;
   width: 1215px; /*1161 + 27 + 27 (padding)*/
 }
 
-
 .nav {
-  margin-top: 4px;
+  margin-top: -11px;
 }
 
 .navbar-brand-img img {
@@ -56,6 +56,10 @@ nav {
 
 nav ul.navbar-nav {
   margin-left: 10px;
+}
+
+.navbar-right {
+  margin-top: 3px;
 }
 
 .modal-content {

--- a/admin/src/main/resources/io/buoyant/admin/template/router_client.template
+++ b/admin/src/main/resources/io/buoyant/admin/template/router_client.template
@@ -1,5 +1,5 @@
 <div class="router-header-large">
-  {{client}}
+  /{{client}}
 </div>
 
 <div class="client-metrics row">

--- a/linkerd/admin/src/main/scala/io/buoyant/linkerd/admin/AdminHandler.scala
+++ b/linkerd/admin/src/main/scala/io/buoyant/linkerd/admin/AdminHandler.scala
@@ -29,7 +29,7 @@ object AdminHandler extends HtmlView {
             <li><a href="/metrics">metrics</a></li>
             <li><a href="/admin/logging">logging</a></li>
             <li><a href="https://linkerd.io/help/">help</a></li>
-            <!-- <li><a href="/dashboard">Beta</a></li> -->
+            <li><a href="/legacy-dashboard">legacy dashboard</a></li>
           </ul>
 
           <ul class="nav navbar-nav navbar-right">
@@ -55,7 +55,11 @@ object AdminHandler extends HtmlView {
         </div>
         <div id="navbar" class="collapse navbar-collapse">
           <ul class="nav navbar-nav">
-            <li>router overview</li>
+            <li><a href="/delegator">dtab</a></li>
+            <li><a href="/metrics">metrics</a></li>
+            <li><a href="/admin/logging">logging</a></li>
+            <li><a href="https://linkerd.io/help/">help</a></li>
+            <li><a href="/legacy-dashboard">legacy dashboard</a></li>
           </ul>
           <ul class="nav navbar-nav navbar-right">
             <li>version ${Build.load().version}</li>

--- a/linkerd/admin/src/main/scala/io/buoyant/linkerd/admin/DashboardHandler.scala
+++ b/linkerd/admin/src/main/scala/io/buoyant/linkerd/admin/DashboardHandler.scala
@@ -9,7 +9,7 @@ private[admin] class DashboardHandler extends Service[Request, Response] {
   lazy val html = dashboardHtml
 
   override def apply(req: Request): Future[Response] = req.path match {
-    case "/dashboard" =>
+    case "/" =>
       AdminHandler.mkResponse(html)
     case _ =>
       Future.value(Response(Status.NotFound))

--- a/linkerd/admin/src/main/scala/io/buoyant/linkerd/admin/LinkerdAdmin.scala
+++ b/linkerd/admin/src/main/scala/io/buoyant/linkerd/admin/LinkerdAdmin.scala
@@ -24,8 +24,8 @@ class LinkerdAdmin(app: App, linker: Linker, config: LinkerConfig) extends Admin
 
   private[this] def linkerdAdminRoutes: Seq[(String, Service[Request, Response])] = Seq(
 
-    "/" -> new SummaryHandler(linker),
-    "/dashboard" -> new DashboardHandler,
+    "/" -> new DashboardHandler,
+    "/legacy-dashboard" -> new SummaryHandler(linker),
     "/files/" -> (StaticFilter andThen ResourceHandler.fromDirectoryOrJar(
       baseRequestPath = "/files/",
       baseResourcePath = "io/buoyant/admin",

--- a/linkerd/admin/src/main/scala/io/buoyant/linkerd/admin/SummaryHandler.scala
+++ b/linkerd/admin/src/main/scala/io/buoyant/linkerd/admin/SummaryHandler.scala
@@ -11,7 +11,7 @@ private[admin] class SummaryHandler(linker: Linker) extends Service[Request, Res
   lazy val html = summaryHtml(linker.routers.length)
 
   override def apply(req: Request): Future[Response] = req.path match {
-    case "/" =>
+    case "/legacy-dashboard" =>
       AdminHandler.mkResponse(html)
     case _ =>
       Future.value(Response(Status.NotFound))

--- a/linkerd/admin/src/test/scala/io/buoyant/linkerd/admin/SummaryHandlerTest.scala
+++ b/linkerd/admin/src/test/scala/io/buoyant/linkerd/admin/SummaryHandlerTest.scala
@@ -20,8 +20,8 @@ class SummaryHandlerTest extends FunSuite with Awaits {
   val linker = Linker.Initializers(Seq(TestProtocol.Fancy, TestProtocol.Plain)).load(yaml)
   val handler = new SummaryHandler(linker)
 
-  test("serves ok on /") {
-    val rsp = await(handler(Request("/")))
+  test("serves ok on /legacy-dashboard") {
+    val rsp = await(handler(Request("/legacy-dashboard")))
     assert(rsp.status == Status.Ok)
   }
 
@@ -31,7 +31,7 @@ class SummaryHandlerTest extends FunSuite with Awaits {
   }
 
   test("serves linkerd admin and version") {
-    val rsp = await(handler(Request("/")))
+    val rsp = await(handler(Request("/legacy-dashboard")))
     assert(rsp.contentString.contains("linkerd admin"))
     assert(rsp.contentString.contains(Build.load().version))
   }


### PR DESCRIPTION
* Add navigation to the new dashboard
* Move the old dashboard to /legacy-dashboard, will remove code in a follow-up branch.

I'm not sure "router overview" is what we want that first nav to say, but leaving for now.