### PR TITLE
Add announcer support to linkerd (and zk announcer)

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -7,8 +7,12 @@
   * Add auth `token` parameter to Consul Namer & Dtab Store
   * Add `datacenter` parameter to Consul Dtab Store
 * Add file-system based name interpreter.
+* Add auth `token` parameter to Consul Namer & Dtab Store
+* Add `datacenter` parameter to Consul Dtab Store
 * Introduce the _telemetry_ plugin subsystem to support arbitrary stats
   exporters and to eventually supplant the `tracers` subsystem.
+* Add announcer support! linkerd can now announce to service discovery backends!
+  * Add zk announcer.
 
 ## 0.7.3
 

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -7,8 +7,6 @@
   * Add auth `token` parameter to Consul Namer & Dtab Store
   * Add `datacenter` parameter to Consul Dtab Store
 * Add file-system based name interpreter.
-* Add auth `token` parameter to Consul Namer & Dtab Store
-* Add `datacenter` parameter to Consul Dtab Store
 * Introduce the _telemetry_ plugin subsystem to support arbitrary stats
   exporters and to eventually supplant the `tracers` subsystem.
 * Add announcer support! linkerd can now announce to service discovery backends!

--- a/linkerd/announcer/serversets/src/main/resources/META-INF/services/io.buoyant.linkerd.AnnouncerInitializer
+++ b/linkerd/announcer/serversets/src/main/resources/META-INF/services/io.buoyant.linkerd.AnnouncerInitializer
@@ -1,0 +1,1 @@
+io.buoyant.linkerd.announcer.serversets.ServersetsAnnouncerInitializer

--- a/linkerd/announcer/serversets/src/main/scala/com/twitter/finagle/zookeeper/buoyant/ZkAnnouncer.scala
+++ b/linkerd/announcer/serversets/src/main/scala/com/twitter/finagle/zookeeper/buoyant/ZkAnnouncer.scala
@@ -7,23 +7,13 @@ import io.buoyant.config.types.HostAndPort
 import io.buoyant.linkerd.Announcer
 import java.net.InetSocketAddress
 
-class ZkAnnouncer(zkAddrs: Seq[HostAndPort], pathPrefix: String) extends Announcer {
+class ZkAnnouncer(zkAddrs: Seq[HostAndPort], pathPrefix: Path) extends Announcer {
   override val scheme: String = "zk-serversets"
 
   val underlying = new FZkAnnouncer(DefaultZkClientFactory)
 
   private[this] val connect = zkAddrs.map(_.toString).mkString(",")
 
-  override def announce(addr: InetSocketAddress, name: String, version: Option[String] = None): Future[Announcement] =
-    version match {
-      case Some(v) => underlying.announce(addr, s"$connect!$pathPrefix/$name-$v!0")
-      case None => underlying.announce(addr, s"$connect!$pathPrefix/$name!0")
-    }
-
-  private[this] val prefix = Path.read(pathPrefix)
-  override def concreteName(name: String, version: Option[String] = None): Path =
-    version match {
-      case Some(v) => Path.Utf8("#", "io.l5d.serversets") ++ prefix ++ Path.Utf8(s"$name-$v")
-      case None => Path.Utf8("#", "io.l5d.serversets") ++ prefix ++ Path.Utf8(name)
-    }
+  override def announce(addr: InetSocketAddress, name: Path): Future[Announcement] =
+    underlying.announce(addr, s"$connect!${(pathPrefix ++ name).show}!0")
 }

--- a/linkerd/announcer/serversets/src/main/scala/com/twitter/finagle/zookeeper/buoyant/ZkAnnouncer.scala
+++ b/linkerd/announcer/serversets/src/main/scala/com/twitter/finagle/zookeeper/buoyant/ZkAnnouncer.scala
@@ -1,0 +1,24 @@
+package com.twitter.finagle.zookeeper.buoyant
+
+import com.twitter.finagle.{Path, Announcement}
+import com.twitter.finagle.zookeeper.{ZkAnnouncer => FZkAnnouncer, DefaultZkClientFactory}
+import com.twitter.util.Future
+import io.buoyant.config.types.HostAndPort
+import io.buoyant.linkerd.Announcer
+import java.net.InetSocketAddress
+
+class ZkAnnouncer(zkAddrs: Seq[HostAndPort], pathPrefix: String) extends Announcer {
+  override val scheme: String = "zk-serversets"
+
+  val underlying = new FZkAnnouncer(DefaultZkClientFactory)
+
+  private[this] val connect = zkAddrs.map(_.toString).mkString(",")
+
+  override def announce(addr: InetSocketAddress, name: String): Future[Announcement] =
+    underlying.announce(addr, s"$connect!$pathPrefix/$name!0")
+
+
+  private[this] val prefix = Path.read(pathPrefix)
+  override def concreteName(name: String): Path =
+    Path.Utf8("#", "io.l5d.serversets") ++ prefix ++ Path.Utf8(name)
+}

--- a/linkerd/announcer/serversets/src/main/scala/com/twitter/finagle/zookeeper/buoyant/ZkAnnouncer.scala
+++ b/linkerd/announcer/serversets/src/main/scala/com/twitter/finagle/zookeeper/buoyant/ZkAnnouncer.scala
@@ -14,11 +14,16 @@ class ZkAnnouncer(zkAddrs: Seq[HostAndPort], pathPrefix: String) extends Announc
 
   private[this] val connect = zkAddrs.map(_.toString).mkString(",")
 
-  override def announce(addr: InetSocketAddress, name: String): Future[Announcement] =
-    underlying.announce(addr, s"$connect!$pathPrefix/$name!0")
-
+  override def announce(addr: InetSocketAddress, name: String, version: Option[String] = None): Future[Announcement] =
+    version match {
+      case Some(v) => underlying.announce(addr, s"$connect!$pathPrefix/$name-$v!0")
+      case None => underlying.announce(addr, s"$connect!$pathPrefix/$name!0")
+    }
 
   private[this] val prefix = Path.read(pathPrefix)
-  override def concreteName(name: String): Path =
-    Path.Utf8("#", "io.l5d.serversets") ++ prefix ++ Path.Utf8(name)
+  override def concreteName(name: String, version: Option[String] = None): Path =
+    version match {
+      case Some(v) => Path.Utf8("#", "io.l5d.serversets") ++ prefix ++ Path.Utf8(s"$name-$v")
+      case None => Path.Utf8("#", "io.l5d.serversets") ++ prefix ++ Path.Utf8(name)
+    }
 }

--- a/linkerd/announcer/serversets/src/main/scala/io/buoyant/linkerd/announcer/serversets/ServersetsAnnouncerInitializer.scala
+++ b/linkerd/announcer/serversets/src/main/scala/io/buoyant/linkerd/announcer/serversets/ServersetsAnnouncerInitializer.scala
@@ -1,0 +1,15 @@
+package io.buoyant.linkerd.announcer.serversets
+
+import com.twitter.finagle.zookeeper.buoyant.ZkAnnouncer
+import io.buoyant.config.types.HostAndPort
+import io.buoyant.linkerd.{Announcer, AnnouncerConfig, AnnouncerInitializer}
+
+class ServersetsAnnouncerInitializer extends AnnouncerInitializer {
+  override def configClass = classOf[ServersetsConfig]
+  override def configId = "io.l5d.serversets"
+}
+
+case class ServersetsConfig(zkAddrs: Seq[HostAndPort], pathPrefix: Option[String]) extends AnnouncerConfig {
+  override def mk(): Announcer = new ZkAnnouncer(zkAddrs, pathPrefix.getOrElse("/discovery"))
+}
+

--- a/linkerd/announcer/serversets/src/main/scala/io/buoyant/linkerd/announcer/serversets/ServersetsAnnouncerInitializer.scala
+++ b/linkerd/announcer/serversets/src/main/scala/io/buoyant/linkerd/announcer/serversets/ServersetsAnnouncerInitializer.scala
@@ -1,5 +1,7 @@
 package io.buoyant.linkerd.announcer.serversets
 
+import com.fasterxml.jackson.annotation.JsonIgnore
+import com.twitter.finagle.Path
 import com.twitter.finagle.zookeeper.buoyant.ZkAnnouncer
 import io.buoyant.config.types.HostAndPort
 import io.buoyant.linkerd.{Announcer, AnnouncerConfig, AnnouncerInitializer}
@@ -9,7 +11,10 @@ class ServersetsAnnouncerInitializer extends AnnouncerInitializer {
   override def configId = "io.l5d.serversets"
 }
 
-case class ServersetsConfig(zkAddrs: Seq[HostAndPort], pathPrefix: Option[String]) extends AnnouncerConfig {
-  override def mk(): Announcer = new ZkAnnouncer(zkAddrs, pathPrefix.getOrElse("/discovery"))
-}
+case class ServersetsConfig(zkAddrs: Seq[HostAndPort], pathPrefix: Option[Path]) extends AnnouncerConfig {
 
+  @JsonIgnore
+  override def defaultPrefix: Path = Path.read("/io.l5d.serversets")
+
+  override def mk(): Announcer = new ZkAnnouncer(zkAddrs, pathPrefix.getOrElse(Path.read("/discovery")))
+}

--- a/linkerd/core/src/main/scala/io/buoyant/linkerd/Announcer.scala
+++ b/linkerd/core/src/main/scala/io/buoyant/linkerd/Announcer.scala
@@ -1,0 +1,11 @@
+package io.buoyant.linkerd
+
+import com.twitter.finagle.{Announcer => FAnnouncer, Path}
+
+abstract class Announcer extends FAnnouncer {
+  def concreteName(name: String): Path
+}
+
+
+
+

--- a/linkerd/core/src/main/scala/io/buoyant/linkerd/Announcer.scala
+++ b/linkerd/core/src/main/scala/io/buoyant/linkerd/Announcer.scala
@@ -1,11 +1,13 @@
 package io.buoyant.linkerd
 
-import com.twitter.finagle.{Announcer => FAnnouncer, Path}
+import com.twitter.finagle.{Announcement, Path}
+import com.twitter.util.Future
+import java.net.InetSocketAddress
 
-abstract class Announcer extends FAnnouncer {
-  def concreteName(name: String): Path
+abstract class Announcer {
+  val scheme: String
+
+  def announce(addr: InetSocketAddress, name: String, version: Option[String] = None): Future[Announcement]
+
+  def concreteName(name: String, version: Option[String] = None): Path
 }
-
-
-
-

--- a/linkerd/core/src/main/scala/io/buoyant/linkerd/Announcer.scala
+++ b/linkerd/core/src/main/scala/io/buoyant/linkerd/Announcer.scala
@@ -7,7 +7,5 @@ import java.net.InetSocketAddress
 abstract class Announcer {
   val scheme: String
 
-  def announce(addr: InetSocketAddress, name: String, version: Option[String] = None): Future[Announcement]
-
-  def concreteName(name: String, version: Option[String] = None): Path
+  def announce(addr: InetSocketAddress, name: Path): Future[Announcement]
 }

--- a/linkerd/core/src/main/scala/io/buoyant/linkerd/AnnouncerInitializer.scala
+++ b/linkerd/core/src/main/scala/io/buoyant/linkerd/AnnouncerInitializer.scala
@@ -1,11 +1,27 @@
 package io.buoyant.linkerd
 
-import com.fasterxml.jackson.annotation.JsonTypeInfo
+import com.fasterxml.jackson.annotation.{JsonIgnore, JsonProperty, JsonTypeInfo}
+import com.twitter.finagle.Path
 import io.buoyant.config.ConfigInitializer
 
 @JsonTypeInfo(use = JsonTypeInfo.Id.NAME, include = JsonTypeInfo.As.PROPERTY, property = "kind")
 trait AnnouncerConfig {
+
+  @JsonProperty("prefix")
+  var _prefix: Option[Path] = None
+
+  @JsonIgnore
+  def defaultPrefix: Path
+
+  @JsonIgnore
+  def prefix: Path = AnnouncerConfig.hash ++ _prefix.getOrElse(defaultPrefix)
+
+  @JsonIgnore
   def mk(): Announcer
+}
+
+object AnnouncerConfig {
+  val hash = Path.Utf8("#")
 }
 
 trait AnnouncerInitializer extends ConfigInitializer

--- a/linkerd/core/src/main/scala/io/buoyant/linkerd/AnnouncerInitializer.scala
+++ b/linkerd/core/src/main/scala/io/buoyant/linkerd/AnnouncerInitializer.scala
@@ -1,0 +1,11 @@
+package io.buoyant.linkerd
+
+import com.fasterxml.jackson.annotation.JsonTypeInfo
+import io.buoyant.config.ConfigInitializer
+
+@JsonTypeInfo(use = JsonTypeInfo.Id.NAME, include = JsonTypeInfo.As.PROPERTY, property = "kind")
+trait AnnouncerConfig {
+  def mk(): Announcer
+}
+
+trait AnnouncerInitializer extends ConfigInitializer

--- a/linkerd/core/src/main/scala/io/buoyant/linkerd/Linker.scala
+++ b/linkerd/core/src/main/scala/io/buoyant/linkerd/Linker.scala
@@ -35,10 +35,11 @@ object Linker {
     tracer: Seq[TracerInitializer] = Nil,
     identifier: Seq[IdentifierInitializer] = Nil,
     classifier: Seq[ResponseClassifierInitializer] = Nil,
-    telemetry: Seq[TelemeterInitializer] = Nil
+    telemetry: Seq[TelemeterInitializer] = Nil,
+    announcer: Seq[AnnouncerInitializer] = Nil
   ) {
     def iter: Iterable[Seq[ConfigInitializer]] =
-      Seq(protocol, namer, interpreter, tlsClient, tracer, identifier, classifier, telemetry)
+      Seq(protocol, namer, interpreter, tlsClient, tracer, identifier, classifier, telemetry, announcer)
 
     def all: Seq[ConfigInitializer] = iter.flatten.toSeq
 
@@ -57,7 +58,8 @@ object Linker {
     LoadService[TracerInitializer],
     LoadService[IdentifierInitializer],
     LoadService[ResponseClassifierInitializer],
-    LoadService[TelemeterInitializer]
+    LoadService[TelemeterInitializer],
+    LoadService[AnnouncerInitializer]
   )
 
   def parse(

--- a/linkerd/core/src/main/scala/io/buoyant/linkerd/ProtocolInitializer.scala
+++ b/linkerd/core/src/main/scala/io/buoyant/linkerd/ProtocolInitializer.scala
@@ -6,6 +6,7 @@ import com.twitter.finagle.server.StackServer
 import com.twitter.finagle.service.TimeoutFilter
 import com.twitter.util.Time
 import io.buoyant.config.ConfigInitializer
+import io.buoyant.linkerd.Server.AnnouncerName
 import io.buoyant.router._
 import java.net.InetSocketAddress
 
@@ -146,7 +147,7 @@ object ProtocolInitializer {
     addr: InetSocketAddress,
     server: StackServer[Req, Rsp],
     factory: ServiceFactory[Req, Rsp],
-    announce: Seq[String]
+    announce: Seq[AnnouncerName]
   ) extends Server.Initializer {
     def params = server.params
     def router: String = server.params[Server.RouterLabel].label

--- a/linkerd/core/src/main/scala/io/buoyant/linkerd/ProtocolInitializer.scala
+++ b/linkerd/core/src/main/scala/io/buoyant/linkerd/ProtocolInitializer.scala
@@ -6,7 +6,6 @@ import com.twitter.finagle.server.StackServer
 import com.twitter.finagle.service.TimeoutFilter
 import com.twitter.util.Time
 import io.buoyant.config.ConfigInitializer
-import io.buoyant.linkerd.Server.AnnouncerName
 import io.buoyant.router._
 import java.net.InetSocketAddress
 
@@ -56,7 +55,7 @@ abstract class ProtocolInitializer extends ConfigInitializer { initializer =>
   private case class ProtocolRouter(
     router: StackRouter[RouterReq, RouterRsp],
     servers: Seq[Server] = Nil,
-    announcers: Seq[Announcer] = Nil
+    announcers: Seq[(Path, Announcer)] = Nil
   ) extends Router {
     def params = router.params
     def protocol = ProtocolInitializer.this
@@ -69,7 +68,7 @@ abstract class ProtocolInitializer extends ConfigInitializer { initializer =>
 
     protected def withServers(ss: Seq[Server]): Router = copy(servers = ss)
 
-    def withAnnouncers(ann: Seq[Announcer]): Router = copy(announcers = ann)
+    def withAnnouncers(ann: Seq[(Path, Announcer)]): Router = copy(announcers = ann)
 
     def initialize(): Router.Initialized = {
       if (servers.isEmpty) {
@@ -135,7 +134,7 @@ object ProtocolInitializer {
     params: Stack.Params,
     factory: ServiceFactory[Req, Rsp],
     servers: Seq[Server.Initializer],
-    announcers: Seq[Announcer]
+    announcers: Seq[(Path, Announcer)]
   ) extends Router.Initialized {
     def name: String = params[Label].label
     def close(t: Time) = factory.close(t)
@@ -147,7 +146,7 @@ object ProtocolInitializer {
     addr: InetSocketAddress,
     server: StackServer[Req, Rsp],
     factory: ServiceFactory[Req, Rsp],
-    announce: Seq[AnnouncerName]
+    announce: Seq[Path]
   ) extends Server.Initializer {
     def params = server.params
     def router: String = server.params[Server.RouterLabel].label

--- a/linkerd/core/src/main/scala/io/buoyant/linkerd/ProtocolInitializer.scala
+++ b/linkerd/core/src/main/scala/io/buoyant/linkerd/ProtocolInitializer.scala
@@ -54,7 +54,8 @@ abstract class ProtocolInitializer extends ConfigInitializer { initializer =>
    */
   private case class ProtocolRouter(
     router: StackRouter[RouterReq, RouterRsp],
-    servers: Seq[Server] = Nil
+    servers: Seq[Server] = Nil,
+    announcers: Seq[Announcer] = Nil
   ) extends Router {
     def params = router.params
     def protocol = ProtocolInitializer.this
@@ -67,6 +68,8 @@ abstract class ProtocolInitializer extends ConfigInitializer { initializer =>
 
     protected def withServers(ss: Seq[Server]): Router = copy(servers = ss)
 
+    def withAnnouncers(ann: Seq[Announcer]): Router = copy(announcers = ann)
+
     def initialize(): Router.Initialized = {
       if (servers.isEmpty) {
         val Label(name) = params[Label]
@@ -77,9 +80,9 @@ abstract class ProtocolInitializer extends ConfigInitializer { initializer =>
       val adapted = adapter.andThen(factory)
       val servable = servers.map { server =>
         val stackServer = defaultServer.withParams(defaultServer.params ++ server.params)
-        ServerInitializer(protocol, server.addr, stackServer, adapted)
+        ServerInitializer(protocol, server.addr, stackServer, adapted, server.announce)
       }
-      InitializedRouter(protocol, params, factory, servable)
+      InitializedRouter(protocol, params, factory, servable, announcers)
     }
 
     private[this] val tlsPrepRole = Stack.Role("TlsClientPrep")
@@ -130,7 +133,8 @@ object ProtocolInitializer {
     protocol: ProtocolInitializer,
     params: Stack.Params,
     factory: ServiceFactory[Req, Rsp],
-    servers: Seq[Server.Initializer]
+    servers: Seq[Server.Initializer],
+    announcers: Seq[Announcer]
   ) extends Router.Initialized {
     def name: String = params[Label].label
     def close(t: Time) = factory.close(t)
@@ -141,7 +145,8 @@ object ProtocolInitializer {
     protocol: ProtocolInitializer,
     addr: InetSocketAddress,
     server: StackServer[Req, Rsp],
-    factory: ServiceFactory[Req, Rsp]
+    factory: ServiceFactory[Req, Rsp],
+    announce: Seq[String]
   ) extends Server.Initializer {
     def params = server.params
     def router: String = server.params[Server.RouterLabel].label

--- a/linkerd/core/src/main/scala/io/buoyant/linkerd/Router.scala
+++ b/linkerd/core/src/main/scala/io/buoyant/linkerd/Router.scala
@@ -62,7 +62,7 @@ trait Router {
   /** Return a router with TLS configuration read from the provided config. */
   def withTls(tls: TlsClientConfig): Router
 
-  def withAnnouncers(announcers: Seq[Announcer]): Router
+  def withAnnouncers(announcers: Seq[(Path, Announcer)]): Router
 
   /**
    * Initialize a router by instantiating a downstream router client
@@ -83,7 +83,7 @@ object Router {
     def protocol: ProtocolInitializer
     def params: Stack.Params
     def servers: Seq[Server.Initializer]
-    def announcers: Seq[Announcer]
+    def announcers: Seq[(Path, Announcer)]
   }
 }
 
@@ -181,7 +181,9 @@ trait RouterConfig {
   def router(params: Stack.Params): Router = {
     val prms = params ++ routerParams
     val param.Label(label) = prms[param.Label]
-    val announcers = _announcers.toSeq.flatten.map(_.mk)
+    val announcers = _announcers.toSeq.flatten.map { announcer =>
+      announcer.prefix -> announcer.mk
+    }
     protocol.router.configured(prms)
       .serving(servers.map(_.mk(protocol, label)))
       .withAnnouncers(announcers)

--- a/linkerd/core/src/main/scala/io/buoyant/linkerd/Router.scala
+++ b/linkerd/core/src/main/scala/io/buoyant/linkerd/Router.scala
@@ -62,6 +62,8 @@ trait Router {
   /** Return a router with TLS configuration read from the provided config. */
   def withTls(tls: TlsClientConfig): Router
 
+  def withAnnouncers(announcers: Seq[Announcer]): Router
+
   /**
    * Initialize a router by instantiating a downstream router client
    * so that its upstream `servers` may be bound.
@@ -81,6 +83,7 @@ object Router {
     def protocol: ProtocolInitializer
     def params: Stack.Params
     def servers: Seq[Server.Initializer]
+    def announcers: Seq[Announcer]
   }
 }
 
@@ -96,6 +99,9 @@ trait RouterConfig {
   var failFast: Option[Boolean] = None
   var timeoutMs: Option[Int] = None
   var dstPrefix: Option[String] = None
+
+  @JsonProperty("announcers")
+  var _announcers: Option[Seq[AnnouncerConfig]] = None
 
   @JsonProperty("label")
   var _label: Option[String] = None
@@ -175,8 +181,10 @@ trait RouterConfig {
   def router(params: Stack.Params): Router = {
     val prms = params ++ routerParams
     val param.Label(label) = prms[param.Label]
+    val announcers = _announcers.toSeq.flatten.map(_.mk)
     protocol.router.configured(prms)
       .serving(servers.map(_.mk(protocol, label)))
+      .withAnnouncers(announcers)
       .maybeTransform(client.flatMap(_.tls).map(tls => _.withTls(tls)))
   }
 

--- a/linkerd/core/src/test/scala/io/buoyant/linkerd/RouterTest.scala
+++ b/linkerd/core/src/test/scala/io/buoyant/linkerd/RouterTest.scala
@@ -129,7 +129,7 @@ servers:
         |- kind: test
         |servers:
         |- announce:
-        |    - foo
+        |    - service: foo
       """.
       stripMargin
     val router = parse(yaml, Stack.Params.empty)

--- a/linkerd/core/src/test/scala/io/buoyant/linkerd/RouterTest.scala
+++ b/linkerd/core/src/test/scala/io/buoyant/linkerd/RouterTest.scala
@@ -1,7 +1,7 @@
 package io.buoyant.linkerd
 
 import com.twitter.conversions.time._
-import com.twitter.finagle.{Dtab, Stack}
+import com.twitter.finagle.{Path, Dtab, Stack}
 import com.twitter.finagle.buoyant.DstBindingFactory
 import com.twitter.finagle.service.TimeoutFilter
 import io.buoyant.config.Parser
@@ -126,14 +126,16 @@ servers:
     val yaml = """
         |protocol: plain
         |announcers:
-        |- kind: test
+        |- kind: io.l5d.test
         |servers:
         |- announce:
-        |    - service: foo
+        |    - /#/io.l5d.test/foobar
       """.
       stripMargin
     val router = parse(yaml, Stack.Params.empty)
-    assert(router.initialize().announcers.head.isInstanceOf[TestAnnouncer])
+    val (path, announcer) = router.initialize().announcers.head
+    assert(path == Path.read("/#/io.l5d.test"))
+    assert(announcer.isInstanceOf[TestAnnouncer])
   }
 
   test("with retries") {

--- a/linkerd/core/src/test/scala/io/buoyant/linkerd/ServerTest.scala
+++ b/linkerd/core/src/test/scala/io/buoyant/linkerd/ServerTest.scala
@@ -101,4 +101,13 @@ fancyRouter: true
       """.stripMargin
     assert(parse(TestProtocol.Plain, yaml).get.params[RequestSemaphoreFilter.Param].sem.get.numInitialPermits == 1000)
   }
+
+  test("announce") {
+    val yaml =
+      """
+        |announce:
+        |- foobar
+      """.stripMargin
+    assert(parse(TestProtocol.Plain, yaml).get.announce == Seq("foobar"))
+  }
 }

--- a/linkerd/core/src/test/scala/io/buoyant/linkerd/ServerTest.scala
+++ b/linkerd/core/src/test/scala/io/buoyant/linkerd/ServerTest.scala
@@ -4,6 +4,7 @@ import com.twitter.finagle.filter.RequestSemaphoreFilter
 import com.twitter.finagle.transport.Transport
 import com.twitter.util.{Return, Try}
 import io.buoyant.config.Parser
+import io.buoyant.linkerd.Server.AnnouncerName
 import java.net.{InetAddress, InetSocketAddress}
 import org.scalatest.FunSuite
 
@@ -106,8 +107,8 @@ fancyRouter: true
     val yaml =
       """
         |announce:
-        |- foobar
+        |- service: foobar
       """.stripMargin
-    assert(parse(TestProtocol.Plain, yaml).get.announce == Seq("foobar"))
+    assert(parse(TestProtocol.Plain, yaml).get.announce == Seq(AnnouncerName("foobar", None)))
   }
 }

--- a/linkerd/core/src/test/scala/io/buoyant/linkerd/ServerTest.scala
+++ b/linkerd/core/src/test/scala/io/buoyant/linkerd/ServerTest.scala
@@ -1,10 +1,10 @@
 package io.buoyant.linkerd
 
+import com.twitter.finagle.Path
 import com.twitter.finagle.filter.RequestSemaphoreFilter
 import com.twitter.finagle.transport.Transport
 import com.twitter.util.{Return, Try}
 import io.buoyant.config.Parser
-import io.buoyant.linkerd.Server.AnnouncerName
 import java.net.{InetAddress, InetSocketAddress}
 import org.scalatest.FunSuite
 
@@ -107,8 +107,8 @@ fancyRouter: true
     val yaml =
       """
         |announce:
-        |- service: foobar
+        |- /#/io.l5d.foo/bar
       """.stripMargin
-    assert(parse(TestProtocol.Plain, yaml).get.announce == Seq(AnnouncerName("foobar", None)))
+    assert(parse(TestProtocol.Plain, yaml).get.announce == Seq(Path.read("/#/io.l5d.foo/bar")))
   }
 }

--- a/linkerd/core/src/test/scala/io/buoyant/linkerd/TestAnnouncer.scala
+++ b/linkerd/core/src/test/scala/io/buoyant/linkerd/TestAnnouncer.scala
@@ -1,0 +1,32 @@
+package io.buoyant.linkerd
+
+import com.twitter.finagle.{Announcement, Announcer}
+import com.twitter.util.Future
+import java.net.InetSocketAddress
+
+class TestAnnouncerInitializer extends AnnouncerInitializer {
+  override def configClass: Class[_] = classOf[TestAnnouncerConfig]
+  override def configId: String = "test"
+}
+
+object TestAnnouncerInitializer extends TestAnnouncerInitializer
+
+class TestAnnouncerConfig extends AnnouncerConfig {
+  override def mk(): Announcer = new TestAnnouncer
+}
+
+class TestAnnouncer extends Announcer {
+  override val scheme: String = "test"
+
+  var services: Map[String, Set[InetSocketAddress]] = Map.empty
+
+  override def announce(addr: InetSocketAddress, name: String): Future[Announcement] = synchronized {
+    services = services + (name -> (services(name) + addr))
+    Future.value(new Announcement {
+      override def unannounce(): Future[Unit] = synchronized {
+        services = services + (name -> (services(name) - addr))
+        Future.Unit
+      }
+    })
+  }
+}

--- a/linkerd/core/src/test/scala/io/buoyant/linkerd/TestAnnouncer.scala
+++ b/linkerd/core/src/test/scala/io/buoyant/linkerd/TestAnnouncer.scala
@@ -1,6 +1,6 @@
 package io.buoyant.linkerd
 
-import com.twitter.finagle.{Announcement, Announcer}
+import com.twitter.finagle.{Path, Announcement}
 import com.twitter.util.Future
 import java.net.InetSocketAddress
 
@@ -20,7 +20,14 @@ class TestAnnouncer extends Announcer {
 
   var services: Map[String, Set[InetSocketAddress]] = Map.empty
 
-  override def announce(addr: InetSocketAddress, name: String): Future[Announcement] = synchronized {
+  override def concreteName(name: String, version: Option[String]): Path =
+    Path.read(s"/#/io.l5d.test/$name")
+
+  override def announce(
+    addr: InetSocketAddress,
+    name: String,
+    version: Option[String] = None
+  ): Future[Announcement] = synchronized {
     services = services + (name -> (services(name) + addr))
     Future.value(new Announcement {
       override def unannounce(): Future[Unit] = synchronized {

--- a/linkerd/docs/announcer.md
+++ b/linkerd/docs/announcer.md
@@ -1,0 +1,13 @@
+# Announcers
+
+## Serversets
+
+`io.l5d.serversets`
+
+Announce to ZooKeeper using the serverset format.
+
+* *zkAddrs* -- list of ZooKeeper addresses:
+  * *host* --  the ZooKeeper host.
+  * *port* --  the ZooKeeper port.
+* *pathPrefix* -- (optional) the ZooKeeper path under which services should be registered. (default:
+  /discovery)

--- a/linkerd/docs/announcer.md
+++ b/linkerd/docs/announcer.md
@@ -1,5 +1,20 @@
 # Announcers
 
+*(for the [announcers](config.md#announcers) key)*
+
+An announcer registers servers in service discovery.  Each server may specify
+a list of concrete names to announce as in the [announce](config.md#announce)
+server key.  Each announcer has a prefix and will only announce names that
+begin with that prefix.
+
+An announcer config block has the following parameters:
+
+* *kind* -- The name of the announcer plugin
+* *prefix* -- This announcer will announce names beginning with `/#/<prefix>`.
+  Some announcers may configure a default prefix; see the specific announcer
+  section for details.
+* *announcer-specific parameters*.
+
 ## Serversets
 
 `io.l5d.serversets`

--- a/linkerd/docs/config.md
+++ b/linkerd/docs/config.md
@@ -136,6 +136,8 @@ Each router must be configured as an object with the following params:
   [interpreter](interpreter.md) object determining what module will be used to
   process destinations.  (default: default)
   * protocol-specific module params, if any (the _default_ module has none)
+* *announcers* (optional) -- a list of service discovery
+  [announcers](announcer.md) that servers can announce to.
 
 <a name="basic-router-params"></a>
 ### Basic router parameters
@@ -178,6 +180,8 @@ local IPv4 interfaces.
   * *keyPath* -- File path to the TLS key file
 * *maxConcurrentRequests* -- Optional.  The maximum number of concurrent
 requests the server will accept.  (default: unlimited)
+* *announce* -- Optional.  A list of names to announce using the router's
+  announcers.
 
 <a name="basic-client-params"></a>
 ### Basic client parameters

--- a/linkerd/docs/config.md
+++ b/linkerd/docs/config.md
@@ -136,6 +136,7 @@ Each router must be configured as an object with the following params:
   [interpreter](interpreter.md) object determining what module will be used to
   process destinations.  (default: default)
   * protocol-specific module params, if any (the _default_ module has none)
+<a name="announcers"></a>
 * *announcers* (optional) -- a list of service discovery
   [announcers](announcer.md) that servers can announce to.
 
@@ -180,10 +181,9 @@ local IPv4 interfaces.
   * *keyPath* -- File path to the TLS key file
 * *maxConcurrentRequests* -- Optional.  The maximum number of concurrent
 requests the server will accept.  (default: unlimited)
-* *announce* -- Optional.  A list of names to announce using the router's
-  announcers.  Each name must be an object with these keys:
-  * *service* -- The service name to announce as.
-  * *version* -- Optional.  The service version name to announce as.
+<a name="announce"></a>
+* *announce* -- Optional.  A list of concrete names to announce using the
+  router's announcers.
 
 <a name="basic-client-params"></a>
 ### Basic client parameters

--- a/linkerd/docs/config.md
+++ b/linkerd/docs/config.md
@@ -181,7 +181,9 @@ local IPv4 interfaces.
 * *maxConcurrentRequests* -- Optional.  The maximum number of concurrent
 requests the server will accept.  (default: unlimited)
 * *announce* -- Optional.  A list of names to announce using the router's
-  announcers.
+  announcers.  Each name must be an object with these keys:
+  * *service* -- The service name to announce as.
+  * *version* -- Optional.  The service version name to announce as.
 
 <a name="basic-client-params"></a>
 ### Basic client parameters

--- a/linkerd/examples/acceptance-test.yaml
+++ b/linkerd/examples/acceptance-test.yaml
@@ -51,6 +51,12 @@ routers:
     httpUriInDst: true
   responseClassifier:
     kind: io.l5d.retryableIdempotent5XX
+  announcers:
+  - kind: io.l5d.serversets
+    zkAddrs:
+    - host: 127.0.0.1
+      port: 2181
+    pathPrefix: /discovery/prod
   client:
     engine:
       kind: netty4
@@ -65,6 +71,9 @@ routers:
   servers:
   - port: 4140
     ip: 0.0.0.0
+    label: foo/bar
+    announce:
+    - foo/bar
     maxConcurrentRequests: 1000
     engine:
       kind: netty3

--- a/linkerd/examples/acceptance-test.yaml
+++ b/linkerd/examples/acceptance-test.yaml
@@ -73,7 +73,7 @@ routers:
     ip: 0.0.0.0
     label: foo/bar
     announce:
-    - foo/bar
+    - service: foo/bar
     maxConcurrentRequests: 1000
     engine:
       kind: netty3

--- a/linkerd/examples/acceptance-test.yaml
+++ b/linkerd/examples/acceptance-test.yaml
@@ -73,7 +73,7 @@ routers:
     ip: 0.0.0.0
     label: foo/bar
     announce:
-    - service: foo/bar
+    - /#/io.l5d.serversets/foo/bar
     maxConcurrentRequests: 1000
     engine:
       kind: netty3

--- a/linkerd/examples/serversets.yaml
+++ b/linkerd/examples/serversets.yaml
@@ -1,0 +1,22 @@
+namers:
+- kind: io.l5d.serversets
+  zkAddrs:
+    - host: 127.0.0.1
+      port: 2181
+
+routers:
+- protocol: http
+  announcers:
+  - kind: io.l5d.serversets
+    zkAddrs:
+    - host: 127.0.0.1
+      port: 2181
+    pathPrefix: /discovery/prod
+  baseDtab: |
+    /host => /#/io.l5d.serversets;
+    /http/1.1/* => /host;
+  servers:
+  - port: 4140
+    ip: 0.0.0.0
+    announce:
+    - foobar

--- a/linkerd/examples/serversets.yaml
+++ b/linkerd/examples/serversets.yaml
@@ -19,4 +19,4 @@ routers:
   - port: 4140
     ip: 0.0.0.0
     announce:
-    - service: foobar
+    - /#/io.l5d.serversets/foobar

--- a/linkerd/examples/serversets.yaml
+++ b/linkerd/examples/serversets.yaml
@@ -19,4 +19,4 @@ routers:
   - port: 4140
     ip: 0.0.0.0
     announce:
-    - foobar
+    - service: foobar

--- a/linkerd/main/src/main/scala/io/buoyant/Linkerd.scala
+++ b/linkerd/main/src/main/scala/io/buoyant/Linkerd.scala
@@ -46,8 +46,13 @@ object Linkerd extends App {
             val listening = server.serve()
             for (name <- server.announce) {
               for (announcer <- running.announcers) {
-                log.info("announcing %s as %s to %s", server.addr, name, announcer.scheme)
-                announcer.announce(server.addr, name).onSuccess(closeOnExit)
+                name.version match {
+                  case Some(version) =>
+                    log.info("announcing %s as %s version %s to %s", server.addr, name.service, version, announcer.scheme)
+                  case None =>
+                    log.info("announcing %s as %s to %s", server.addr, name.service, announcer.scheme)
+                }
+                announcer.announce(server.addr, name.service, name.version).onSuccess(closeOnExit)
               }
             }
             closeOnExit(listening)

--- a/linkerd/main/src/main/scala/io/buoyant/Linkerd.scala
+++ b/linkerd/main/src/main/scala/io/buoyant/Linkerd.scala
@@ -44,6 +44,12 @@ object Linkerd extends App {
           running.servers.map { server =>
             log.info("serving %s on %s:%d", server.router, server.ip, server.port)
             val listening = server.serve()
+            for (name <- server.announce) {
+              for (announcer <- running.announcers) {
+                log.info("announcing %s as %s to %s", server.addr, name, announcer.scheme)
+                announcer.announce(server.addr, name).onSuccess(closeOnExit)
+              }
+            }
             closeOnExit(listening)
             listening
           }

--- a/project/LinkerdBuild.scala
+++ b/project/LinkerdBuild.scala
@@ -396,6 +396,15 @@ object LinkerdBuild extends Base {
         .aggregate(zipkin)
     }
 
+    object Announcer {
+      val serversets = projectDir("linkerd/announcer/serversets")
+        .withTwitterLib(Deps.finagle("serversets").exclude("org.slf4j", "slf4j-jdk14"))
+        .dependsOn(core)
+
+      val all = projectDir("linkerd/announcer")
+        .aggregate(serversets)
+    }
+
     val admin = projectDir("linkerd/admin")
       .withTwitterLib(Deps.twitterServer)
       .withTests()
@@ -452,7 +461,7 @@ object LinkerdBuild extends Base {
 
     val all = projectDir("linkerd")
       .settings(aggregateSettings)
-      .aggregate(admin, core, main, configCore, Namer.all, Protocol.all, Tracer.all, tls)
+      .aggregate(admin, core, main, configCore, Namer.all, Protocol.all, Tracer.all, Announcer.all, tls)
       .configs(Minimal, Bundle)
       // Minimal cofiguration includes a runtime, HTTP routing and the
       // fs service discovery.
@@ -465,6 +474,7 @@ object LinkerdBuild extends Base {
         Interpreter.namerd, Interpreter.fs,
         Protocol.mux, Protocol.thrift,
         Tracer.zipkin,
+        Announcer.serversets,
         tls)
       .settings(inConfig(Bundle)(BundleSettings))
       .settings(
@@ -554,6 +564,8 @@ object LinkerdBuild extends Base {
   val linkerdProtocolThrift = Linkerd.Protocol.thrift
   val linkerdTracer = Linkerd.Tracer.all
   val linkerdTracerZipkin = Linkerd.Tracer.zipkin
+  val linkerdAnnouncer = Linkerd.Announcer.all
+  val linkerdAnnouncerServersets = Linkerd.Announcer.serversets
   val linkerdTls = Linkerd.tls
 
   // Unified documentation via the sbt-unidoc plugin


### PR DESCRIPTION
In the router section of the linkerd config, you can now specify a list of announcers.  Each server may then specify a list of names to announce.