### PR TITLE
Move kind names out of doc headers.

### DIFF
--- a/linkerd/docs/client_tls.md
+++ b/linkerd/docs/client_tls.md
@@ -5,11 +5,15 @@ to destination services.  A client TLS config block must contain a `kind`
 parameter which indicates which client TLS plugin to use as well as any
 parameters specific to the plugin.
 
-## io.l5d.noValidation
+## No Validation
+
+`io.l5d.noValidation`
 
 Skip hostname validation.  This is unsafe.
 
-## io.l5d.static
+## Static
+
+`io.l5d.static`
 
 Use a single common name for all TLS requests.  This assumes that all servers
 that the router connects to all use the same TLS cert (or all use certs
@@ -19,7 +23,9 @@ options:
 * *commonName* -- Required.  The common name to use for all TLS requests.
 * *caCertPath* -- Optional.  Use the given CA cert for common name validation.
 
-## io.l5d.boundPath
+## Bound Path
+
+`io.l5d.boundPath`
 
 Determine the common name based on the destination bound path.  This plugin
 supports the following options:

--- a/linkerd/docs/interpreter.md
+++ b/linkerd/docs/interpreter.md
@@ -3,13 +3,15 @@
 An interpreter determines how names are resolved.  An interpreter config block
 must contain a `kind` parameter which indicates which interpreter plugin to use.
 
-## default
+## Default
 
 The default interpreter resolves names via the configured
 [`namers`](config.md#namers), with a fallback to the default Finagle
 `Namer.Global` that handles paths of the form `/$/`.
 
-## io.l5d.namerd
+## namerd
+
+`io.l5d.namerd`
 
 The namerd interpreter offloads the responsibilities of name resolution to the
 namerd service.  Any namers configured in this linkerd are not used.  This

--- a/linkerd/docs/namer.md
+++ b/linkerd/docs/namer.md
@@ -14,6 +14,8 @@ A namer config block has the following parameters:
 
 ## File-based service discovery
 
+`io.l5d.fs`
+
 linkerd ships with a simple file-based service discovery mechanism, called the
 *file-based namer*. This system is intended to act as a structured form of
 basic host lists.
@@ -73,6 +75,8 @@ baseDtab: |
 
 ## ZooKeeper ServerSets service discovery
 
+`io.l5d.serversets`
+
 linkerd provides support for [ZooKeeper
 ServerSets](https://twitter.github.io/commons/apidocs/com/twitter/common/zookeeper/ServerSet.html).
 
@@ -101,6 +105,8 @@ baseDtab: |
 ```
 
 ## Consul service discovery (experimental)
+
+`io.l5d.consul`
 
 linkerd provides support for service discovery via
 [Consul](https://www.consul.io/). Note that this support is still considered
@@ -131,6 +137,8 @@ baseDtab: |
 ```
 
 ## Kubernetes service discovery (experimental)
+
+`io.l5d.k8s`
 
 linkerd provides support for service discovery via
 [Kubernetes](https://k8s.io/). Note that this support is still considered
@@ -170,6 +178,8 @@ baseDtab: |
 ```
 
 ## Marathon service discovery (experimental)
+
+`io.l5d.marathon`
 
 linkerd provides support for service discovery via
 [Marathon](https://mesosphere.github.io/marathon/). Note that this support is still considered
@@ -216,6 +226,8 @@ baseDtab: |
 ```
 
 ## ZooKeeper Leader
+
+`io.l5d.zkLeader`
 
 A namer backed by ZooKeeper leader election. The path processed by this namer is treated as the
 ZooKeeper path of a leader group. The namer resolves to the address stored in the data of the

--- a/linkerd/docs/protocol-http.md
+++ b/linkerd/docs/protocol-http.md
@@ -37,7 +37,9 @@ request with the following parameters:
   * *io.l5d.path*
 * any other identifier-specific parameters
 
-### io.l5d.methodAndHost
+### Method and Host
+
+`io.l5d.methodAndHost`
 
 HTTP requests are routed by a combination of Host header, method, and URI.
 
@@ -56,7 +58,9 @@ and HTTP/1.1 logical names are of the form:
 In both cases, `uri` is only considered a part
 of the logical name if the config option `httpUriInDst` is true.
 
-### io.l5d.path
+### Path
+
+`io.l5d.path`
 
 HTTP requests are routed based on a configurable number of "/" separated
 segments from the start of their HTTP path.

--- a/linkerd/docs/response_classifier.md
+++ b/linkerd/docs/response_classifier.md
@@ -6,17 +6,23 @@ of these responses may be [retried](retries.md). A response classifier
 config block must contain a `kind` parameter which indicates which classifier
 plugin to use.  By default, the _io.l5d.nonRetryable5XX_ classifier is used.
 
-## io.l5d.nonRetryable5XX
+## Non-Retryable 5XX
+
+`io.l5d.nonRetryable5XX`
 
 All 5XX responses are considered to be failures and none of these
 requests are considered to be retryable.
 
-## io.l5d.retryableRead5XX
+## Retryable Read 5XX
+
+`io.l5d.retryableRead5XX`
 
 All 5XX responses are considered to be failures. However, `GET`,
 `HEAD`, `OPTIONS`, and `TRACE` requests may be retried automatically.
 
-## io.l5d.retryableIdempotent5XX
+## Retryable Idempotent 5XX
+
+`io.l5d.retryableIdempotent5XX`
 
 Like _io.l5d.retryableRead5XX_, but `PUT` and `DELETE` requests may also be
 retried.

--- a/linkerd/docs/tracer.md
+++ b/linkerd/docs/tracer.md
@@ -11,7 +11,9 @@ that flag if not set here.
 
 Current tracers include:
 
-## io.l5d.zipkin
+## Zipkin
+
+`io.l5d.zipkin`
 
 Finagle's [zipkin-tracer](https://github.com/twitter/finagle/tree/develop/finagle-zipkin).
 

--- a/namerd/docs/interface.md
+++ b/namerd/docs/interface.md
@@ -9,7 +9,9 @@ block supports the following params:
 * *port* -- Optional.  The port number on which to server the namer interface.
 (defaults may be provided by plugins)
 
-## io.l5d.thriftNameInterpreter
+## Thrift Name Interpreter
+
+`io.l5d.thriftNameInterpreter`
 
 A read-only interface providing `NameInterpreter` functionality over the ThriftMux protocol.
 
@@ -20,7 +22,9 @@ before retrying after an error.  (default: 600)
 * *retryJitterSecs* -- Optional.  Maximum number of seconds to jitter retry
 time by.  (default: 60)
 
-## io.l5d.httpController
+## Http Controller
+
+`io.l5d.httpController`
 
 A read-write HTTP interface to the `storage`.
 

--- a/namerd/docs/storage.md
+++ b/namerd/docs/storage.md
@@ -7,13 +7,17 @@ dtabs. This object supports the following params:
 * *experimental* -- Set this to `true` to enable the storage if it is experimental.
 * *sotrage-specific parameters*.
 
-## io.l5d.inMemory
+## In Memory
+
+`io.l5d.inMemory`
 
 Stores the dtab in memory.  Not suitable for production use.
 
 * *namespaces* -- Optional.  A map of namespaces to corresponding dtabs.
 
-## io.l5d.k8s
+## Kubernetes
+
+`io.l5d.k8s`
 
 *experimental*
 
@@ -30,7 +34,9 @@ running Kubernetes 1.2+ with the ThirdPartyResource feature enabled.
 * *namespace* The Kubernetes namespace in which dtabs will be stored. This should usually be the
   same namespace in which namerd is running. (default: "default")
 
-## io.l5d.zk
+## ZooKeeper
+
+`io.l5d.zk`
 
 *experimental*
 
@@ -52,7 +58,9 @@ containing:
   * *perms* -- Required.  A subset of the string "crwda" representing the permissions of this ACL.
   The characters represent create, read, write, delete, and admin, respectively.
 
-## io.l5d.etcd
+## Etcd
+
+`io.l5d.etcd`
 
 *experimental*
 


### PR DESCRIPTION
With certain stylings, headers are displayed in all caps which makes it impossible to see the casing of kind names.  We move kind names out of the headers to avoid this.