### PR TITLE
Use "nightly" docker tags in CI.

### DIFF
--- a/ci/docker-publish.sh
+++ b/ci/docker-publish.sh
@@ -2,22 +2,31 @@
 
 set -eu
 
+# usage: docker-publish.sh [tag]
+
+tag=""
+if [ -n "${1:-}" ]; then
+  tag="$1"
+fi
+
+# if DOCKER_CREDENTIALS is set, save it locally.
 if [ -n "${DOCKER_CREDENTIALS:-}" ]; then
   mkdir -p ~/.docker
   echo "$DOCKER_CREDENTIALS" > ~/.docker/config.json
 fi
 
-set_tag=""
-if [ "${NIGHTLY:-}" = "1" ] && [ ! "${TWITTER_DEVELOP:-}" = "1" ]; then
-  set_tag='set dockerTag in Global := "nightly"'
-fi
-
+# For debugging, alow this to be run without pushing.
 docker_target="dockerBuildAndPush"
 if [ "${NO_PUSH:-}" = "1" ]; then
   docker_target="docker"
 fi
 
-./sbt "$set_tag" \
-      "linkerd/bundle:${docker_target}" \
-      "namerd/bundle:${docker_target}" \
-      "namerd/dcos:${docker_target}"
+if [ -n "$tag" ]; then
+  ./sbt "set dockerTag in (linkerd, Bundle) := \"${tag}\"" "linkerd/bundle:${docker_target}" \
+        "set dockerTag in (namerd, Bundle) := \"${tag}\"" "namerd/bundle:${docker_target}" \
+        "set dockerTag in (namerd, Dcos) := \"dcos-${tag}\"" "namerd/dcos:${docker_target}"
+else
+  ./sbt "linkerd/bundle:${docker_target}" \
+        "namerd/bundle:${docker_target}" \
+        "namerd/dcos:${docker_target}"
+fi

--- a/ci/docker-publish.sh
+++ b/ci/docker-publish.sh
@@ -8,12 +8,8 @@ if [ -n "${DOCKER_CREDENTIALS:-}" ]; then
 fi
 
 set_tag=""
-if [ "${NIGHTLY:-}" = "1" ]; then
-  if [ "${TWITTER_DEVELOP:-}" = "1" ]; then
-    set_tag='set dockerTag in Global := "unstable"'
-  else 
-    set_tag='set dockerTag in Global := "nightly"'
-  fi
+if [ "${NIGHTLY:-}" = "1" ] && [ ! "${TWITTER_DEVELOP:-}" = "1" ]; then
+  set_tag='set dockerTag in Global := "nightly"'
 fi
 
 docker_target="dockerBuildAndPush"

--- a/ci/update.sh
+++ b/ci/update.sh
@@ -2,7 +2,7 @@
 
 set -eu
 
-if [ -n "${TWITTER_DEVELOP:-}" ]; then
+if [ "${TWITTER_DEVELOP:-}" = "1" ]; then
   mkdir -p ~/.gitshas
   export GIT_SHA_DIR=~/.gitshas
   ./ci/twitter-develop.sh

--- a/circle.yml
+++ b/circle.yml
@@ -22,7 +22,7 @@ test:
     - mkdir -p "$CIRCLE_TEST_REPORTS/junit" && find . -type f -regex ".*/target/test-reports/.*xml" -exec cp {} "$CIRCLE_TEST_REPORTS/junit/" \;
 
 deployment:
-  master:
+  nightly:
     branch: master
     commands:
       - if [ "$NIGHTLY" = "1" ]; then ci/docker-publish.sh ; fi

--- a/circle.yml
+++ b/circle.yml
@@ -25,4 +25,4 @@ deployment:
   master:
     branch: master
     commands:
-      - ci/docker-publish.sh
+      - if [ "$NIGHTLY" = "1" ]; then ci/docker-publish.sh ; fi

--- a/circle.yml
+++ b/circle.yml
@@ -25,4 +25,4 @@ deployment:
   nightly:
     branch: master
     commands:
-      - if [ "$NIGHTLY" = "1" ]; then ci/docker-publish.sh ; fi
+      - if [ "$NIGHTLY" = "1" ]; then ci/docker-publish.sh nightly ; fi

--- a/project/Base.scala
+++ b/project/Base.scala
@@ -44,7 +44,7 @@ class Base extends Build {
       "typesafe" at "https://repo.typesafe.com/typesafe/releases"
     ),
     aggregate in assembly := false,
-    developTwitterDeps := sys.env.contains("TWITTER_DEVELOP")
+    developTwitterDeps := { sys.env.get("TWITTER_DEVELOP") == Some("1") }
   )
 
   val scalariformSettings = baseScalariformSettings ++ Seq(
@@ -68,6 +68,7 @@ class Base extends Build {
 
   val dockerEnvPrefix = settingKey[String]("prefix to be applied to environment variables")
   val dockerJavaImage = settingKey[String]("base docker image, providing java")
+  val dockerTag = settingKey[String]("docker image tag")
   val assemblyExecScript = settingKey[Seq[String]]("script used to execute the application")
 
   val appPackagingSettings = assemblySettings ++ baseDockerSettings ++ Seq(
@@ -98,10 +99,11 @@ class Base extends Build {
       copy((assemblyOutputPath in assembly).value, exec)
       entryPoint(exec)
     },
+    dockerTag <<= (dockerTag in Global).or((version, configuration) { (v, c) => s"${v}-${c}" }),
     imageName in docker := ImageName(
       namespace = Some("buoyantio"),
       repository = name.value,
-      tag = Some(s"${version.value}-${configuration.value}")
+      tag = Some(dockerTag.value)
     )
   )
 

--- a/project/LinkerdBuild.scala
+++ b/project/LinkerdBuild.scala
@@ -10,6 +10,7 @@ object LinkerdBuild extends Base {
 
   val Minimal = config("minimal")
   val Bundle = config("bundle") extend Minimal
+  val Dcos = config("dcos") extend Bundle
 
   val consul = projectDir("consul")
     .withTwitterLib(Deps.finagle("http"))
@@ -228,7 +229,7 @@ object LinkerdBuild extends Base {
     val Bundle = config("bundle") extend Minimal
     val BundleSettings = MinimalSettings ++ Seq(
       assemblyJarName in assembly := s"${name.value}-${version.value}-exec",
-      imageName in docker := (imageName in docker).value.copy(tag = Some(version.value))
+      dockerTag := version.value
     )
 
     /**
@@ -263,7 +264,6 @@ object LinkerdBuild extends Base {
     val dcosBootstrap = projectDir("namerd/dcos-bootstrap")
       .dependsOn(core, admin, configCore, Storage.zk)
 
-    val Dcos = config("dcos") extend Bundle
     val DcosSettings = MinimalSettings ++ Seq(
       assemblyExecScript := dcosExecScript.split("\n").toSeq
     )
@@ -420,7 +420,7 @@ object LinkerdBuild extends Base {
 
     val BundleSettings = MinimalSettings ++ Seq(
       assemblyJarName in assembly := s"${name.value}-${version.value}-exec",
-      imageName in docker := (imageName in docker).value.copy(tag = Some(version.value))
+      dockerTag := version.value
     )
 
     val all = projectDir("linkerd")

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -14,7 +14,7 @@ addSbtPlugin("com.eed3si9n"   % "sbt-unidoc"    % "0.3.3")
 // packaging
 addSbtPlugin("com.eed3si9n"      % "sbt-assembly"  % "0.14.1")
 
-addSbtPlugin("se.marcuslonnberg" % "sbt-docker"    % "1.2.0")
+addSbtPlugin("se.marcuslonnberg" % "sbt-docker"    % "1.4.0")
 
 // scrooge
 addSbtPlugin("com.twitter" %% "scrooge-sbt-plugin" % "4.6.0")


### PR DESCRIPTION
Only publish docker tags from CI when the `NIGHTLY` build parameter is set to 1.

When the `TWITTER_DEVELOP` build parameter is also set to 1, publish the "unstable" tag.