### PR TITLE
Fix ThriftMux serving

### DIFF
--- a/namerd/iface/interpreter-thrift/src/main/scala/io/buoyant/namerd/iface/ThriftInterpreterInterfaceConfig.scala
+++ b/namerd/iface/interpreter-thrift/src/main/scala/io/buoyant/namerd/iface/ThriftInterpreterInterfaceConfig.scala
@@ -42,5 +42,5 @@ class ThriftInterpreterInterfaceInitializer extends InterfaceInitializer {
 
 case class ThriftServable(addr: InetSocketAddress, iface: ThriftService) extends Servable {
   def kind = ThriftInterpreterInterfaceConfig.kind
-  def serve() = ThriftMux.serveIface(addr, iface)
+  def serve() = ThriftMux.server.serveIface(addr, iface)
 }


### PR DESCRIPTION
In the next finagle release, ThriftMux.serveIface has been removed. It now must
be called on ThriftMux.server instead.

See: https://circleci.com/gh/BuoyantIO/linkerd/1291