### PR TITLE
Remove TLS support from k8s namer.

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -9,6 +9,8 @@
   budgets and backoffs.
 * Automatically retry certain types of failures, as determined by
   response classifiers.
+* Remove TLS support from the k8s namer in favor of using `kubectl proxy` for
+  securely communicating with the k8s cluster API.
 
 ## 0.4.0
 

--- a/k8s/src/main/scala/io/buoyant/k8s/ClientConfig.scala
+++ b/k8s/src/main/scala/io/buoyant/k8s/ClientConfig.scala
@@ -14,9 +14,6 @@ trait ClientConfig {
 
   def host: Option[String]
   def portNum: Option[Int]
-  def tls: Option[Boolean]
-  def tlsWithoutValidation: Option[Boolean]
-  def authTokenFile: Option[String]
 
   protected def getHost = host.getOrElse(DefaultHost)
 
@@ -24,36 +21,13 @@ trait ClientConfig {
 
   protected def dst = s"/$$/inet/$getHost/$getPort"
 
-  private def authFilter = authTokenFile match {
-    case Some(path) =>
-      val token = Source.fromFile(path).mkString
-      if (token.nonEmpty) new AuthFilter(token)
-      else Filter.identity[Request, Response]
-    case None => Filter.identity[Request, Response]
-  }
-
   protected def mkClient(
     params: Stack.Params = Stack.Params.empty
-  ) = {
-    val setHost = new SetHostFilter(getHost, getPort)
-    val client = (tls, tlsWithoutValidation) match {
-      case (Some(false), Some(_)) =>
-        log.warning("tlsWithoutValidation is specified, but has no effect as tls is disabled")
-        Http.client
-      case (Some(false), _) => Http.client
-      case (_, Some(true)) => Http.client.withTlsWithoutValidation
-      case _ => Http.client.withTls(setHost.host)
-    }
-    client.withParams(client.params ++ params)
-      .withStreaming(true)
-      .filtered(setHost)
-      .filtered(authFilter)
-  }
-
+  ) = Http.client.withParams(Http.client.params ++ params).withStreaming(true)
 }
 
 object ClientConfig {
-  val DefaultHost = "kubernetes.default.svc.cluster.local"
+  val DefaultHost = "localhost"
   val DefaultNamespace = "default"
-  val DefaultPort = 443
+  val DefaultPort = 8001
 }

--- a/linkerd/docs/config.md
+++ b/linkerd/docs/config.md
@@ -662,12 +662,8 @@ experimental.
 
 The Kubernetes namer is configured with kind `io.l5d.experimental.k8s`, and these parameters:
 
-* *host* -- the Kubernetes master host. (default: kubernetes.default.svc.cluster.local)
-* *port* -- the Kubernetes master port. (default: 443)
-* *tls* -- Whether TLS should be used in communicating with the Kubernetes master. (default: true)
-* *tlsWithoutValidation* -- Whether certificate-checking should be disabled. (default: false)
-* *authTokenFile* -- Path to a file containing the Kubernetes master's authorization token.
-  (default: /var/run/secrets/kubernetes.io/serviceaccount/token)
+* *host* -- the Kubernetes master host. (default: localhost)
+* *port* -- the Kubernetes master port. (default: 8001)
 
 For example:
 ```yaml
@@ -675,9 +671,10 @@ namers:
 - kind: io.l5d.experimental.k8s
   host: kubernetes.default.svc.cluster.local
   port: 443
-  tls: true
-  authTokenFile: /var/run/secrets/kubernetes.io/serviceaccount/token
 ```
+
+The Kubernetes namer does not support TLS.  Instead, you should run `kubectl proxy` on each host
+which will create a local proxy for securely talking to the Kubernetes cluster API.
 
 The default _prefix_ is `io.l5d.k8s`. (Note that this is *different* from
 the name in the configuration block.)

--- a/linkerd/docs/config.md
+++ b/linkerd/docs/config.md
@@ -669,8 +669,8 @@ For example:
 ```yaml
 namers:
 - kind: io.l5d.experimental.k8s
-  host: kubernetes.default.svc.cluster.local
-  port: 443
+  host: localhost
+  port: 8001
 ```
 
 The Kubernetes namer does not support TLS.  Instead, you should run `kubectl proxy` on each host

--- a/linkerd/examples/acceptance-test.yaml
+++ b/linkerd/examples/acceptance-test.yaml
@@ -24,10 +24,8 @@ namers:
   port: 2181
 
 - kind: io.l5d.experimental.k8s
-  host: kubernetes.default.svc.cluster.local
-  port: 443
-  tls: true
-  authTokenFile: linkerd/examples/io.l5d.k8s/kube_token
+  host: localhost
+  port: 8001
 
 - kind: io.l5d.experimental.marathon
   prefix: /io.l5d.marathon

--- a/linkerd/examples/k8s.yaml
+++ b/linkerd/examples/k8s.yaml
@@ -4,10 +4,7 @@ admin:
 namers:
 - kind: io.l5d.experimental.k8s
   host: localhost
-  port: 443
-  tls: true
-  tlsWithoutValidation: true
-  authTokenFile: linkerd/examples/io.l5d.k8s/kube_token
+  port: 8001
 
 routers:
 - protocol: http

--- a/namer/k8s/src/main/scala/io/l5d/k8s.scala
+++ b/namer/k8s/src/main/scala/io/l5d/k8s.scala
@@ -15,10 +15,8 @@ import scala.io.Source
  * <pre>
  * namers:
  * - kind: io.l5d.experimental.k8s
- *   host: k8s-master.site.biz
- *   port: 80
- *   tls: false
- *   authTokenFile: ../auth.token
+ *   host: localhost
+ *   port: 8001
  * </pre>
  */
 class K8sInitializer extends NamerInitializer {
@@ -29,10 +27,7 @@ object K8sInitializer extends K8sInitializer
 
 case class k8s(
   host: Option[String],
-  port: Option[Port],
-  tls: Option[Boolean],
-  tlsWithoutValidation: Option[Boolean],
-  authTokenFile: Option[String]
+  port: Option[Port]
 ) extends NamerConfig with ClientConfig {
 
   @JsonIgnore

--- a/namer/k8s/src/test/scala/io/l5d/K8sTest.scala
+++ b/namer/k8s/src/test/scala/io/l5d/K8sTest.scala
@@ -11,7 +11,7 @@ class K8sTest extends FunSuite {
 
   test("sanity") {
     // ensure it doesn't totally blowup
-    val _ = k8s(None, None, None, None, None).newNamer(Stack.Params.empty)
+    val _ = k8s(None, None).newNamer(Stack.Params.empty)
   }
 
   test("service registration") {
@@ -23,15 +23,11 @@ class K8sTest extends FunSuite {
                   |kind: io.l5d.experimental.k8s
                   |host: k8s-master.site.biz
                   |port: 80
-                  |tls: false
-                  |authTokenFile: ../auth.token
       """.stripMargin
 
     val mapper = Parser.objectMapper(yaml, Iterable(Seq(K8sInitializer)))
     val k8s = mapper.readValue[NamerConfig](yaml).asInstanceOf[k8s]
     assert(k8s.host == Some("k8s-master.site.biz"))
     assert(k8s.port == Some(Port(80)))
-    assert(k8s.tls == Some(false))
-    assert(k8s.authTokenFile == Some("../auth.token"))
   }
 }

--- a/namerd/examples/k8s.yaml
+++ b/namerd/examples/k8s.yaml
@@ -3,7 +3,6 @@ storage:
   kind: io.buoyant.namerd.storage.experimental.k8s
   host: localhost
   port: 8001 # Running through kubectl proxy
-  tls: false # kubectl proxy does not support tls
 interfaces:
 - kind: thriftNameInterpreter
 - kind: httpController


### PR DESCRIPTION
Starting a local `kubectl proxy` is the recommended way to securely talk to the k8s cluster API.  See https://github.com/BuoyantIO/linkerd-examples/pull/12