### PR TITLE
Hold cached vars open

### DIFF
--- a/namerd/iface/interpreter-thrift/src/main/scala/io/buoyant/namerd/iface/ThriftNamerClient.scala
+++ b/namerd/iface/interpreter-thrift/src/main/scala/io/buoyant/namerd/iface/ThriftNamerClient.scala
@@ -46,6 +46,8 @@ class ThriftNamerClient(
           Trace.recordBinary("namerd.client/bind.cached", false)
           val act = watchName(dtab, path)
           bindCache += (key -> act)
+          // hold the cached activity open forever
+          val _ = act.run.changes.respond(_ => ())
           act
       }
     }
@@ -117,6 +119,8 @@ class ThriftNamerClient(
             case None =>
               val addr = watchAddr(tid)
               addrCache += (id -> addr)
+              // hold the cached var open forever
+              val _ = addr.changes.respond(_ => ())
               addr
           }
         }


### PR DESCRIPTION
# Problem

In ThriftNamerClient, we cache the bind Activity and addr Var.  However, each request passing through linkerd will observe an Activity/Var and then close the observation.  This means that the Var.async loop gets restarted on every request.  The result is that 2 calls to namerd are made for each linkerd request which causes extreme memory blowup.

# Solution

Register a dummy observer for each cached Var to hold it open.

Note: when we add eviction to ThiftNamerClient, we will also need to add a mechanism to close observations on the evicted Vars.