### PR TITLE
Attempt to fix CI for non-Buoyant contributors

### DIFF
--- a/circle.yml
+++ b/circle.yml
@@ -18,7 +18,7 @@ test:
         parallel: true
 
   post:
-    - ci/coverage-publish.sh
+    - ci/coverage-publish.sh || true # We don't want to block the build on a failure to publish coverage results
     - mkdir -p "$CIRCLE_TEST_REPORTS/junit" && find . -type f -regex ".*/target/test-reports/.*xml" -exec cp {} "$CIRCLE_TEST_REPORTS/junit/" \;
 
 deployment:


### PR DESCRIPTION
...by continuing even if coverage fails.

See https://circleci.com/gh/BuoyantIO/linkerd/1564 for an example of the kind of failure we're trying to avoid here.

Fixes #399.