### PR TITLE
Fix etcd event observation

### DIFF
--- a/etcd/src/test/scala/io/buoyant/etcd/KeyTest.scala
+++ b/etcd/src/test/scala/io/buoyant/etcd/KeyTest.scala
@@ -409,8 +409,8 @@ class KeyTest extends FunSuite with ParallelTestExecution {
     val key = mkKey(base) {
       case (Method.Get, Watch(true, None)) if currentIndex < responses.length =>
         val idx = currentIndex.toInt
-        requested(idx.toInt).setDone()
-        responses(idx.toInt)
+        requested(idx).setDone()
+        responses(idx)
 
       case (Method.Get, Watch(true, Some(idx))) if idx < responses.length =>
         requested(idx.toInt).setDone()


### PR DESCRIPTION
Before, event observation used the maximum modifiedIndex from the returned
set of nodes. There are no guarantees that this index is anywhere near current,
and so the watch could replay the history of updates or fail with an unknown
index.

By using etcd index (as returned in the header), we can ensure we're watching
from a recent index.