### PR TITLE
Add support for router-wide retry configuration

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -5,6 +5,8 @@
 * Add etcd backed dtab storage.
 * Introduce a default HTTP response classifier so that 5XX responses
   are marked as failures.
+* Add a `retries` client config section supporting configurable retry
+  budgets and backoffs.
 
 ## 0.4.0
 

--- a/linkerd/core/src/main/scala/io/buoyant/linkerd/Router.scala
+++ b/linkerd/core/src/main/scala/io/buoyant/linkerd/Router.scala
@@ -222,12 +222,23 @@ trait BackoffConfig {
 }
 
 case class ConstantBackoffConfig(ms: Int) extends BackoffConfig {
+  // ms defaults to 0 when not specified
   def mk = Backoff.constant(ms.millis)
 }
 
 /** See http://www.awsarchitectureblog.com/2015/03/backoff.html */
-case class JitteredBackoffConfig(minMs: Int, maxMs: Int) extends BackoffConfig {
-  def mk = Backoff.decorrelatedJittered(minMs.millis, maxMs.millis)
+case class JitteredBackoffConfig(minMs: Option[Int], maxMs: Option[Int]) extends BackoffConfig {
+  def mk = {
+    val min = minMs match {
+      case Some(ms) => ms.millis
+      case None => throw new IllegalArgumentException("'minMs' must be specified")
+    }
+    val max = maxMs match {
+      case Some(ms) => ms.millis
+      case None => throw new IllegalArgumentException("'maxMs' must be specified")
+    }
+    Backoff.decorrelatedJittered(min, max)
+  }
 }
 
 case class RetryBudgetConfig(

--- a/linkerd/core/src/main/scala/io/buoyant/linkerd/Router.scala
+++ b/linkerd/core/src/main/scala/io/buoyant/linkerd/Router.scala
@@ -1,13 +1,13 @@
 package io.buoyant.linkerd
 
-import com.fasterxml.jackson.annotation.{JsonIgnore, JsonProperty, JsonTypeInfo}
+import com.fasterxml.jackson.annotation.{JsonIgnore, JsonProperty, JsonTypeInfo, JsonSubTypes}
 import com.fasterxml.jackson.core.{io => _}
 import com.twitter.conversions.time._
 import com.twitter.finagle._
 import com.twitter.finagle.buoyant.DstBindingFactory
 import com.twitter.finagle.client.DefaultPool
-import com.twitter.finagle.service.{FailFastFactory, ResponseClassifier, TimeoutFilter}
-import com.twitter.util.Closable
+import com.twitter.finagle.service._
+import com.twitter.util.{Closable, Duration}
 import io.buoyant.namer.{InterpreterConfig, DefaultInterpreterConfig}
 import io.buoyant.router.RoutingFactory
 
@@ -187,11 +187,59 @@ class ClientConfig {
   var tls: Option[TlsClientConfig] = None
   var loadBalancer: Option[LoadBalancerConfig] = None
   var hostConnectionPool: Option[HostConnectionPool] = None
+  var retries: Option[RetriesConfig] = None
 
   @JsonIgnore
   def clientParams: Stack.Params = Stack.Params.empty
     .maybeWith(loadBalancer.map(_.clientParams))
     .maybeWith(hostConnectionPool.map(_.param))
+    .maybeWith(retries.map(_.mk))
+}
+
+case class RetriesConfig(
+  backoff: Option[BackoffConfig] = None,
+  budget: Option[RetryBudgetConfig] = None
+) {
+
+  @JsonIgnore
+  def mk: Retries.Budget = Retries.Budget(
+    budget.map(_.mk).getOrElse(RetryBudget()),
+    backoff.map(_.mk).getOrElse(Backoff.const(Duration.Zero))
+  )
+}
+
+@JsonTypeInfo(
+  use = JsonTypeInfo.Id.NAME,
+  include = JsonTypeInfo.As.PROPERTY, property = "kind"
+)
+@JsonSubTypes(Array(
+  new JsonSubTypes.Type(value = classOf[ConstantBackoffConfig], name = "constant"),
+  new JsonSubTypes.Type(value = classOf[JitteredBackoffConfig], name = "jittered")
+))
+trait BackoffConfig {
+  @JsonIgnore
+  def mk: Stream[Duration]
+}
+
+case class ConstantBackoffConfig(ms: Int) extends BackoffConfig {
+  def mk = Backoff.constant(ms.millis)
+}
+
+/** See http://www.awsarchitectureblog.com/2015/03/backoff.html */
+case class JitteredBackoffConfig(minMs: Int, maxMs: Int) extends BackoffConfig {
+  def mk = Backoff.decorrelatedJittered(minMs.millis, maxMs.millis)
+}
+
+case class RetryBudgetConfig(
+  ttlSecs: Option[Int],
+  minRetriesPerSec: Option[Int],
+  percentCanRetry: Option[Double]
+) {
+  @JsonIgnore
+  def mk: RetryBudget = {
+    val ttl = ttlSecs.map(_.seconds).getOrElse(10.seconds)
+    RetryBudget(ttl, minRetriesPerSec.getOrElse(10), percentCanRetry.getOrElse(0.2))
+  }
 }
 
 case class HostConnectionPool(

--- a/linkerd/core/src/test/scala/io/buoyant/linkerd/RetriesConfigTest.scala
+++ b/linkerd/core/src/test/scala/io/buoyant/linkerd/RetriesConfigTest.scala
@@ -34,6 +34,15 @@ class RetriesConfigTest extends FunSuite {
     assert(parse(yaml) == RetriesConfig(Some(JitteredBackoffConfig(30, 6000)), None))
   }
 
+  test("jittered backoff: no min") {
+    val yaml =
+      s"""|backoff:
+          |  kind: jittered
+          |  maxMs: 6000
+          |""".stripMargin
+    assert(parse(yaml) == RetriesConfig(Some(JitteredBackoffConfig(0, 6000)), None))
+  }
+
   test("budget") {
     val yaml =
       s"""|budget:

--- a/linkerd/core/src/test/scala/io/buoyant/linkerd/RetriesConfigTest.scala
+++ b/linkerd/core/src/test/scala/io/buoyant/linkerd/RetriesConfigTest.scala
@@ -1,0 +1,48 @@
+package io.buoyant.linkerd
+
+import com.twitter.finagle.service.Retries
+import io.buoyant.config.Parser
+import org.scalatest.FunSuite
+
+class RetriesConfigTest extends FunSuite {
+
+  def parse(yaml: String): RetriesConfig = {
+    val mapper = Parser.objectMapper(yaml, Nil)
+    mapper.readValue[RetriesConfig](yaml)
+  }
+
+  test("empty") {
+    assert(parse("{}") == RetriesConfig(None, None))
+  }
+
+  test("constant backoff") {
+    val yaml =
+      s"""|backoff:
+          |  kind: constant
+          |  ms: 30
+          |""".stripMargin
+    assert(parse(yaml) == RetriesConfig(Some(ConstantBackoffConfig(30)), None))
+  }
+
+  test("jittered backoff") {
+    val yaml =
+      s"""|backoff:
+          |  kind: jittered
+          |  minMs: 30
+          |  maxMs: 6000
+          |""".stripMargin
+    assert(parse(yaml) == RetriesConfig(Some(JitteredBackoffConfig(30, 6000)), None))
+  }
+
+  test("budget") {
+    val yaml =
+      s"""|budget:
+          |  ttlSecs: 12
+          |  minRetriesPerSec: 20
+          |  percentCanRetry: 0.33
+          |""".stripMargin
+    assert(parse(yaml) ==
+      RetriesConfig(None, Some(RetryBudgetConfig(Some(12), Some(20), Some(0.33)))))
+  }
+
+}

--- a/linkerd/core/src/test/scala/io/buoyant/linkerd/RouterTest.scala
+++ b/linkerd/core/src/test/scala/io/buoyant/linkerd/RouterTest.scala
@@ -1,7 +1,7 @@
 package io.buoyant.linkerd
 
-import com.twitter.finagle.buoyant.DstBindingFactory
 import com.twitter.finagle.{Dtab, Stack}
+import com.twitter.finagle.buoyant.DstBindingFactory
 import io.buoyant.config.Parser
 import io.buoyant.namer.{ConfiguredNamersInterpreter, InterpreterInitializer, TestInterpreterInitializer, TestInterpreter}
 import io.buoyant.router.RoutingFactory
@@ -95,5 +95,22 @@ servers:
     val router = parse(yaml, Stack.Params.empty)
     val DstBindingFactory.Namer(interpreter) = router.params[DstBindingFactory.Namer]
     assert(interpreter.isInstanceOf[TestInterpreter])
+  }
+
+  test("with retries") {
+    val yaml =
+      """|protocol: plain
+         |client:
+         |  retries:
+         |    backoff:
+         |      kind: jittered
+         |      minMs: 100
+         |      maxMs: 10000
+         |    budget:
+         |      ttlSecs: 30
+         |      minRetriesPerSec: 3
+         |      percentCanRetry: 0.33
+         |""".stripMargin
+    assert(parse(yaml, Stack.Params.empty) != null)
   }
 }

--- a/linkerd/core/src/test/scala/io/buoyant/linkerd/RouterTest.scala
+++ b/linkerd/core/src/test/scala/io/buoyant/linkerd/RouterTest.scala
@@ -11,14 +11,20 @@ import org.scalatest.FunSuite
 
 class RouterTest extends FunSuite with Exceptions {
 
+  def parseConfig(
+    yaml: String,
+    protos: Seq[ProtocolInitializer] = Seq(TestProtocol.Plain, TestProtocol.Fancy),
+    interpreters: Seq[InterpreterInitializer] = Seq(TestInterpreterInitializer)
+  ): RouterConfig =
+    Parser.objectMapper(yaml, Iterable(protos, interpreters)).readValue[RouterConfig](yaml)
+
   def parse(
     yaml: String,
     params: Stack.Params = Stack.Params.empty,
     protos: Seq[ProtocolInitializer] = Seq(TestProtocol.Plain, TestProtocol.Fancy),
     interpreters: Seq[InterpreterInitializer] = Seq(TestInterpreterInitializer)
   ): Router = {
-    val mapper = Parser.objectMapper(yaml, Iterable(protos, interpreters))
-    val cfg = mapper.readValue[RouterConfig](yaml)
+    val cfg = parseConfig(yaml, protos, interpreters)
     val interpreter = cfg.interpreter.newInterpreter(cfg.routerParams)
     cfg.router(params + DstBindingFactory.Namer(interpreter))
   }
@@ -104,13 +110,15 @@ servers:
          |  retries:
          |    backoff:
          |      kind: jittered
-         |      minMs: 100
          |      maxMs: 10000
          |    budget:
          |      ttlSecs: 30
          |      minRetriesPerSec: 3
          |      percentCanRetry: 0.33
          |""".stripMargin
-    assert(parse(yaml, Stack.Params.empty) != null)
+    assert(parseConfig(yaml).client.flatMap(_.retries) == Some(RetriesConfig(
+      Some(JitteredBackoffConfig(0, 10000)),
+      Some(RetryBudgetConfig(Some(30), Some(3), Some(0.33)))
+    )))
   }
 }

--- a/linkerd/core/src/test/scala/io/buoyant/linkerd/RouterTest.scala
+++ b/linkerd/core/src/test/scala/io/buoyant/linkerd/RouterTest.scala
@@ -117,7 +117,7 @@ servers:
          |      percentCanRetry: 0.33
          |""".stripMargin
     assert(parseConfig(yaml).client.flatMap(_.retries) == Some(RetriesConfig(
-      Some(JitteredBackoffConfig(0, 10000)),
+      Some(JitteredBackoffConfig(None, Some(10000))),
       Some(RetryBudgetConfig(Some(30), Some(3), Some(0.33)))
     )))
   }

--- a/linkerd/core/src/test/scala/io/buoyant/linkerd/RouterTest.scala
+++ b/linkerd/core/src/test/scala/io/buoyant/linkerd/RouterTest.scala
@@ -110,14 +110,15 @@ servers:
          |  retries:
          |    backoff:
          |      kind: jittered
-         |      maxMs: 10000
+         |      minMs: 1
+         |      maxMs: 1000
          |    budget:
          |      ttlSecs: 30
          |      minRetriesPerSec: 3
          |      percentCanRetry: 0.33
          |""".stripMargin
     assert(parseConfig(yaml).client.flatMap(_.retries) == Some(RetriesConfig(
-      Some(JitteredBackoffConfig(None, Some(10000))),
+      Some(JitteredBackoffConfig(Some(1), Some(1000))),
       Some(RetryBudgetConfig(Some(30), Some(3), Some(0.33)))
     )))
   }

--- a/linkerd/docs/config.md
+++ b/linkerd/docs/config.md
@@ -307,11 +307,9 @@ The _constant_ backoff policy takes a single configuration parameter:
 
 The _jittered_ backoff policy uses a
 [decorrelated jitter](http://www.awsarchitectureblog.com/2015/03/backoff.html)
-backoff algorithm and accepts two configuration parameters:
-* _minMs_ -- Optional. The minimum number of milliseconds to wait
-  before each retry. (Default: 0)
-* _maxMs_ -- The maximum number of milliseconds to wait before each
-  retry.
+backoff algorithm and requires two configuration parameters:
+* _minMs_ -- The minimum number of milliseconds to wait before each retry.
+* _maxMs_ -- The maximum number of milliseconds to wait before each retry.
 
 <a name="protocol-http"></a>
 ### HTTP/1.1 protocol parameters

--- a/linkerd/docs/config.md
+++ b/linkerd/docs/config.md
@@ -273,6 +273,46 @@ aperture supports the following options (see [here][aperture] for option semanti
 
 heap does not support any options.
 
+
+#### Retries
+
+linkerd can automatically retry requests on certain failures (for
+example, connection errors).
+
+* *retries* -- Optional. A retry policy for all clients created by
+  this router.
+  * *budget* -- Optional. Determines _how many_ failed requests are
+    eligible to be retried.
+    * *minRetriesPerSec* -- Optional. The minimum rate of retries
+      allowed in order to accommodate clients that have just started
+      issuing requests as well as clients that do not issue many
+      requests per window. Must be non-negative and if `0`, then no
+      reserve is given. (Default: 10)
+    * *percentCanRetry* -- Optional. The percentage of calls that can
+      be retried. This is in addition to any retries allowed for via
+      `minRetriesPerSec`.  Must be >= 0 and <= 1000. As an example, if
+      `0.1` is used, then for every 10 successful calls , 1 retry will
+      be allowed. If `2.0` is used then every success, 2
+      retries. (Default: 0.2)
+    * *ttlSecs* -- Optional. The amount of time in seconds that
+      successful calls are considered when calculating retry budgets
+      (Default: 10)
+  * *backoff* -- Optional. Determines which backoff algorithm should
+    be used (see below).
+    * *kind* -- The name of a backoff algorithm. Either _constant_ or
+      _jittered_.
+
+The _constant_ backoff policy takes a single configuration parameter:
+* _ms_ -- The number of milliseconds to wait before each retry.
+
+The _jittered_ backoff policy uses a
+[decorrelated jitter](http://www.awsarchitectureblog.com/2015/03/backoff.html)
+backoff algorithm and requires takes two configuration parameters:
+* _minMs_ -- Optional. The minimum number of milliseconds to wait
+  before each retry.
+* _maxMs_ -- The maximum number of milliseconds to wait before each
+  retry.
+
 <a name="protocol-http"></a>
 ### HTTP/1.1 protocol parameters
 

--- a/linkerd/docs/config.md
+++ b/linkerd/docs/config.md
@@ -307,9 +307,9 @@ The _constant_ backoff policy takes a single configuration parameter:
 
 The _jittered_ backoff policy uses a
 [decorrelated jitter](http://www.awsarchitectureblog.com/2015/03/backoff.html)
-backoff algorithm and takes two configuration parameters:
+backoff algorithm and accepts two configuration parameters:
 * _minMs_ -- Optional. The minimum number of milliseconds to wait
-  before each retry.
+  before each retry. (Default: 0)
 * _maxMs_ -- The maximum number of milliseconds to wait before each
   retry.
 

--- a/linkerd/docs/config.md
+++ b/linkerd/docs/config.md
@@ -291,8 +291,8 @@ example, connection errors).
     * *percentCanRetry* -- Optional. The percentage of calls that can
       be retried. This is in addition to any retries allowed for via
       `minRetriesPerSec`.  Must be >= 0 and <= 1000. As an example, if
-      `0.1` is used, then for every 10 successful calls , 1 retry will
-      be allowed. If `2.0` is used then every success, 2
+      `0.1` is used, then for every 10 non-retry calls , 1 retry will
+      be allowed. If `2.0` is used then every non-retry call, 2
       retries. (Default: 0.2)
     * *ttlSecs* -- Optional. The amount of time in seconds that
       successful calls are considered when calculating retry budgets

--- a/linkerd/docs/config.md
+++ b/linkerd/docs/config.md
@@ -292,8 +292,8 @@ example, connection errors).
       be retried. This is in addition to any retries allowed for via
       `minRetriesPerSec`.  Must be >= 0 and <= 1000. As an example, if
       `0.1` is used, then for every 10 non-retry calls , 1 retry will
-      be allowed. If `2.0` is used then every non-retry call, 2
-      retries. (Default: 0.2)
+      be allowed. If `2.0` is used then every non-retry call will
+      allow 2 retries. (Default: 0.2)
     * *ttlSecs* -- Optional. The amount of time in seconds that
       successful calls are considered when calculating retry budgets
       (Default: 10)
@@ -307,7 +307,7 @@ The _constant_ backoff policy takes a single configuration parameter:
 
 The _jittered_ backoff policy uses a
 [decorrelated jitter](http://www.awsarchitectureblog.com/2015/03/backoff.html)
-backoff algorithm and requires takes two configuration parameters:
+backoff algorithm and takes two configuration parameters:
 * _minMs_ -- Optional. The minimum number of milliseconds to wait
   before each retry.
 * _maxMs_ -- The maximum number of milliseconds to wait before each


### PR DESCRIPTION
Allows users to configure backoffs and retry budgets.

Fixes #336