### PR TITLE
Trace response status using response classification.

### DIFF
--- a/router/core/src/main/scala/io/buoyant/router/ClassifiedTracing.scala
+++ b/router/core/src/main/scala/io/buoyant/router/ClassifiedTracing.scala
@@ -1,0 +1,52 @@
+package io.buoyant.router
+
+import com.twitter.finagle.{Stack, Stackable, Service, ServiceFactory, SimpleFilter, param}
+import com.twitter.finagle.tracing.{Trace, Tracer}
+import com.twitter.finagle.service.{ReqRep, ResponseClass, ResponseClassifier}
+import com.twitter.util.{Duration, Future}
+
+object ClassifiedTracing {
+  val role = Stack.Role("ClassifiedTracing")
+
+  /**
+   * A RetryPolicy that uses a ResponseClassifier.
+   */
+  private class Filter[Req, Rsp](classifier: ResponseClassifier) extends SimpleFilter[Req, Rsp] {
+    def apply(req: Req, service: Service[Req, Rsp]): Future[Rsp] =
+      service(req).respond { rsp =>
+        if (Trace.isActivelyTracing) {
+          classifier.applyOrElse(ReqRep(req, rsp), ResponseClassifier.Default) match {
+            case ResponseClass.Successful(fraction) =>
+              Trace.recordBinary("l5d.success", fraction)
+            case ResponseClass.Failed(true) =>
+              Trace.record("l5d.retryable")
+            case ResponseClass.Failed(false) =>
+              Trace.record("l5d.failed")
+          }
+        }
+      }
+  }
+
+  /**
+   * A stack module that, if a tracer is enabled, annotates traces
+   * based on response classifications.
+   */
+  def module[Req, Rsp]: Stackable[ServiceFactory[Req, Rsp]] =
+    new Stack.Module2[param.Tracer, param.ResponseClassifier, ServiceFactory[Req, Rsp]] {
+      val role = ClassifiedTracing.role
+      val description = "Traces response classification annotations"
+      def make(
+        _tracer: param.Tracer,
+        _classifier: param.ResponseClassifier,
+        next: ServiceFactory[Req, Rsp]
+      ): ServiceFactory[Req, Rsp] = {
+        val param.Tracer(tracer) = _tracer
+        if (tracer.isNull) next
+        else {
+          val param.ResponseClassifier(classifier) = _classifier
+          new Filter[Req, Rsp](classifier) andThen next
+        }
+      }
+    }
+}
+

--- a/router/core/src/main/scala/io/buoyant/router/Router.scala
+++ b/router/core/src/main/scala/io/buoyant/router/Router.scala
@@ -277,7 +277,8 @@ object StackRouter {
   object Client {
 
     /**
-     * Install ClassifiedTracing to
+     * Install ClassifiedTracing to mark each request-response's
+     * classification (success, failure, or retryable).
      *
      * Install the TlsClientPrep module below the endpoint stack so that it
      * may avail itself of any and all params to set TLS params.

--- a/router/core/src/main/scala/io/buoyant/router/Router.scala
+++ b/router/core/src/main/scala/io/buoyant/router/Router.scala
@@ -277,11 +277,13 @@ object StackRouter {
   object Client {
 
     /**
+     * Install ClassifiedTracing to
+     *
      * Install the TlsClientPrep module below the endpoint stack so that it
      * may avail itself of any and all params to set TLS params.
      */
     def mkStack[Req, Rsp](orig: Stack[ServiceFactory[Req, Rsp]]): Stack[ServiceFactory[Req, Rsp]] =
-      (orig ++ (TlsClientPrep.nop[Req, Rsp] +: stack.nilStack))
+      ClassifiedTracing.module[Req, Rsp] +: (orig ++ (TlsClientPrep.nop[Req, Rsp] +: stack.nilStack))
   }
 
   def newPathStack[Req, Rsp]: Stack[ServiceFactory[Req, Rsp]] = {

--- a/router/core/src/test/scala/io/buoyant/router/ClassifiedTracingTest.scala
+++ b/router/core/src/test/scala/io/buoyant/router/ClassifiedTracingTest.scala
@@ -1,0 +1,116 @@
+package io.buoyant.router
+
+import com.twitter.finagle.{Service, ServiceFactory, Stack, param}
+import com.twitter.finagle.stack._
+import com.twitter.finagle.service.{ReqRep, ResponseClass, ResponseClassifier}
+import com.twitter.finagle.tracing._
+import com.twitter.util.{Future, Return, Throw}
+import io.buoyant.test.Awaits
+import org.scalatest.FunSuite
+
+class ClassifiedTracingTest extends FunSuite with Awaits {
+
+  trait Ctx {
+    val classifier = ResponseClassifier.named("test") {
+      case ReqRep(_, Throw(_)) => ResponseClass.NonRetryableFailure
+      case ReqRep("retry", Return(_)) => ResponseClass.RetryableFailure
+      case ReqRep(_, Return(s: Double)) => ResponseClass.Successful(s)
+    }
+
+    var tracer = new BufferingTracer
+    var sampled: Option[Boolean] = None
+
+    lazy val factory = {
+      val sf = ServiceFactory.const(Service.mk[String, Double] {
+        case "fail" => Future.exception(new Exception)
+        case s => Future.value(0.84)
+      })
+      val stk = ClassifiedTracing.module[String, Double] +: Stack.Leaf(Endpoint, sf)
+      val params = Stack.Params.empty +
+        param.ResponseClassifier(classifier) +
+        param.Tracer(tracer)
+      stk.make(params)
+    }
+
+    lazy val svc = Service.mk[String, Double] { s =>
+      Trace.letTracerAndId(tracer, TraceId(None, None, SpanId(3), sampled), false) {
+        factory().flatMap { svc =>
+          svc(s).ensure {
+            val _ = svc.close()
+          }
+        }
+      }
+    }
+
+    def call(s: String): Unit = {
+      val _ = await(svc(s).liftToTry)
+    }
+  }
+
+  test("module installs a classified tracing filter") {
+    val ctx = new Ctx {}
+    import ctx._
+
+    tracer.clear()
+    call("ok")
+    assert(tracer.iterator.map(_.annotation).toSeq ==
+      Seq(Annotation.BinaryAnnotation("l5d.success", 0.84)))
+
+    tracer.clear()
+    call("fail")
+    assert(tracer.iterator.map(_.annotation).toSeq ==
+      Seq(Annotation.Message("l5d.failure")))
+
+    tracer.clear()
+    call("retry")
+    assert(tracer.iterator.map(_.annotation).toSeq ==
+      Seq(Annotation.Message("l5d.retryable")))
+  }
+
+  test("module doesn't install tracing filter when no tracer is configured") {
+    val ctx = new Ctx {}
+    import ctx._
+
+    tracer = new BufferingTracer {
+      override def isNull = true
+    }
+
+    call("ok")
+    assert(tracer.iterator.map(_.annotation).toSeq == Seq())
+
+    call("fail")
+    assert(tracer.iterator.map(_.annotation).toSeq == Seq())
+
+    call("retry")
+    assert(tracer.iterator.map(_.annotation).toSeq == Seq())
+  }
+
+  test("traces when no sampling configured") {
+    val ctx = new Ctx {}
+    import ctx._
+
+    sampled = None
+    call("ok")
+    assert(tracer.iterator.map(_.annotation).toSeq ==
+      Seq(Annotation.BinaryAnnotation("l5d.success", 0.84)))
+  }
+
+  test("traces when sampling is true") {
+    val ctx = new Ctx {}
+    import ctx._
+
+    sampled = Some(true)
+    call("ok")
+    assert(tracer.iterator.map(_.annotation).toSeq ==
+      Seq(Annotation.BinaryAnnotation("l5d.success", 0.84)))
+  }
+
+  test("does not trace when is false") {
+    val ctx = new Ctx {}
+    import ctx._
+
+    sampled = Some(false)
+    call("ok")
+    assert(tracer.iterator.map(_.annotation).toSeq == Seq())
+  }
+}


### PR DESCRIPTION
Each client response causes the annotation of:

- l5d.success, with a "fractional success" value
- l5d.retryable, when a retryable failure is encountered
- l5d.failed, when a non-retryable failure is encounted

Fixes #431