### PR TITLE
Prevent re-use of sessions across retries

### DIFF
--- a/router/core/src/e2e/scala/io/buoyant/router/EchoEndToEndTest.scala
+++ b/router/core/src/e2e/scala/io/buoyant/router/EchoEndToEndTest.scala
@@ -6,6 +6,7 @@ import com.twitter.finagle.buoyant.{Echo => FinagleEcho, _}
 import com.twitter.finagle.client.StackClient
 import com.twitter.finagle.param.ProtocolLibrary
 import com.twitter.finagle.server.StackServer
+import com.twitter.finagle.stack.nilStack
 import com.twitter.finagle.stats.NullStatsReceiver
 import com.twitter.finagle.tracing.{Annotation, BufferingTracer, Trace, NullTracer}
 import com.twitter.util._
@@ -103,7 +104,7 @@ class EchoEndToEndTest extends FunSuite with Awaits {
       assert(anns.exists(_ == Annotation.BinaryAnnotation("namer.path", "/s/idk")))
       assert(anns.exists(_ == Annotation.BinaryAnnotation(
         RoutingFactory.Annotations.Failure.key,
-        RoutingFactory.Annotations.Failure.ClientAcquisition
+        RoutingFactory.Annotations.Failure.ClientAcquisition.name
       )))
     }
 
@@ -112,7 +113,7 @@ class EchoEndToEndTest extends FunSuite with Awaits {
       assert(anns.exists(_ == Annotation.BinaryAnnotation("namer.path", "/s")))
       assert(anns.exists(_ == Annotation.BinaryAnnotation(
         RoutingFactory.Annotations.Failure.key,
-        RoutingFactory.Annotations.Failure.Service
+        RoutingFactory.Annotations.Failure.Service.name
       )))
     }
 
@@ -180,7 +181,7 @@ object Echo extends Router[String, String] with Server[String, String] {
     }
 
     val pathStack: Stack[ServiceFactory[String, String]] =
-      ErrorFilter +: StackRouter.newPathStack[String, String]
+      StackRouter.newPathStack[String, String] ++ (ErrorFilter +: nilStack)
 
     val boundStack: Stack[ServiceFactory[String, String]] =
       StackRouter.newBoundStack[String, String]

--- a/router/core/src/main/scala/io/buoyant/router/Router.scala
+++ b/router/core/src/main/scala/io/buoyant/router/Router.scala
@@ -289,8 +289,9 @@ object StackRouter {
      * The ordering here is very important:
      *
      * - At the top of the path stack, we measure tracing and stats so
-     *   that we have a logical view of the request.  Success rate as
-     *   computed from the stats.
+     *   that we have a logical view of the request.  Success rate may
+     *   be computed from these stats to reflect the upstream client's
+     *   view of this endpoint.
      *
      * - Application-level retries are controlled by [[ClassifiedRetries]].
      *
@@ -301,7 +302,7 @@ object StackRouter {
      *
      * - The failureRecording module records errors encountered when
      *   acquiring a service from the underlying service factory. This
-     *   must be installed below factory to service in order to catch
+     *   must be installed below factoryToService in order to catch
      *   errors from the lower stacks (notably NoBrokersAvailable,
      *   etc).
      */

--- a/router/http/src/e2e/scala/io/buoyant/router/HttpEndToEndTest.scala
+++ b/router/http/src/e2e/scala/io/buoyant/router/HttpEndToEndTest.scala
@@ -221,7 +221,6 @@ class HttpEndToEndTest extends FunSuite with Awaits {
       assert(err == None)
       assert(rsp1.status == Status.Ok)
       assert(downstreamCounter("connects") == Some(1))
-      assert(downstreamCounter("closed") == Some(1))
 
       retriesToDo = 1
       val rsp2 = get()
@@ -231,7 +230,6 @@ class HttpEndToEndTest extends FunSuite with Awaits {
       assert(err == None)
       assert(rsp2.status == Status.Ok)
       assert(downstreamCounter("connects") == Some(2))
-      assert(downstreamCounter("closed") == Some(2))
 
     } finally {
       await(client.close())
@@ -298,20 +296,17 @@ class HttpEndToEndTest extends FunSuite with Awaits {
       assert(err == None)
       assert(rsp0.status == Status.Ok)
       assert(downstreamCounter("connects") == Some(1))
-      assert(downstreamCounter("closed") == Some(1))
 
       val rsp1 = get()
       assert(err == None)
       assert(rsp1.status == Status.Ok)
       assert(downstreamCounter("connects") == Some(2))
-      assert(downstreamCounter("closed") == Some(2))
 
       retriesToDo = 1
       val rsp2 = get()
       assert(err == None)
       assert(rsp2.status == Status.Ok)
       assert(downstreamCounter("connects") == Some(4))
-      assert(downstreamCounter("closed") == Some(4))
 
     } finally {
       await(client.close())

--- a/router/http/src/e2e/scala/io/buoyant/router/HttpEndToEndTest.scala
+++ b/router/http/src/e2e/scala/io/buoyant/router/HttpEndToEndTest.scala
@@ -1,8 +1,10 @@
 package io.buoyant.router
 
 import com.twitter.conversions.time._
-import com.twitter.finagle.http.{Request, Response, Status}
-import com.twitter.finagle.stats.NullStatsReceiver
+import com.twitter.finagle.service.Retries
+import com.twitter.finagle.stack.nilStack
+import com.twitter.finagle.http.{Request, Response, Status, Version}
+import com.twitter.finagle.stats.{NullStatsReceiver, InMemoryStatsReceiver}
 import com.twitter.finagle.tracing.{Annotation, BufferingTracer, NullTracer}
 import com.twitter.finagle.{Http => FinagleHttp, Status => _, http => _, _}
 import com.twitter.util._
@@ -24,14 +26,24 @@ class HttpEndToEndTest extends FunSuite with Awaits {
   }
 
   object Downstream {
-    def mk(name: String)(f: Request=>Response): Downstream = {
-      val service = Service.mk { req: Request => Future(f(req)) }
+    def factory(name: String)(f: ClientConnection => Service[Request, Response]): Downstream = {
+      val factory = new ServiceFactory[Request, Response] {
+        def apply(conn: ClientConnection): Future[Service[Request, Response]] = Future(f(conn))
+        def close(deadline: Time): Future[Unit] = Future.Done
+      }
       val server = FinagleHttp.server
         .configured(param.Label(name))
         .configured(param.Tracer(NullTracer))
-        .serve(":*", service)
+        .serve(":*", factory)
       Downstream(name, server)
     }
+
+    def mk(name: String)(f: Request=>Response): Downstream =
+      factory(name) { _ =>
+        Service.mk[Request, Response] { req =>
+          Future(f(req))
+        }
+      }
 
     def const(name: String, value: String): Downstream =
       mk(name) { _ =>
@@ -139,6 +151,172 @@ class HttpEndToEndTest extends FunSuite with Awaits {
       await(client.close())
       await(srv.server.close())
       await(router.close())
+    }
+  }
+
+  test("http/1.1: server closes connection after response") {
+    @volatile var connection: Option[ClientConnection] = None
+    val downstream = Downstream.factory("ds") { conn =>
+      connection = Some(conn)
+      Service.mk[Request, Response](_ => Future.value(Response()))
+    }
+
+    val stats = new InMemoryStatsReceiver
+    def downstreamCounter(name: String) = {
+      val k = Seq("http", "dst", "id", s"$$/inet/127.1/${downstream.port}", name)
+      stats.counters.get(k)
+    }
+
+    @volatile var retriesToDo = 0
+    @volatile var err: Option[Throwable] = None
+    val router = {
+      val dtab = Dtab.read(s"/http/1.1/*/ds => /$$/inet/127.1/${downstream.port}")
+      def doReq(req: () => Future[Response], retries: Int = 0): Future[Response] =
+        req().transform { ret =>
+          if (retries > 0) {
+            doReq(req, retries - 1)
+          } else Future.const(ret)
+        }
+      val retryFilter = Filter.mk[Request, Response, Request, Response] { (req, svc) =>
+        doReq(() => svc(req), retriesToDo)
+      }
+      val errFilter = Filter.mk[Request, Response, Request, Response] { (req, svc) =>
+        svc(req).onFailure { e =>
+          err = Some(e)
+        }
+      }
+      val factory = Http.router
+        .withPathStack(Http.router.pathStack
+          .replace(ClassifiedRetries.role, retryFilter)
+          .insertBefore(ClassifiedRetries.role, errFilter))
+        .configured(RoutingFactory.BaseDtab(() => dtab))
+        .configured(RoutingFactory.DstPrefix(Path.Utf8("http")))
+        .configured(param.Stats(stats))
+        .factory()
+      Http.serve(new InetSocketAddress(0), factory)
+    }
+
+    val client = upstream(router)
+    def get() = {
+      val req = Request()
+      req.host = "ds"
+      req.version = Version.Http11
+      await(client(req))
+    }
+
+    // Issue a request
+    try {
+      val rsp0 = get()
+      // don't disconnect to prove we reuse the connection
+      assert(err == None)
+      assert(rsp0.status == Status.Ok)
+      assert(downstreamCounter("connects") == Some(1))
+      assert(downstreamCounter("closed") == None)
+
+      val rsp1 = get()
+      // disconnect, to show that linkerd handles the following request gracefully
+      assert(connection.isDefined)
+      connection.foreach(c => await(c.close()))
+      connection = None
+      assert(err == None)
+      assert(rsp1.status == Status.Ok)
+      assert(downstreamCounter("connects") == Some(1))
+      assert(downstreamCounter("closed") == Some(1))
+
+      retriesToDo = 1
+      val rsp2 = get()
+      assert(connection.isDefined)
+      connection.foreach(c => await(c.close()))
+      connection = None
+      assert(err == None)
+      assert(rsp2.status == Status.Ok)
+      assert(downstreamCounter("connects") == Some(2))
+      assert(downstreamCounter("closed") == Some(2))
+
+    } finally {
+      await(client.close())
+      await(router.close())
+      await(downstream.server.close())
+    }
+  }
+
+  test("http/1.0: server closes connection after response") {
+    val downstream = Downstream.mk("ds") { req =>
+      val status = req.version match {
+        case Version.Http11 => Status.HttpVersionNotSupported
+        case Version.Http10 => Status.Ok
+      }
+      Response(Version.Http10, status)
+    }
+
+    val stats = new InMemoryStatsReceiver
+    def downstreamCounter(name: String) = {
+      val k = Seq("http", "dst", "id", s"$$/inet/127.1/${downstream.port}", name)
+      stats.counters.get(k)
+    }
+
+    @volatile var retriesToDo = 0
+    @volatile var err: Option[Throwable] = None
+    val router = {
+      val dtab = Dtab.read(s"/http => /$$/inet/127.1/${downstream.port}")
+      def doReq(req: () => Future[Response], retries: Int = 0): Future[Response] =
+        req().transform { ret =>
+          if (retries > 0) {
+            doReq(req, retries - 1)
+          } else Future.const(ret)
+        }
+      val retryFilter = Filter.mk[Request, Response, Request, Response] { (req, svc) =>
+        doReq(() => svc(req), retriesToDo)
+      }
+      val errFilter = Filter.mk[Request, Response, Request, Response] { (req, svc) =>
+        svc(req).onFailure { e =>
+          err = Some(e)
+        }
+      }
+      val factory = Http.router
+        .withPathStack(Http.router.pathStack
+          .replace(ClassifiedRetries.role, retryFilter)
+          .insertBefore(ClassifiedRetries.role, errFilter))
+        .configured(RoutingFactory.BaseDtab(() => dtab))
+        .configured(RoutingFactory.DstPrefix(Path.Utf8("http")))
+        .configured(param.Stats(stats))
+        .factory()
+      Http.serve(new InetSocketAddress(0), factory)
+    }
+
+    val client = upstream(router)
+    def get() = {
+      val req = Request()
+      req.host = "ds"
+      req.version = Version.Http10
+      await(client(req))
+    }
+
+    // Issue a request
+    try {
+      val rsp0 = get()
+      assert(err == None)
+      assert(rsp0.status == Status.Ok)
+      assert(downstreamCounter("connects") == Some(1))
+      assert(downstreamCounter("closed") == Some(1))
+
+      val rsp1 = get()
+      assert(err == None)
+      assert(rsp1.status == Status.Ok)
+      assert(downstreamCounter("connects") == Some(2))
+      assert(downstreamCounter("closed") == Some(2))
+
+      retriesToDo = 1
+      val rsp2 = get()
+      assert(err == None)
+      assert(rsp2.status == Status.Ok)
+      assert(downstreamCounter("connects") == Some(4))
+      assert(downstreamCounter("closed") == Some(4))
+
+    } finally {
+      await(client.close())
+      await(router.close())
+      await(downstream.server.close())
     }
   }
 }


### PR DESCRIPTION
The retry filter may issue multiple requests on the underlying service factory.
This interaction needs to be managed by a FactoryToService module so that the
underlying service (connection) is released to finagle between requests so
that, for instance, it may be closed in the case of HTTP/1.0 requests.

Fixes #409