### PR TITLE
Move requeueing up into the path stack

### DIFF
--- a/linkerd/protocol/http/src/e2e/scala/io/buoyant/linkerd/protocol/HttpEndToEndTest.scala
+++ b/linkerd/protocol/http/src/e2e/scala/io/buoyant/linkerd/protocol/HttpEndToEndTest.scala
@@ -261,9 +261,13 @@ class HttpEndToEndTest extends FunSuite with Awaits {
         assert(stats.counters.get(Seq("http", "dst", "id", label, "requests")) == Some(2))
         assert(stats.counters.get(Seq("http", "dst", "id", label, "success")) == Some(1))
         assert(stats.counters.get(Seq("http", "dst", "id", label, "failures")) == Some(1))
-        assert(stats.counters.get(Seq("http", "dst", "id", label, "retries", "requeues")) == Some(1))
         assert(stats.counters.get(Seq("http", "dst", "id", label, "status", "200")) == Some(1))
         assert(stats.counters.get(Seq("http", "dst", "id", label, "status", "500")) == Some(1))
+        val name = s"http/1.1/$method/dog"
+        assert(stats.counters.get(Seq("http", "dst", "path", name, "requests")) == Some(2))
+        assert(stats.counters.get(Seq("http", "dst", "path", name, "success")) == Some(1))
+        assert(stats.counters.get(Seq("http", "dst", "path", name, "failures")) == Some(1))
+        assert(stats.counters.get(Seq("http", "dst", "path", name, "retries", "requeues")) == Some(1))
       }
 
       // non-retryable request, fails and is not retried
@@ -283,6 +287,11 @@ class HttpEndToEndTest extends FunSuite with Awaits {
         assert(stats.counters.get(Seq("http", "dst", "id", label, "failures")) == Some(1))
         assert(stats.counters.get(Seq("http", "dst", "id", label, "status", "200")) == None)
         assert(stats.counters.get(Seq("http", "dst", "id", label, "status", "500")) == Some(1))
+        val name = s"http/1.1/$method/dog"
+        assert(stats.counters.get(Seq("http", "dst", "path", name, "requests")) == Some(1))
+        assert(stats.counters.get(Seq("http", "dst", "path", name, "success")) == None)
+        assert(stats.counters.get(Seq("http", "dst", "path", name, "failures")) == Some(1))
+        assert(stats.counters.get(Seq("http", "dst", "path", name, "retries", "requeues")) == None)
       }
     } finally {
       await(client.close())

--- a/linkerd/protocol/http/src/main/scala/io/buoyant/linkerd/protocol/HttpInitializer.scala
+++ b/linkerd/protocol/http/src/main/scala/io/buoyant/linkerd/protocol/HttpInitializer.scala
@@ -18,9 +18,12 @@ class HttpInitializer extends ProtocolInitializer.Simple {
   protected val defaultRouter = {
     val pathStack = Headers.Dst.PathFilter +: Http.router.pathStack
     val boundStack = Headers.Dst.BoundFilter +: Http.router.boundStack
-    val clientStack = (http.AccessLogger.module +: Http.router.clientStack)
-      .replace(HttpTraceInitializer.role, HttpTraceInitializer.client)
-      .insertAfter(Retries.Role, http.StatusCodeStatsFilter.module)
+    val clientStack = {
+      val stk = new StackBuilder(Http.router.clientStack)
+      stk.push(http.StatusCodeStatsFilter.module)
+      stk.push(http.AccessLogger.module)
+      stk.result.replace(HttpTraceInitializer.role, HttpTraceInitializer.client)
+    }
 
     Http.router
       .withPathStack(pathStack)


### PR DESCRIPTION
By default, the requeueing filter is installed on the client stack. However,
this means that retries must be performed on the same client, which isn't
always desirable. By moving retries into the (logical) path stack, retry
requests may issued on an client (i.e. if the name tree includes unions).

Furthermore, this adds some basic stats at the logical level so that we have
top-level successrate, etc.

Depends on #364 