### PR TITLE
Fix zkLeader package and class name conflict.

### DIFF
--- a/linkerd/examples/marathon-leader.yaml
+++ b/linkerd/examples/marathon-leader.yaml
@@ -2,7 +2,7 @@ namers:
 - kind:      io.l5d.experimental.marathon
   prefix:    /io.l5d.marathon
   # Discover the marathon master by leader election
-  dst:       /$/io.buoyant.namer.ZkLeader/localhost:2181/marathon/leader
+  dst:       /$/io.buoyant.namer.zk.leader/localhost:2181/marathon/leader
   uriPrefix: /marathon
   ttlMs:     300
 

--- a/linkerd/examples/marathon-leader.yaml
+++ b/linkerd/examples/marathon-leader.yaml
@@ -2,7 +2,7 @@ namers:
 - kind:      io.l5d.experimental.marathon
   prefix:    /io.l5d.marathon
   # Discover the marathon master by leader election
-  dst:       /$/io.buoyant.namer.zkLeader/localhost:2181/marathon/leader
+  dst:       /$/io.buoyant.namer.ZkLeader/localhost:2181/marathon/leader
   uriPrefix: /marathon
   ttlMs:     300
 

--- a/namer/zk-leader/src/main/resources/META-INF/services/io.buoyant.namer.NamerInitializer
+++ b/namer/zk-leader/src/main/resources/META-INF/services/io.buoyant.namer.NamerInitializer
@@ -1,1 +1,1 @@
-io.buoyant.namer.zkLeader.ZkLeaderNamerInitializer
+io.buoyant.namer.zk.ZkLeaderNamerInitializer

--- a/namer/zk-leader/src/main/scala/io/buoyant/namer/zk/ZkLeaderNamer.scala
+++ b/namer/zk-leader/src/main/scala/io/buoyant/namer/zk/ZkLeaderNamer.scala
@@ -1,4 +1,4 @@
-package io.buoyant.namer.zkLeader
+package io.buoyant.namer.zk
 
 import com.twitter.common.zookeeper.Group.GroupChangeListener
 import com.twitter.common.zookeeper._

--- a/namer/zk-leader/src/main/scala/io/buoyant/namer/zk/ZkLeaderNamerInitializer.scala
+++ b/namer/zk-leader/src/main/scala/io/buoyant/namer/zk/ZkLeaderNamerInitializer.scala
@@ -1,4 +1,4 @@
-package io.buoyant.namer.zkLeader
+package io.buoyant.namer.zk
 
 import com.fasterxml.jackson.annotation.JsonIgnore
 import com.twitter.finagle.Stack.Params

--- a/namer/zk-leader/src/main/scala/io/buoyant/namer/zk/leader.scala
+++ b/namer/zk-leader/src/main/scala/io/buoyant/namer/zk/leader.scala
@@ -1,15 +1,14 @@
-package io.buoyant.namer
+package io.buoyant.namer.zk
 
-import com.twitter.finagle.{Name, NameTree, Path, Namer}
+import com.twitter.finagle.{Name, NameTree, Namer, Path}
 import com.twitter.util.Activity
-import io.buoyant.namer.zkLeader.ZkLeaderNamer
 
 /**
  * This namer accepts paths of the form /<zkHosts>/<zkPath>.  The zkPath is the location
  * in ZooKeeper of a leader group.  This namer resolves to the addresses stored in the data of
  * the leader of the group.
  */
-class ZkLeader extends Namer {
+class leader extends Namer {
   override def lookup(path: Path): Activity[NameTree[Name]] = {
     val Path.Utf8(hosts) = path.take(1)
     val namer = new ZkLeaderNamer(Path.empty, hosts)

--- a/namer/zk-leader/src/main/scala/io/buoyant/namer/zkLeader.scala
+++ b/namer/zk-leader/src/main/scala/io/buoyant/namer/zkLeader.scala
@@ -9,7 +9,7 @@ import io.buoyant.namer.zkLeader.ZkLeaderNamer
  * in ZooKeeper of a leader group.  This namer resolves to the addresses stored in the data of
  * the leader of the group.
  */
-class zkLeader extends Namer {
+class ZkLeader extends Namer {
   override def lookup(path: Path): Activity[NameTree[Name]] = {
     val Path.Utf8(hosts) = path.take(1)
     val namer = new ZkLeaderNamer(Path.empty, hosts)

--- a/namer/zk-leader/src/test/scala/io/buoyant/namer/zk/ZkLeaderTest.scala
+++ b/namer/zk-leader/src/test/scala/io/buoyant/namer/zk/ZkLeaderTest.scala
@@ -1,0 +1,18 @@
+package io.buoyant.namer.zk
+
+import com.twitter.finagle.Stack
+import com.twitter.finagle.util.LoadService
+import io.buoyant.namer.NamerInitializer
+import org.scalatest.FunSuite
+
+class ZkLeaderTest extends FunSuite {
+
+  test("sanity") {
+    // ensure it doesn't totally blowup
+    val _ = ZkLeaderNamerConfig("localhost:1234").newNamer(Stack.Params.empty)
+  }
+
+  test("service registration") {
+    assert(LoadService[NamerInitializer]().exists(_.isInstanceOf[ZkLeaderNamerInitializer]))
+  }
+}

--- a/project/LinkerdBuild.scala
+++ b/project/LinkerdBuild.scala
@@ -101,6 +101,7 @@ object LinkerdBuild extends Base {
     val zkLeader = projectDir("namer/zk-leader")
       .dependsOn(core)
       .withTwitterLib(Deps.zkCandidate)
+      .withTests()
 
     val all = projectDir("namer")
       .aggregate(core, consul, fs, k8s, marathon, serversets, zkLeader)


### PR DESCRIPTION
io.buoyant.namer.zkLeader referred to both a package and a class.  This seems to cause non-deterministic compiler errors.  