### PR TITLE
more verbose logging for invalid request errors

### DIFF
--- a/linkerd/protocol/http/src/main/scala/io/buoyant/linkerd/protocol/http/ErrorResponder.scala
+++ b/linkerd/protocol/http/src/main/scala/io/buoyant/linkerd/protocol/http/ErrorResponder.scala
@@ -6,6 +6,7 @@ import com.twitter.finagle.http.{MediaType, Request, Response, Status}
 import com.twitter.logging.Logger
 import com.twitter.util.NonFatal
 import io.buoyant.router.RoutingFactory
+import java.net.URLEncoder
 
 object ErrorResponder extends Stack.Module0[ServiceFactory[Request, Response]] {
   val role = Stack.Role("ErrorResponder")
@@ -30,7 +31,7 @@ object ErrorResponder extends Stack.Module0[ServiceFactory[Request, Response]] {
         }
 
         val rsp = Response(status)
-        rsp.headerMap(Headers.Err) = e.getMessage
+        rsp.headerMap(Headers.Err) = URLEncoder.encode(e.getMessage, "ISO-8859-1")
         rsp.contentType = MediaType.Txt
         rsp.contentString = e.getMessage
         rsp

--- a/linkerd/protocol/http/src/test/scala/io/buoyant/linkerd/protocol/http/ErrorResponderTest.scala
+++ b/linkerd/protocol/http/src/test/scala/io/buoyant/linkerd/protocol/http/ErrorResponderTest.scala
@@ -1,0 +1,33 @@
+package io.buoyant.linkerd.protocol.http
+
+import com.twitter.finagle.{Service, ServiceFactory, Stack}
+import com.twitter.finagle.buoyant.linkerd.Headers
+import com.twitter.util.Future
+import com.twitter.finagle.http.{Request, Response, Status}
+import java.net.URLEncoder
+import io.buoyant.router.RoutingFactory
+import io.buoyant.test.Awaits
+import org.scalatest.FunSuite
+
+class ErrorResponderTest extends FunSuite with Awaits {
+
+  val svc = Service.mk[Request, Response] { _ =>
+    Future.exception(RoutingFactory.UnknownDst(Request(), new Exception(s"foo\nbar")))
+  }
+  val stk = ErrorResponder.toStack(
+    Stack.Leaf(ErrorResponder.role, ServiceFactory.const(svc))
+  )
+  val service = await(stk.make(Stack.Params.empty)())
+
+  test("returns BadRequest for UnknownDst exception") {
+    val rsp = await(service(Request()))
+    assert(rsp.status == Status.BadRequest)
+  }
+
+  test("correctly encodes error headers") {
+    val rsp = await(service(Request()))
+    val headerErr = rsp.headerMap(Headers.Err)
+    assert(!headerErr.contains("\n"))
+    assert(headerErr.contains(URLEncoder.encode("\n", "ISO-8859-1")))
+  }
+}

--- a/namerd/iface/control-http/src/main/scala/io/buoyant/namerd/iface/HttpControlService.scala
+++ b/namerd/iface/control-http/src/main/scala/io/buoyant/namerd/iface/HttpControlService.scala
@@ -82,7 +82,7 @@ object HttpControlService {
   }
 
   case class InvalidPathException(path: String, underlying: Exception)
-    extends Exception(s"Invalid path: $path\n${underlying.getMessage}", underlying)
+    extends Exception(s"Invalid path: $path / ${underlying.getMessage}", underlying)
 
   trait NsPathUri {
     val prefix: String

--- a/router/core/src/main/scala/io/buoyant/router/RoutingFactory.scala
+++ b/router/core/src/main/scala/io/buoyant/router/RoutingFactory.scala
@@ -10,7 +10,7 @@ object RoutingFactory {
   val description = "Performs per-request name binding"
 
   case class UnknownDst[Req](request: Req, cause: Throwable)
-    extends Exception(s"Unknown destination: ${cause.getMessage}", cause)
+    extends Exception(s"Unknown destination: $request / ${cause.getMessage}", cause)
     with NoStacktrace
 
   /**

--- a/router/core/src/test/scala/io/buoyant/router/RoutingFactoryTest.scala
+++ b/router/core/src/test/scala/io/buoyant/router/RoutingFactoryTest.scala
@@ -54,8 +54,14 @@ class RoutingFactoryTest extends FunSuite with Awaits with Exceptions {
     val tracer = new TestTracer()
     Trace.letTracer(tracer) {
       val service = mkService(pathMk = (_: Request) => Future.exception(Thrown))
-      assertThrows[RoutingFactory.UnknownDst[Request]] {
-        await(service(Request()))
+
+      val req = Request()
+      try {
+        await(service(req))
+        assert(false)
+      } catch {
+        case e: Exception => assert(e.getMessage.contains(req.toString))
+        case _: Throwable => assert(false)
       }
     }
   }

--- a/router/http/src/main/scala/io/buoyant/router/http/DefaultIdentifier.scala
+++ b/router/http/src/main/scala/io/buoyant/router/http/DefaultIdentifier.scala
@@ -33,7 +33,7 @@ case class DefaultIdentifier(
         case Some(host) if host.nonEmpty =>
           Future.value(mkPath(Path.Utf8("1.1", req.method.toString, host) ++ suffix(req)))
         case _ =>
-          Future.exception(new IllegalArgumentException("invalid http request"))
+          Future.exception(new IllegalArgumentException(s"${http.Version.Http11} request missing hostname: $req"))
       }
   }
 

--- a/router/http/src/main/scala/io/buoyant/router/http/TracingFilter.scala
+++ b/router/http/src/main/scala/io/buoyant/router/http/TracingFilter.scala
@@ -33,7 +33,7 @@ object TracingFilter extends SimpleFilter[Request, Response] {
     Trace.recordBinary("http.rsp.version", rsp.version.toString)
     rsp.contentLength.foreach(Trace.recordBinary("http.rsp.content-length", _))
     if (rsp.status.code >= 500 && rsp.status.code < 600) {
-      Trace.recordBinary("http.rsp.body", rsp.content.slice(0, 64 * 1000 /*64kb*/))
+      Trace.recordBinary("http.rsp.body", rsp.content.slice(0, 64 * 1000 /*64kb*/ ))
     }
     rsp.contentType.foreach(Trace.recordBinary("http.rsp.content-type", _))
     rsp.headerMap.get("transfer-encoding").foreach { te =>


### PR DESCRIPTION
This change adds more exception logging to both `RoutingFactory` and `DefaultIdentifier`. I erred on the side of redundant logging of the request, as I thought it prudent to capture requests in cases where we're throwing an `UnknownDst` exception, as well as when an `HTTP/1.1` request is missing a host header.

Example exception:
```
io.buoyant.router.RoutingFactory$UnknownDst: Unknown destination: Request("GET /info?txtAirPlay&txtRAOP", from /127.0.0.1:55704)
HTTP/1.1 request missing hostname: Request("GET /info?txtAirPlay&txtRAOP", from /127.0.0.1:55704)
```

Multiline exception format inspired by:
https://github.com/BuoyantIO/linkerd/blob/master/namerd/iface/control-http/src/main/scala/io/buoyant/namerd/iface/HttpControlService.scala#L85

fixes #389