### PR TITLE
Don't mark commons dependencies as 'twitter libs'

### DIFF
--- a/project/LinkerdBuild.scala
+++ b/project/LinkerdBuild.scala
@@ -100,7 +100,7 @@ object LinkerdBuild extends Base {
 
     val zkLeader = projectDir("namer/zk-leader")
       .dependsOn(core)
-      .withTwitterLib(Deps.zkCandidate)
+      .withLib(Deps.zkCandidate)
       .withTests()
 
     val all = projectDir("namer")


### PR DESCRIPTION
The withTwitterLib helper is used to build against snapshots of the twitter
tree for: util, finagle, scrooge, and twitter-server. However, commons
dependencies are not pushed with the same regularity, so we can't build against
snapshot versions of commons dependencies.