### PR TITLE
Use a static RoutingService in RoutingFactory

### DIFF
--- a/router/core/src/main/scala/io/buoyant/router/RoutingFactory.scala
+++ b/router/core/src/main/scala/io/buoyant/router/RoutingFactory.scala
@@ -72,8 +72,16 @@ class RoutingFactory[Req, Rsp](
   override def close(deadline: Time): Future[Unit] = clientFactory.close(deadline)
   override def status: Status = clientFactory.status
 
-  def apply(conn: ClientConnection): Future[Service[Req, Rsp]] =
-    Future.value(new RoutingService(conn))
+  def apply(conn: ClientConnection): Future[Service[Req, Rsp]] = service
+
+  /**
+   * The router doesn't actually need a reference to the client
+   * connection, so we can use a nil client connection (as would be
+   * the case when manually constructing a Finagle Client
+   * ServiceFactory). This has a notable impact on performance,
+   * especially in the face of server connection churn.
+   */
+  private val service = Future.value(new RoutingService(ClientConnection.nil))
 
   // TODO move trace recording into a separate stack module?
   private class RoutingService(conn: ClientConnection) extends Service[Req, Rsp] {


### PR DESCRIPTION
RoutingFactory currently builds a new RoutingService for each connection. The
server-side connection is passed into the DstBindingFactory.  This is wasteful,
considering that none of the server-side connection state matters to the
router. By simplifying this to use a static RoutingService with a nil
connection, we see substantial performance improvements in the face of
serverside connection churn.