### PR TITLE
Remove the 'Connection' header from downstream requests.

### DIFF
--- a/router/http/src/main/scala/io/buoyant/router/Http.scala
+++ b/router/http/src/main/scala/io/buoyant/router/Http.scala
@@ -6,7 +6,7 @@ import com.twitter.finagle.param.ProtocolLibrary
 import com.twitter.finagle.server.StackServer
 import com.twitter.finagle.{Http => FinagleHttp, Server => FinagleServer, http => fhttp, _}
 import io.buoyant.router.Http.param.HttpIdentifier
-import io.buoyant.router.http.{DefaultIdentifier, ForwardedFilter}
+import io.buoyant.router.http.{DefaultIdentifier, ForwardedFilter, StripConnectionHeader}
 import java.net.SocketAddress
 
 object Http extends Router[Request, Response] with FinagleServer[Request, Response] {
@@ -20,7 +20,8 @@ object Http extends Router[Request, Response] with FinagleServer[Request, Respon
 
   object Router {
     val pathStack: Stack[ServiceFactory[Request, Response]] =
-      StackRouter.newPathStack[Request, Response]
+      StripConnectionHeader.module +:
+        StackRouter.newPathStack[Request, Response]
 
     val boundStack: Stack[ServiceFactory[Request, Response]] =
       StackRouter.newBoundStack[Request, Response]

--- a/router/http/src/main/scala/io/buoyant/router/http/StripConnectionHeader.scala
+++ b/router/http/src/main/scala/io/buoyant/router/http/StripConnectionHeader.scala
@@ -1,0 +1,26 @@
+package io.buoyant.router.http
+
+import com.twitter.finagle.{Service, ServiceFactory, SimpleFilter, Stack}
+import com.twitter.finagle.http.{Request, Response}
+
+object StripConnectionHeader {
+
+  val Key = "Connection"
+
+  /**
+   * Removes the 'Connection' header from (i.e. downstream) requests.
+   */
+  object filter extends SimpleFilter[Request, Response] {
+    def apply(req: Request, svc: Service[Request, Response]) = {
+      req.headerMap.remove(Key)
+      svc(req)
+    }
+  }
+
+  object module extends Stack.Module0[ServiceFactory[Request, Response]] {
+    val role = Stack.Role("StripConnectionHeader")
+    val description = "Removes the 'Connection' header from requests"
+    def make(next: ServiceFactory[Request, Response]) =
+      filter andThen next
+  }
+}

--- a/router/http/src/test/scala/io/buoyant/router/http/StripConnectionHeaderTest.scala
+++ b/router/http/src/test/scala/io/buoyant/router/http/StripConnectionHeaderTest.scala
@@ -1,0 +1,25 @@
+package io.buoyant.router.http
+
+import com.twitter.finagle.{Service, ServiceFactory}
+import com.twitter.finagle.http.{Request, Response}
+import com.twitter.util.Future
+import io.buoyant.test.Awaits
+import org.scalatest.FunSuite
+
+class StripConnectionHeaderTest extends FunSuite with Awaits {
+
+  test("strips 'Connection' header") {
+    @volatile var connection: Option[Option[String]] = None
+    val sf = StripConnectionHeader.module.make(ServiceFactory.const(
+      Service.mk[Request, Response] { req =>
+        connection = Some(req.headerMap.get("Connection"))
+        Future.value(Response())
+      }
+    ))
+    val svc = await(sf())
+    val req = Request()
+    req.headerMap.set("Connection", "close")
+    val _ = await(svc(req))
+    assert(connection == Some(None))
+  }
+}


### PR DESCRIPTION
Per RFC2616:

> The Connection general-header field allows the sender to specify options that
> are desired for that particular connection and MUST NOT be communicated by
> proxies over further connections.