### PR TITLE
Make HTTP tracing more efficient

### DIFF
--- a/router/core/src/main/scala/com/twitter/finagle/buoyant/DstTracing.scala
+++ b/router/core/src/main/scala/com/twitter/finagle/buoyant/DstTracing.scala
@@ -21,9 +21,11 @@ object DstTracing {
       private[this] val localDtabShow = dst.localDtab.show
       private[this] val pathShow = dst.path.show
       override def apply(conn: ClientConnection) = {
-        Trace.recordBinary("namer.dtab.base", baseDtabShow)
-        Trace.recordBinary("namer.dtab.local", localDtabShow)
-        Trace.recordBinary("namer.path", pathShow)
+        if (Trace.isActivelyTracing) {
+          Trace.recordBinary("namer.dtab.base", baseDtabShow)
+          Trace.recordBinary("namer.dtab.local", localDtabShow)
+          Trace.recordBinary("namer.path", pathShow)
+        }
         self(conn)
       }
     }
@@ -44,8 +46,10 @@ object DstTracing {
       private[this] val idStr = dst.idStr
       private[this] val path = dst.path.show
       override def apply(conn: ClientConnection) = {
-        Trace.recordBinary("dst.id", idStr)
-        Trace.recordBinary("dst.path", path)
+        if (Trace.isActivelyTracing) {
+          Trace.recordBinary("dst.id", idStr)
+          Trace.recordBinary("dst.path", path)
+        }
         self(conn)
       }
     }

--- a/router/http/src/main/scala/io/buoyant/router/Http.scala
+++ b/router/http/src/main/scala/io/buoyant/router/Http.scala
@@ -31,7 +31,7 @@ object Http extends Router[Request, Response] with FinagleServer[Request, Respon
      */
     val client: StackClient[Request, Response] = FinagleHttp.client
       .transformed(StackRouter.Client.mkStack(_))
-      .transformed(_.replace(StackClient.Role.protoTracing, http.TracingFilter))
+      .transformed(_.replace(http.TracingFilter.role, http.TracingFilter.module))
       .transformed(_.remove(TlsFilter.role))
 
     val defaultParams: Stack.Params =

--- a/router/http/src/main/scala/io/buoyant/router/http/TracingFilter.scala
+++ b/router/http/src/main/scala/io/buoyant/router/http/TracingFilter.scala
@@ -1,43 +1,83 @@
 package io.buoyant.router.http
 
-import com.twitter.finagle.{Service, SimpleFilter}
-import com.twitter.finagle.http.{Request, Response}
+import com.twitter.conversions.storage._
+import com.twitter.finagle.{Service, ServiceFactory, SimpleFilter, Stack, Stackable, param}
+import com.twitter.finagle.client.StackClient
+import com.twitter.finagle.http.{Request, Response, Status}
 import com.twitter.finagle.tracing.Trace
+
+object TracingFilter {
+  val role = StackClient.Role.protoTracing
+  val module: Stackable[ServiceFactory[Request, Response]] =
+    new Stack.Module1[param.Tracer, ServiceFactory[Request, Response]] {
+      val role = TracingFilter.role
+      val description = "Traces HTTP-specific request metadata"
+      def make(_tracer: param.Tracer, next: ServiceFactory[Request, Response]) = {
+        val param.Tracer(tracer) = _tracer
+        if (tracer.isNull) next
+        else (new TracingFilter).andThen(next)
+      }
+    }
+
+  val TransferEncoding = "transfer-encoding"
+}
 
 /**
  * Annotates HTTP method, uri, and status code, content-type, and content-length.
  */
-object TracingFilter extends SimpleFilter[Request, Response] {
+class TracingFilter extends SimpleFilter[Request, Response] {
+  import TracingFilter.TransferEncoding
 
   def apply(req: Request, service: Service[Request, Response]) = {
     recordRequest(req)
     service(req).onSuccess(recordResponse)
   }
 
-  private[this] def recordRequest(req: Request): Unit = {
+  private[this] def recordRequest(req: Request): Unit = if (Trace.isActivelyTracing) {
     Trace.recordRpc(req.method.toString)
     // http.uri is used here for consistency with finagle-http's tracing filter
     Trace.recordBinary("http.uri", req.uri)
     Trace.recordBinary("http.req.method", req.method.toString)
-    req.host.foreach(Trace.recordBinary("http.req.host", _))
+    req.host match {
+      case Some(h) => Trace.recordBinary("http.req.host", h)
+      case None =>
+    }
     Trace.recordBinary("http.req.version", req.version.toString)
-    req.contentLength.foreach(Trace.recordBinary("http.req.content-length", _))
-    req.contentType.foreach(Trace.recordBinary("http.req.content-type", _))
-    req.headerMap.get("transfer-encoding").foreach { te =>
-      Trace.recordBinary("http.req.transfer-encoding", te)
+    req.contentLength match {
+      case Some(l) => Trace.recordBinary("http.req.content-length", l)
+      case None =>
+    }
+    req.contentType match {
+      case Some(t) => Trace.recordBinary("http.req.content-type", t)
+      case None =>
+    }
+    req.headerMap.get(TransferEncoding) match {
+      case Some(te) => Trace.recordBinary("http.req.transfer-encoding", te)
+      case None =>
     }
   }
 
-  private[this] def recordResponse(rsp: Response): Unit = {
-    Trace.recordBinary("http.rsp.status", rsp.status.code)
-    Trace.recordBinary("http.rsp.version", rsp.version.toString)
-    rsp.contentLength.foreach(Trace.recordBinary("http.rsp.content-length", _))
-    if (rsp.status.code >= 500 && rsp.status.code < 600) {
-      Trace.recordBinary("http.rsp.body", rsp.content.slice(0, 64 * 1000 /*64kb*/ ))
-    }
-    rsp.contentType.foreach(Trace.recordBinary("http.rsp.content-type", _))
-    rsp.headerMap.get("transfer-encoding").foreach { te =>
-      Trace.recordBinary("http.rsp.transfer-encoding", te)
+  private[this] val recordResponse: Response => Unit = (rsp: Response) => {
+    if (Trace.isActivelyTracing) {
+      Trace.recordBinary("http.rsp.status", rsp.status.code)
+      Trace.recordBinary("http.rsp.version", rsp.version.toString)
+      rsp.status match {
+        case Status.ServerError(_) =>
+          Trace.recordBinary("http.rsp.body", rsp.content.slice(0, 64 * 1000))
+        case _ =>
+      }
+      rsp.contentLength match {
+        case Some(l) => Trace.recordBinary("http.rsp.content-length", l)
+        case None =>
+      }
+      rsp.contentType match {
+        case Some(ct) => Trace.recordBinary("http.rsp.content-type", ct)
+        case None =>
+      }
+      rsp.headerMap.get(TransferEncoding) match {
+        case Some(te) => Trace.recordBinary("http.rsp.transfer-encoding", te)
+        case None =>
+      }
     }
   }
 }


### PR DESCRIPTION
The HTTP tracing filter is inefficient:
- It is always installed, even if tracing is disabled.
- It always annotates requests, even if the request is not sampled.
- It needlessly allocates anonymous functions.

In order to fix these issues:
- TracingFilter.module now only adds the filter is a non-nil tracer is present
- Annotations are only added if the request is actively being traced (i.e. it is sampled).
- Anonymous functions have been converted to non-allocating alternatives.