### PR TITLE
Add media query to modify dashboard appearance on large screens

### DIFF
--- a/admin/src/main/resources/io/buoyant/admin/css/dashboard.css
+++ b/admin/src/main/resources/io/buoyant/admin/css/dashboard.css
@@ -205,3 +205,26 @@ nav ul.navbar-nav {
   padding-left: 15px;
   margin: 20px 0 30px 0;
 }
+
+/*
+* For wider screens
+*/
+
+@media (min-width: 1400px) {
+  .navbar-container {
+    width: 100vw;
+  }
+
+  .dashboard-container {
+    margin: 0 1.5vw 0;
+    min-width: 96vw;
+  }
+
+  .row.proc-info, .router, .clients .router-graph {
+    min-width: 96vw;
+  }
+
+  .router > div {
+    width: 100%;
+  }
+}

--- a/admin/src/main/resources/io/buoyant/admin/js/client_success_graph.js
+++ b/admin/src/main/resources/io/buoyant/admin/js/client_success_graph.js
@@ -1,6 +1,7 @@
 /* globals UpdateableChart */
 /* exported ClientSuccessRateGraph */
 var ClientSuccessRateGraph = (function() {
+  var columnGridPadding = 27; // from our css grid setup
   var neutralLineColor = "#878787"; // greys.neutral
 
   function createChartLegend(successLineColor) {
@@ -32,7 +33,10 @@ var ClientSuccessRateGraph = (function() {
       },
       $canvas[0],
       function() {
-        return $chartEl.width();
+        var containerWidth = $(".router-clients").first().width();
+        var metricsWidth = $(".metrics-container").first().width();
+
+        return containerWidth - metricsWidth - columnGridPadding; // get this to display nicely on wide screens
       },
       timeseriesParamsFn
     );

--- a/admin/src/main/resources/io/buoyant/admin/js/combined_client_graph.js
+++ b/admin/src/main/resources/io/buoyant/admin/js/combined_client_graph.js
@@ -1,6 +1,8 @@
 /* globals Query, UpdateableChart */
 /* exported CombinedClientGraph */
 var CombinedClientGraph = (function() {
+  var defaultWidth = 1181;
+
   function clientToMetric(client) {
     return {name: client, color: ""}; //TODO: move to clientName only after v2 migration
   }
@@ -34,7 +36,8 @@ var CombinedClientGraph = (function() {
       },
       $root[0],
       function() {
-        return 1161;
+        var containerWidth = $(".router-clients").first().width(); // get this to display nicely on wide screens
+        return containerWidth || defaultWidth;
       },
       timeseriesParams
     );


### PR DESCRIPTION
Fixes #412
I used viewport widths rather than pixels, and guestimated on reasonable values for our col-md choices.
Now if you widen the window the dashboard will scale.
Let me know what you think.  Latency table does look a little weird.

Here are some screenshots of various widths:

![screen shot 2016-05-24 at 3 13 42 pm](https://cloud.githubusercontent.com/assets/549258/15521797/a41d359c-21c2-11e6-85b9-45fb0bcefc8a.png)
![screen shot 2016-05-24 at 3 13 47 pm](https://cloud.githubusercontent.com/assets/549258/15521795/a41d9cd0-21c2-11e6-98ab-6a3db4998bdf.png)
![screen shot 2016-05-24 at 3 13 56 pm](https://cloud.githubusercontent.com/assets/549258/15521796/a41df55e-21c2-11e6-9065-725be929bdab.png)
![screen shot 2016-05-24 at 3 13 59 pm](https://cloud.githubusercontent.com/assets/549258/15521799/a41fe440-21c2-11e6-80c6-3825e48556c8.png)
![screen shot 2016-05-24 at 3 14 06 pm](https://cloud.githubusercontent.com/assets/549258/15521800/a421510e-21c2-11e6-9c3c-33783d0f559b.png)
<img width="1280" alt="screen shot 2016-05-24 at 3 15 42 pm" src="https://cloud.githubusercontent.com/assets/549258/15521798/a41f31d0-21c2-11e6-994a-cb33ecb6bbe6.png">
