### PR TITLE
retry application failures in linkerd

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -7,6 +7,8 @@
   are marked as failures.
 * Add a `retries` client config section supporting configurable retry
   budgets and backoffs.
+* Automatically retry certain types of failures, as determined by
+  response classifiers.
 
 ## 0.4.0
 

--- a/linkerd/docs/config.md
+++ b/linkerd/docs/config.md
@@ -174,6 +174,12 @@ maintain to each destination host.  It must be an object containing keys:
   * *maxWaiters* -- Optional.  The maximum number of connection requests that
   are queued when the connection concurrency exceeds maxSize.  (default:
   Int.MaxValue)
+* *responseClassifier* -- Optional. A (sometimes protocol-specific)
+  module that determines which responses should be considered failures
+  and, of those, which should be considered [retryable](#retries). By
+  default, connection-level errors are considered failures and those
+  where the request has not been written are considered retryable.
+  * *kind* -- Indicates the response classifier moduel
 
 #### TLS
 
@@ -273,7 +279,7 @@ aperture supports the following options (see [here][aperture] for option semanti
 
 heap does not support any options.
 
-
+<a name="retries"></a>
 #### Retries
 
 linkerd can automatically retry requests on certain failures (for
@@ -364,6 +370,29 @@ and HTTP/1.1 logical names are of the form:
 
 In both cases, `uri` is only considered a part
 of the logical name if the config option `httpUriInDst` is true.
+
+
+#### HTTP Response Classifiers
+
+Response classifiers determine which HTTP responses are considered to
+be failures (for the purposes of success rate calculation) and which
+of these responses may be [retried](#retries). By default, the
+_nonRetryable5XX_ classifier is used.
+
+##### nonRetryable5XX
+
+All 5XX responses are considered to be failures and none of these
+requests are considered to be retryable.
+
+##### retryableRead5XX
+
+All 5XX responses are considered to be failures. However, `GET`,
+`HEAD`, `OPTIONS`, and `TRACE` requests may be retried automatically.
+
+##### retryableIdempotent5XX
+
+Like _retryableRead5XX_, but `PUT` and `DELETE` requests may also be
+retried.
 
 <a name="protocol-thrift"></a>
 ### Thrift protocol parameters

--- a/linkerd/protocol/http/src/e2e/scala/io/buoyant/linkerd/protocol/HttpEndToEndTest.scala
+++ b/linkerd/protocol/http/src/e2e/scala/io/buoyant/linkerd/protocol/HttpEndToEndTest.scala
@@ -262,6 +262,8 @@ class HttpEndToEndTest extends FunSuite with Awaits {
         assert(stats.counters.get(Seq("http", "dst", "id", label, "success")) == Some(1))
         assert(stats.counters.get(Seq("http", "dst", "id", label, "failures")) == Some(1))
         assert(stats.counters.get(Seq("http", "dst", "id", label, "retries", "requeues")) == Some(1))
+        assert(stats.counters.get(Seq("http", "dst", "id", label, "status", "200")) == Some(1))
+        assert(stats.counters.get(Seq("http", "dst", "id", label, "status", "500")) == Some(1))
       }
 
       // non-retryable request, fails and is not retried
@@ -279,7 +281,8 @@ class HttpEndToEndTest extends FunSuite with Awaits {
         assert(stats.counters.get(Seq("http", "dst", "id", label, "requests")) == Some(1))
         assert(stats.counters.get(Seq("http", "dst", "id", label, "success")) == None)
         assert(stats.counters.get(Seq("http", "dst", "id", label, "failures")) == Some(1))
-        assert(stats.counters.get(Seq("http", "dst", "id", label, "retries", "requeues")) == None)
+        assert(stats.counters.get(Seq("http", "dst", "id", label, "status", "200")) == None)
+        assert(stats.counters.get(Seq("http", "dst", "id", label, "status", "500")) == Some(1))
       }
     } finally {
       await(client.close())

--- a/router/core/src/main/scala/com/twitter/finagle/buoyant/XXX_ClassifiedRequeueFilter.scala
+++ b/router/core/src/main/scala/com/twitter/finagle/buoyant/XXX_ClassifiedRequeueFilter.scala
@@ -1,0 +1,183 @@
+package com.twitter.finagle.buoyant
+
+import com.twitter.finagle._
+import com.twitter.finagle.param.HighResTimer
+import com.twitter.finagle.service._
+import com.twitter.finagle.stats.{Counter, StatsReceiver}
+import com.twitter.util._
+
+/*
+ * Copied from com.twitter.finagle.service.RequeueFilter
+ * [https://github.com/twitter/finagle/pull/504].
+ * 
+ * XXX remove once the Pull Request is merged & released.
+ */
+object XXX_ClassifierRequeueFilter {
+  def module[Req, Rep]: Stackable[ServiceFactory[Req, Rep]] =
+    new Stack.Module4[param.Stats, Retries.Budget, param.ResponseClassifier, param.HighResTimer, ServiceFactory[Req, Rep]] {
+      def role: Stack.Role = Retries.Role
+
+      def description: String =
+        "Retries requests, at the service application level, that have been rejected"
+
+      def make(
+        statsP: param.Stats,
+        budgetP: Retries.Budget,
+        classifierP: param.ResponseClassifier,
+        timerP: param.HighResTimer,
+        next: ServiceFactory[Req, Rep]
+      ): ServiceFactory[Req, Rep] = {
+        val statsRecv = statsP.statsReceiver
+        val scoped = statsRecv.scope("retries")
+        val requeues = scoped.counter("requeues")
+        val retryBudget = budgetP.retryBudget
+        val param.ResponseClassifier(classifier) = classifierP
+        val timer = timerP.timer
+
+        val filter = newRequeueFilter[Req, Rep](
+          retryBudget,
+          budgetP.requeueBackoffs,
+          scoped,
+          () => next.status == Status.Open,
+          MaxRequeuesPerReq,
+          timer,
+          classifier
+        )
+        svcFactory(retryBudget, filter, scoped, requeues, next)
+      }
+    }
+
+  // The upper bound on service acquisition attempts
+  private[this] val Effort = 25
+
+  // semi-arbitrary, but we don't want requeues to eat the entire budget
+  private[this] val MaxRequeuesPerReq = 0.2
+
+  private[this] def svcFactory[Req, Rep](
+    retryBudget: RetryBudget,
+    filters: Filter[Req, Rep, Req, Rep],
+    statsReceiver: StatsReceiver,
+    requeuesCounter: Counter,
+    next: ServiceFactory[Req, Rep]
+  ): ServiceFactory[Req, Rep] = {
+    new ServiceFactoryProxy(next) {
+      // We define the gauge inside of the ServiceFactory so that their lifetimes
+      // are tied together.
+      private[this] val budgetGauge =
+        statsReceiver.addGauge("budget") { retryBudget.balance }
+      private[this] val notOpenCounter =
+        statsReceiver.counter("not_open")
+
+      private[this] val serviceFn: Service[Req, Rep] => Service[Req, Rep] =
+        service => filters.andThen(service)
+
+      /**
+       * Failures to acquire a service can be thought of as local failures because
+       * we're certain that we haven't dispatched a request yet. Thus, this simply
+       * tries up to `n` attempts to acquire a service. However, we still only
+       * requeue a subset of exceptions (currently only `RetryableWriteExceptions`) as
+       * some exceptions to acquire a service are considered fatal.
+       */
+      private[this] def applySelf(conn: ClientConnection, n: Int): Future[Service[Req, Rep]] =
+        self(conn).rescue {
+          case e@RetryPolicy.RetryableWriteException(_) if n > 0 =>
+            if (status == Status.Open) {
+              requeuesCounter.incr()
+              applySelf(conn, n - 1)
+            } else {
+              notOpenCounter.incr()
+              Future.exception(e)
+            }
+        }
+
+      override def apply(conn: ClientConnection): Future[Service[Req, Rep]] =
+        applySelf(conn, Effort).map(serviceFn)
+
+      override def close(deadline: Time): Future[Unit] = {
+        budgetGauge.remove()
+        self.close(deadline)
+      }
+
+    }
+  }
+
+  def newRequeueFilter[Req, Rep](
+    retryBudget: RetryBudget,
+    retryBackoffs: Stream[Duration],
+    statsReceiver: StatsReceiver,
+    canRetry: () => Boolean,
+    maxRetriesPerReq: Double,
+    timer: Timer,
+    classifier: ResponseClassifier = PartialFunction.empty
+  ) = new SimpleFilter[Req, Rep] {
+    require(
+      maxRetriesPerReq >= 0,
+      s"maxRetriesPerReq must be non-negative: $maxRetriesPerReq"
+    )
+
+    private[this] val requeueCounter = statsReceiver.counter("requeues")
+    private[this] val budgetExhaustCounter = statsReceiver.counter("budget_exhausted")
+    private[this] val requestLimitCounter = statsReceiver.counter("request_limit")
+    private[this] val requeueStat = statsReceiver.stat("requeues_per_request")
+    private[this] val canNotRetryCounter = statsReceiver.counter("cannot_retry")
+
+    private[this] def responseFuture(
+      attempt: Int,
+      t: Try[Rep]
+    ): Future[Rep] = {
+      requeueStat.add(attempt)
+      Future.const(t)
+    }
+
+    private[this] def applyService(
+      req: Req,
+      service: Service[Req, Rep],
+      attempt: Int,
+      retriesRemaining: Int,
+      backoffs: Stream[Duration]
+    ): Future[Rep] = {
+      service(req).transform { result =>
+        classifier.applyOrElse(ReqRep(req, result), ResponseClassifier.Default) match {
+          case ResponseClass.RetryableFailure =>
+            if (!canRetry()) {
+              canNotRetryCounter.incr()
+              responseFuture(attempt, result)
+            } else if (retriesRemaining > 0 && retryBudget.tryWithdraw()) {
+              backoffs match {
+                case Duration.Zero #:: rest =>
+                  // no delay between retries. Retry immediately.
+                  requeueCounter.incr()
+                  applyService(req, service, attempt + 1, retriesRemaining - 1, rest)
+                case delay #:: rest =>
+                  // Delay and then retry.
+                  timer.doLater(delay) {
+                    requeueCounter.incr()
+                    applyService(req, service, attempt + 1, retriesRemaining - 1, rest)
+                  }.flatten
+                case _ =>
+                  // Schedule has run out of entries. Budget is empty.
+                  budgetExhaustCounter.incr()
+                  responseFuture(attempt, result)
+              }
+            } else {
+              if (retriesRemaining > 0)
+                budgetExhaustCounter.incr()
+              else
+                requestLimitCounter.incr()
+              responseFuture(attempt, result)
+            }
+
+          case _ =>
+            responseFuture(attempt, result)
+        }
+      }
+    }
+
+    def apply(req: Req, service: Service[Req, Rep]): Future[Rep] = {
+      retryBudget.deposit()
+      val maxRetries = Math.ceil(maxRetriesPerReq * retryBudget.balance).toInt
+      applyService(req, service, 0, maxRetries, retryBackoffs)
+    }
+  }
+
+}

--- a/router/core/src/main/scala/io/buoyant/router/Router.scala
+++ b/router/core/src/main/scala/io/buoyant/router/Router.scala
@@ -4,7 +4,7 @@ import com.twitter.finagle._
 import com.twitter.finagle.buoyant._
 import com.twitter.finagle.client._
 import com.twitter.finagle.server.StackServer
-import com.twitter.finagle.service.FailFastFactory
+import com.twitter.finagle.service.{FailFastFactory, Retries}
 import com.twitter.finagle.stack.Endpoint
 import com.twitter.finagle.stats.DefaultStatsReceiver
 
@@ -254,7 +254,8 @@ object StackRouter {
      * may avail itself of any and all params to set TLS params.
      */
     def mkStack[Req, Rsp](orig: Stack[ServiceFactory[Req, Rsp]]): Stack[ServiceFactory[Req, Rsp]] =
-      orig ++ (TlsClientPrep.nop[Req, Rsp] +: stack.nilStack)
+      (orig ++ (TlsClientPrep.nop[Req, Rsp] +: stack.nilStack))
+        .replace(Retries.Role, XXX_ClassifierRequeueFilter.module[Req, Rsp])
   }
 
   def newPathStack[Req, Rsp]: Stack[ServiceFactory[Req, Rsp]] = {


### PR DESCRIPTION
When certain requests fail, we should be able to retry them automatically.  _ResponseClassifiers_ determine whether a request-response pair should be considered a retryable failure. Once we are able to [configure how responses are clarified](https://github.com/BuoyantIO/linkerd/pull/339), we need to [change requeing logic](https://github.com/twitter/finagle/pull/504) to take these failure classifications into account.

I have temporarily copied finagle's RequeueFilter, and its associated stack module, verbatim so that we can take advantage of this functionality before finagle's next release. Once finagle absorbs this functionality, we can remove the duplicated logic from linkerd.

Fixes #361 