### PR TITLE
Add a link to the delegator UI in the no hosts error message.

### DIFF
--- a/admin/src/main/scala/io/buoyant/admin/names/DelegateHandler.scala
+++ b/admin/src/main/scala/io/buoyant/admin/names/DelegateHandler.scala
@@ -12,8 +12,15 @@ class DelegateHandler(
   namers: Seq[(Path, Namer)]
 ) extends Service[Request, Response] {
 
-  def apply(req: Request): Future[Response] =
-    dtabs().map(render).flatMap(view.mkResponse(_))
+  def apply(req: Request): Future[Response] = {
+    val dtabLocal = req.params.get("dtab.local") match {
+      case Some(dtabStr) => Dtab.read(dtabStr)
+      case None => Dtab.empty
+    }
+    dtabs().map { dtabs =>
+      render(dtabs.mapValues(_ ++ dtabLocal))
+    }.flatMap(view.mkResponse(_))
+  }
 
   def render(dtab: Map[String, Dtab]) =
     view.html(


### PR DESCRIPTION
Fixes #445 

Changed the no hosts exception message from 

```No hosts are available for /http/1.1/POST/api-close, Dtab.base=[/http/1.1/*=>/#/io.l5d.k8s/linkerd/http], Dtab.local=[]. Remote Info: Not Available```

to

```Error resolving /http/1.1/GET/foobar.  See 0.0.0.0:9991/delegator?dtab.local=%2Fhost%2Ffoobar%3D%3E%2Fnope&router=http#%2Fhttp%2F1.1%2FGET%2Ffoobar for details. Remote Info: Not Available```

which is a link to a pre-populated delegator UI.