### PR TITLE
Add blank line in sbt file.

### DIFF
--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -11,6 +11,7 @@ addSbtPlugin("com.eed3si9n"      % "sbt-unidoc"    % "0.3.3")
 
 // packaging
 addSbtPlugin("com.eed3si9n"      % "sbt-assembly"  % "0.14.1")
+
 addSbtPlugin("se.marcuslonnberg" % "sbt-docker"    % "1.2.0")
 
 // scrooge


### PR DESCRIPTION
The spec for sbt require a blank line between Scala expressions. IntelliJ fails to import the project when there isn't one.