### PR TITLE
add a debugTrace to tracer configs

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,5 +1,8 @@
 ## x.x.x
 
+* Add a `debugTrace` parameter to the `tracers` config section, which enables
+  printing all traces to the console.
+
 ## 0.4.0
 
 * Add a `bindingTimeoutMs` router parameter to configure the maximum amount of

--- a/linkerd/core/src/main/scala/io/buoyant/linkerd/TracerInitializer.scala
+++ b/linkerd/core/src/main/scala/io/buoyant/linkerd/TracerInitializer.scala
@@ -1,13 +1,21 @@
 package io.buoyant.linkerd
 
 import com.fasterxml.jackson.annotation.JsonAutoDetect.Visibility
-import com.fasterxml.jackson.annotation.{JsonAutoDetect, JsonIgnore, JsonTypeInfo}
-import com.twitter.finagle.tracing.Tracer
+import com.fasterxml.jackson.annotation.{JsonAutoDetect, JsonIgnore, JsonProperty, JsonTypeInfo}
+import com.twitter.finagle.tracing.{debugTrace => fDebugTrace, Tracer}
 import io.buoyant.config.ConfigInitializer
 
 @JsonTypeInfo(use = JsonTypeInfo.Id.NAME, include = JsonTypeInfo.As.PROPERTY, property = "kind")
 @JsonAutoDetect(fieldVisibility = Visibility.ANY)
 trait TracerConfig {
+
+  @JsonProperty("debugTrace")
+  var _debugTrace: Option[Boolean] = None
+
+  // default to {com.twitter.finagle.tracing.debugTrace} if not set
+  @JsonIgnore
+  def debugTrace: Boolean = _debugTrace.getOrElse(fDebugTrace())
+
   /**
    * Construct a tracer.
    */

--- a/linkerd/core/src/test/scala/io/buoyant/linkerd/LinkerTest.scala
+++ b/linkerd/core/src/test/scala/io/buoyant/linkerd/LinkerTest.scala
@@ -9,6 +9,8 @@ import io.buoyant.namer.{NamerInitializer, ConflictingNamerInitializer, TestName
 import java.net.{InetAddress, InetSocketAddress}
 import org.scalatest.FunSuite
 
+import com.twitter.finagle.tracing.{debugTrace => fDebugTrace}
+
 class LinkerTest extends FunSuite {
 
   def initializer(
@@ -179,6 +181,7 @@ class LinkerTest extends FunSuite {
     val yaml =
       """|tracers:
          |- kind: test
+         |  debugTrace: true
          |routers:
          |- protocol: plain
          |  servers:
@@ -188,12 +191,14 @@ class LinkerTest extends FunSuite {
     val param.Tracer(tracer) = linker.routers.head.params[param.Tracer]
     assert(tracer != DefaultTracer)
     assert(linker.tracer != DefaultTracer)
+    assert(fDebugTrace())
   }
 
   test("with namers & tracers") {
     val yaml =
       """|tracers:
          |- kind: test
+         |  debugTrace: true
          |namers:
          |- kind: test
          |routers:
@@ -213,6 +218,7 @@ class LinkerTest extends FunSuite {
     val param.Tracer(tracer) = linker.routers.head.params[param.Tracer]
     assert(tracer.isInstanceOf[TestTracer])
     assert(linker.tracer.isInstanceOf[TestTracer])
+    assert(fDebugTrace())
   }
 
   test("with admin") {

--- a/linkerd/docs/config.md
+++ b/linkerd/docs/config.md
@@ -414,6 +414,9 @@ configuring tracers via a top-level `tracers` section:
 
 * *tracers* --
   * *kind* -- One of the supported tracers, by fully-qualified class name.
+  * *debugTrace* -- Print all traces to the console. Note this overrides the
+    global `-com.twitter.finagle.tracing.debugTrace` flag, and will default to
+    that flag if not set here.
   * Any options specific to the tracer
 
 Current tracers include:
@@ -434,6 +437,7 @@ tracers:
   host: localhost
   port: 9410
   sampleRate: 0.02
+  debugTrace: true
 ```
 
 <a name="naming"></a>

--- a/linkerd/examples/acceptance-test.yaml
+++ b/linkerd/examples/acceptance-test.yaml
@@ -8,6 +8,7 @@ tracers:
   host: zipkincollector
   port: 9410
   sampleRate: 0.02
+  debugTrace: true
 
 namers:
 - kind: io.l5d.fs

--- a/linkerd/tracer/zipkin/src/test/scala/io/l5d/ZipkinTest.scala
+++ b/linkerd/tracer/zipkin/src/test/scala/io/l5d/ZipkinTest.scala
@@ -22,6 +22,7 @@ class ZipkinTest extends FunSuite {
                   |host: foo
                   |port: 1234
                   |sampleRate: 0.5
+                  |debugTrace: true
       """.stripMargin
 
     val mapper = Parser.objectMapper(yaml, Iterable(Seq(ZipkinTracerInitializer)))
@@ -29,5 +30,6 @@ class ZipkinTest extends FunSuite {
     assert(zipkin.host == Some("foo"))
     assert(zipkin.port == Some(1234))
     assert(zipkin.sampleRate == Some(0.5))
+    assert(zipkin.debugTrace == true)
   }
 }


### PR DESCRIPTION
this overrides finagle's com.twitter.finagle.tracing.debugTrace flag
fixes #144