### PR TITLE
Fix issue where metrics were disappearing and reappearing

### DIFF
--- a/admin/src/main/resources/io/buoyant/admin/js/dashboard.js
+++ b/admin/src/main/resources/io/buoyant/admin/js/dashboard.js
@@ -11,11 +11,22 @@ $.when(
   $.get("/files/template/router_client.template"),
   $.get("/files/template/router_client_container.template"),
   $.get("/files/template/server_rate_metric.partial.template"),
+  $.get("/files/template/metric.partial.template"),
   $.get("/files/template/router_summary.template"),
   $.get("/files/template/process_info.template"),
   $.get("/files/template/request_totals.template"),
   $.get("/admin/metrics.json")
-).done(function(routerContainerRsp, routerServerRsp, routerClientRsp, routerClientContainerRsp, metricPartialRsp, routerSummaryRsp, overviewStatsRsp, requestTotalsRsp, metricsJson) {
+).done(function(
+    routerContainerRsp,
+    routerServerRsp,
+    routerClientRsp,
+    routerClientContainerRsp,
+    serverMetricPartialRsp,
+    metricPartialRsp,
+    routerSummaryRsp,
+    overviewStatsRsp,
+    requestTotalsRsp,
+    metricsJson) {
   var selectedRouter = getSelectedRouter(); // TODO: update this to avoid passing params in urls #198
   var routerTemplates = {
     summary: Handlebars.compile(routerSummaryRsp[0]),
@@ -23,7 +34,8 @@ $.when(
     server: Handlebars.compile(routerServerRsp[0]),
     client: Handlebars.compile(routerClientRsp[0]),
     clientContainer: Handlebars.compile(routerClientContainerRsp[0]),
-    serverMetric: Handlebars.compile(metricPartialRsp[0])
+    serverMetric: Handlebars.compile(serverMetricPartialRsp[0]),
+    metric: Handlebars.compile(metricPartialRsp[0])
   }
 
   var metricsCollector = MetricsCollector(metricsJson[0]);

--- a/admin/src/main/resources/io/buoyant/admin/js/metrics_collector.js
+++ b/admin/src/main/resources/io/buoyant/admin/js/metrics_collector.js
@@ -68,7 +68,10 @@ var MetricsCollector = (function() {
     }
 
     return {
-      start: function(interval) { setInterval(update, interval); },
+      start: function(interval) {
+        update();
+        setInterval(update, interval);
+      },
       getCurrentMetrics: function() { return defaultMetrics; },
       registerListener: registerListener,
       deregisterListener: deregisterListener

--- a/admin/src/main/resources/io/buoyant/admin/js/router_clients.js
+++ b/admin/src/main/resources/io/buoyant/admin/js/router_clients.js
@@ -8,7 +8,7 @@ var RouterClients = (function() {
     }, {});
   }
 
-  return function (metricsCollector, routers, $clientEl, routerName, clientTemplate, clientContainerTemplate, colors) {
+  return function (metricsCollector, routers, $clientEl, routerName, clientTemplate, metricPartial, clientContainerTemplate, colors) {
     var clientToColor = assignColorsToClients(colors, routers.clients(routerName));
     var combinedClientGraph = CombinedClientGraph(metricsCollector, routerName, $clientEl.find(".router-graph"), clientToColor);
     var clients = routers.clients(routerName);
@@ -29,7 +29,7 @@ var RouterClients = (function() {
       var $metrics = $container.find(".metrics-container");
       var $chart = $container.find(".chart-container");
 
-      return RouterClient(metricsCollector, routers, client, $metrics, routerName, clientTemplate, $chart, colorsForClient);
+      return RouterClient(metricsCollector, routers, client, $metrics, routerName, clientTemplate, metricPartial, $chart, colorsForClient);
     }
 
     function addClients(addedClients) {

--- a/admin/src/main/resources/io/buoyant/admin/js/router_controller.js
+++ b/admin/src/main/resources/io/buoyant/admin/js/router_controller.js
@@ -92,7 +92,7 @@ var RouterController = (function () {
 
       RouterSummary(metricsCollector, templates.summary, $summaryEl, router);
       RouterServers(metricsCollector, routers, $serversEl, router, templates.server, templates.serverMetric);
-      RouterClients(metricsCollector, routers, $clientsEl, router , templates.client, templates.clientContainer, colorOrder);
+      RouterClients(metricsCollector, routers, $clientsEl, router , templates.client, templates.metric, templates.clientContainer, colorOrder);
     });
 
     return {};

--- a/admin/src/main/resources/io/buoyant/admin/template/metric.partial.template
+++ b/admin/src/main/resources/io/buoyant/admin/template/metric.partial.template
@@ -1,0 +1,16 @@
+<div class="{{containerClass}}" style={{#if borderColor}}"border-left: 1px solid {{borderColor}}"{{/if}}>
+  <div class="metric-header">
+    {{#if description}}
+      {{description}}
+    {{else}}
+      metric
+    {{/if}}
+  </div>
+  <div class="{{metricClass}}">
+    {{#if value}}
+      {{value}}
+    {{else}}
+      0
+    {{/if}}
+  </div>
+</div>

--- a/admin/src/main/resources/io/buoyant/admin/template/router_client.template
+++ b/admin/src/main/resources/io/buoyant/admin/template/router_client.template
@@ -4,37 +4,13 @@
 
 <div class="client-metrics row">
   <div class="col-md-2">
-    <div class="metric-container" style="border-left: 1px solid {{clientColor}};">
-      <div class="metric-header">Requests</div>
-      <div class="metric-large">{{requests}}</div>
-    </div>
-    <div class="success-metric-container metric-container">
-      <div class="metric-header">Successes</div>
-      <div class="success-metric metric-large">
-        {{#if successRate}}
-          {{successRate}}
-        {{else}}
-          {{success}}
-        {{/if}}
-      </div>
-    </div>
+    {{> metricPartial data.requests containerClass="metric-container" metricClass="metric-large" borderColor=clientColor}}
+    {{> metricPartial data.success containerClass="success-metric-container metric-container" metricClass="success-metric metric-large"}}
   </div>
 
   <div class="col-md-2">
-    <div class="metric-container" style="border-left: 1px solid {{clientColor}};">
-      <div class="metric-header">Connections</div>
-      <div class="metric-large">{{connections}}</div>
-    </div>
-    <div class="failure-metric-container metric-container">
-      <div class="metric-header">Failures</div>
-      <div class="failure-metric metric-large">
-        {{#if failures}}
-          {{failures}}
-        {{else}}
-          0
-        {{/if}}
-      </div>
-    </div>
+    {{> metricPartial data.connections containerClass="metric-container" metricClass="metric-large" borderColor=clientColor}}
+    {{> metricPartial data.failures containerClass="failure-metric-container metric-container" metricClass="failure-metric metric-large"}}
   </div>
 
   <div class="col-md-2">


### PR DESCRIPTION
* Fixes #376 
* Refactor some repeated metrics code into partials

The bug:
* The templates re-render every 1000ms when we fetch new data.
* When both metrics are null, there was no display value, which causes the displayed text to adjust upwards.
* Adding a default value of 0 if the metric has no value fixes this.

One disadvantage to the template approach is that when data takes 1 second to load, all of the metrics display their default values, such as "metric 0" as opposed to something like "requests 0"