### PR TITLE
Bump EndToEndTest timeouts to 5 seconds

### DIFF
--- a/router/core/src/e2e/scala/io/buoyant/router/EchoEndToEndTest.scala
+++ b/router/core/src/e2e/scala/io/buoyant/router/EchoEndToEndTest.scala
@@ -16,7 +16,7 @@ import org.scalatest.FunSuite
 
 class EchoEndToEndTest extends FunSuite with Awaits {
 
-  override val defaultWait = 2.seconds
+  override val defaultWait = 5.seconds
 
   case class Downstream(name: String, server: ListeningServer) {
     val address = server.boundAddress.asInstanceOf[InetSocketAddress]

--- a/router/http/src/e2e/scala/io/buoyant/router/HttpEndToEndTest.scala
+++ b/router/http/src/e2e/scala/io/buoyant/router/HttpEndToEndTest.scala
@@ -14,7 +14,7 @@ import org.scalatest.FunSuite
 
 class HttpEndToEndTest extends FunSuite with Awaits {
 
-  override val defaultWait = 2.seconds
+  override val defaultWait = 5.seconds
 
   case class Downstream(name: String, server: ListeningServer) {
     val address = server.boundAddress.asInstanceOf[InetSocketAddress]

--- a/router/mux/src/e2e/scala/io/buoyant/router/MuxEndToEndTest.scala
+++ b/router/mux/src/e2e/scala/io/buoyant/router/MuxEndToEndTest.scala
@@ -14,7 +14,7 @@ class MuxEndToEndTest extends FunSuite with Awaits {
 
   // since this is dealing with open sockets we need to be somewhat
   // tolerant to slow test environments (cough circleci).
-  override val defaultWait = 2.seconds
+  override val defaultWait = 5.seconds
 
   /*
    * A bunch of utility/setup.  The test is configured as follows:

--- a/router/thrift/src/e2e/scala/io/buoyant/router/ThriftEndToEndTest.scala
+++ b/router/thrift/src/e2e/scala/io/buoyant/router/ThriftEndToEndTest.scala
@@ -13,7 +13,7 @@ import org.scalatest.FunSuite
 
 class ThriftEndToEndTest extends FunSuite with Awaits {
 
-  override val defaultWait = 2.seconds
+  override val defaultWait = 5.seconds
 
   case class Downstream(name: String, server: ListeningServer) {
     val address = server.boundAddress.asInstanceOf[InetSocketAddress]


### PR DESCRIPTION
We still see way too many CI failures due to timeouts, presumably because the
CI infrastructure is slooooow. So let's set a ridiculously high timeout to work
around it.