### PR TITLE
Increase bindcache capacity

### DIFF
--- a/linkerd/core/src/test/scala/io/buoyant/linkerd/RouterTest.scala
+++ b/linkerd/core/src/test/scala/io/buoyant/linkerd/RouterTest.scala
@@ -122,4 +122,19 @@ servers:
       Some(RetryBudgetConfig(Some(30), Some(3), Some(0.33)))
     )))
   }
+
+  test("with binding cache") {
+    val yaml =
+      """|protocol: plain
+         |bindingCache:
+         |  paths: 1000
+         |  trees: 999
+         |  bounds: 998
+         |""".stripMargin
+    val capacity = parseConfig(yaml).routerParams[DstBindingFactory.Capacity]
+    assert(capacity.paths == 1000)
+    assert(capacity.trees == 999)
+    assert(capacity.bounds == 998)
+    assert(capacity.clients == DstBindingFactory.Capacity.default.clients)
+  }
 }

--- a/linkerd/docs/config.md
+++ b/linkerd/docs/config.md
@@ -151,6 +151,12 @@ Each router must be configured as an object with the following params:
 * *timeoutMs* -- Per-request timeout in milliseconds. (default: no timeout)
 * *bindingTimeoutMs* -- Optional.  The maximum amount of time in milliseconds to
   spend binding a path.  (default: 10 seconds)
+* *bindingCache* -- Optional.  Configure the size of binding cache.  It must be
+  an object containing keys:
+  * *paths* -- Optional.  Size of the path cache.  (default: 100)
+  * *trees* -- Optional.  Size of the tree cache.  (default: 100)
+  * *bounds* -- Optional.  Size of the bound cache.  (default: 100)
+  * *clients* -- Optional.  Size of the client cache.  (default: 10)
 
 <a name="basic-server-params"></a>
 ### Basic server parameters

--- a/namerd/docs/interface.md
+++ b/namerd/docs/interface.md
@@ -23,6 +23,16 @@ A read-only interface providing `NameInterpreter` functionality over the ThriftM
 before retrying after an error.  (default: 600)
 * *retryJitterSecs* -- Optional.  Maximum number of seconds to jitter retry
 time by.  (default: 60)
+* *cache* -- Optional.  Configure the size of the binding and address caches.
+It must be an object containing keys:
+  * *bindingCacheActive* -- Optional.  The size of the binding active cache.
+  (default: 1000)
+  * *bindingCacheInactive* -- Optional.  The size of the binding inactive cache.
+  (default: 100)
+  * *addrCacheActive* -- Optional.  The size of the address active cache.
+  (default: 1000)
+  * *addrCacheInactive* -- Optional.  The size of the address inactive cache.
+  (default: 100)
 
 ## Http Controller
 

--- a/namerd/iface/interpreter-thrift/src/test/scala/io/buoyant/namerd/iface/ThriftInterpreterInterfaceConfigTest.scala
+++ b/namerd/iface/interpreter-thrift/src/test/scala/io/buoyant/namerd/iface/ThriftInterpreterInterfaceConfigTest.scala
@@ -1,0 +1,29 @@
+package io.buoyant.namerd.iface
+
+import io.buoyant.config.Parser
+import org.scalatest.FunSuite
+
+class ThriftInterpreterInterfaceConfigTest extends FunSuite {
+
+  test("cache capacity") {
+    val yaml = """
+      |kind: io.l5d.thriftNameInterpreter
+      |cache:
+      |  bindingCacheActive: 5000
+      |  bindingCacheInactive: 1000
+      |  addrCacheActive: 6000
+    """.stripMargin
+
+    val config = Parser
+      .objectMapper(
+        yaml,
+        Iterable(Seq(new ThriftInterpreterInterfaceInitializer))
+      ).readValue[ThriftInterpreterInterfaceConfig](yaml)
+
+    val capacity = config.cache.get.capacity
+    assert(capacity.bindingCacheActive == 5000)
+    assert(capacity.bindingCacheInactive == 1000)
+    assert(capacity.addrCacheActive == 6000)
+    assert(capacity.addrCacheInactive == ThriftNamerInterface.Capacity.default.addrCacheInactive)
+  }
+}

--- a/namerd/iface/interpreter-thrift/src/test/scala/io/buoyant/namerd/iface/ThriftNamerEndToEndTest.scala
+++ b/namerd/iface/interpreter-thrift/src/test/scala/io/buoyant/namerd/iface/ThriftNamerEndToEndTest.scala
@@ -47,7 +47,7 @@ class ThriftNamerEndToEndTest extends FunSuite with Eventually with IntegrationP
         else Activity.exception(new Exception)
     }
     val namers = Map(Path.read("/io.l5d.w00t") -> namer)
-    val service = new ThriftNamerInterface(interpreter, namers, newStamper, retryIn, NullStatsReceiver)
+    val service = new ThriftNamerInterface(interpreter, namers, newStamper, retryIn, Capacity.default, NullStatsReceiver)
     val client = new ThriftNamerClient(service, ns, clientId)
 
     val act = client.bind(reqDtab, reqPath)

--- a/namerd/iface/interpreter-thrift/src/test/scala/io/buoyant/namerd/iface/ThriftNamerInterfaceTest.scala
+++ b/namerd/iface/interpreter-thrift/src/test/scala/io/buoyant/namerd/iface/ThriftNamerInterfaceTest.scala
@@ -25,7 +25,7 @@ class ThriftNamerInterfaceTest extends FunSuite {
     }
     val stampCounter = new AtomicLong(1)
     def stamper() = Stamp.mk(stampCounter.getAndIncrement)
-    val service = new ThriftNamerInterface(interpreter, Map.empty, stamper, retryIn, NullStatsReceiver)
+    val service = new ThriftNamerInterface(interpreter, Map.empty, stamper, retryIn, Capacity.default, NullStatsReceiver)
 
     // The first request before the tree has been refined -- no value initially
     val initName = thrift.NameRef(TStamp.empty, TPath("ysl", "thugger"), ns)
@@ -72,7 +72,7 @@ class ThriftNamerInterfaceTest extends FunSuite {
     val namers = Map(pfx -> new Namer { def lookup(path: Path) = Activity(states) })
     val stampCounter = new AtomicLong(1)
     def stamper() = Stamp.mk(stampCounter.getAndIncrement)
-    val service = new ThriftNamerInterface(interpreter, namers, stamper, retryIn, NullStatsReceiver)
+    val service = new ThriftNamerInterface(interpreter, namers, stamper, retryIn, Capacity.default, NullStatsReceiver)
   }
 
   test("addr") {

--- a/router/core/src/main/scala/com/twitter/finagle/buoyant/DstBindingFactory.scala
+++ b/router/core/src/main/scala/com/twitter/finagle/buoyant/DstBindingFactory.scala
@@ -106,7 +106,7 @@ object DstBindingFactory {
   }
 
   implicit object Capacity extends Stack.Param[Capacity] {
-    val default = Capacity(50, 50, 50, 5)
+    val default = Capacity(500, 500, 500, 50)
   }
 
   case class BindingTimeout(timeout: Duration)

--- a/router/core/src/main/scala/com/twitter/finagle/buoyant/DstBindingFactory.scala
+++ b/router/core/src/main/scala/com/twitter/finagle/buoyant/DstBindingFactory.scala
@@ -106,7 +106,7 @@ object DstBindingFactory {
   }
 
   implicit object Capacity extends Stack.Param[Capacity] {
-    val default = Capacity(500, 500, 500, 50)
+    val default = Capacity(100, 100, 100, 10)
   }
 
   case class BindingTimeout(timeout: Duration)


### PR DESCRIPTION
If the number of distinct paths linkerd handles is larger than the path cache, evictions will cause a lot of churn.  