### PR TITLE
Better defaults

### DIFF
--- a/project/LinkerdBuild.scala
+++ b/project/LinkerdBuild.scala
@@ -119,7 +119,8 @@ object LinkerdBuild extends Base {
   val execScriptJvmOptions =
     """|DEFAULT_JVM_OPTIONS="-Djava.net.preferIPv4Stack=true \
        |   -Dsun.net.inetaddr.ttl=60                         \
-       |   -Xms${JVM_HEAP:-40M} -Xmx${JVM_HEAP:-40M}         \
+       |   -Xms${JVM_HEAP_MIN:-32M}                          \
+       |   -Xmx${JVM_HEAP_MAX:-1024M}                        \
        |   -XX:+AggressiveOpts                               \
        |   -XX:+UseConcMarkSweepGC                           \
        |   -XX:+CMSParallelRemarkEnabled                     \
@@ -128,8 +129,7 @@ object LinkerdBuild extends Base {
        |   -XX:+CMSScavengeBeforeRemark                      \
        |   -XX:+UseCMSInitiatingOccupancyOnly                \
        |   -XX:CMSInitiatingOccupancyFraction=70             \
-       |   -XX:ReservedCodeCacheSize=32m                     \
-       |   -XX:CICompilerCount=2                             \
+       |   -XX:-TieredCompilation                            \
        |   -XX:+UseStringDeduplication                       "
        |""".stripMargin
 


### PR DESCRIPTION
Removing JVM_HEAP and instead using a JVM_MIN_HEAP and JVM_MAX_HEAP allows linkerd to grow the heap as traffic increases. slow cooking it showed that memory use was pretty consistent at 1000 qps and didn't grow without bounds.

I removed `-XX:ReservedCodeCacheSize=32m` because that's already the default.
I removed `-XX:CICompilerCount=2` to let the JVM tune itself.

At 10 qps, RSS is 105mb, cpu is 4%
At 100 qps, RSS is 110mb, cpu is 10%
At 1000 qps, RSS is 140mb, cpu is 40%