### PR TITLE
Use :: as the zk host delimiter in the zk leader namer

### DIFF
--- a/namer/zk-leader/src/main/scala/io/buoyant/namer/zk/ZkLeaderNamer.scala
+++ b/namer/zk-leader/src/main/scala/io/buoyant/namer/zk/ZkLeaderNamer.scala
@@ -16,7 +16,7 @@ import scala.collection.JavaConverters._
  * in ZooKeeper of a leader group.  This namer resolves to the addresses stored in the data of
  * the leader of the group.
  */
-class ZkLeaderNamer(
+case class ZkLeaderNamer(
   prefix: Path,
   zkAddrs: Seq[HostAndPort],
   factory: Iterable[InetSocketAddress] => ZooKeeperClient

--- a/namer/zk-leader/src/main/scala/io/buoyant/namer/zk/leader.scala
+++ b/namer/zk-leader/src/main/scala/io/buoyant/namer/zk/leader.scala
@@ -6,17 +6,25 @@ import com.twitter.util.Activity
 import io.buoyant.config.types.{Port, HostAndPort}
 
 /**
- * This namer accepts paths of the form /<zkHosts>/<zkPath>.  The zkPath is the location
- * in ZooKeeper of a leader group.  This namer resolves to the addresses stored in the data of
- * the leader of the group.
+ * This namer accepts paths of the form /<zkHosts>/<zkPath>.  zkHosts is a ::
+ * delimited list of zookeeper hostname:port pairs.  The zkPath is the location
+ * in ZooKeeper of a leader group.  This namer resolves to the addresses stored
+ * in the data of the leader of the group.
+ *
+ * e.g. `/1.2.3.4:8001::5.6.7.8:8001::9.10.11.12:8001/path/to/leader/group`
  */
 class leader extends Namer {
-  override def lookup(path: Path): Activity[NameTree[Name]] = {
+
+  private[zk] def zkLeaderNamer(path: Path): ZkLeaderNamer = {
     val Path.Utf8(hosts) = path.take(1)
-    val zkAddrs = InetSocketAddressUtil.parseHostPorts(hosts).map {
-      case (host, port) => HostAndPort(Some(host), Some(Port(port)))
-    }
-    val namer = new ZkLeaderNamer(Path.empty, zkAddrs)
-    namer.lookup(path.drop(1))
+    val zkAddrs = hosts.split("::")
+      .flatMap(InetSocketAddressUtil.parseHostPorts).map {
+        case (host, port) => HostAndPort(Some(host), Some(Port(port)))
+      }
+    new ZkLeaderNamer(Path.empty, zkAddrs)
+  }
+
+  override def lookup(path: Path): Activity[NameTree[Name]] = {
+    zkLeaderNamer(path).lookup(path.drop(1))
   }
 }

--- a/namer/zk-leader/src/test/scala/io/buoyant/namer/zk/ZkLeaderTest.scala
+++ b/namer/zk-leader/src/test/scala/io/buoyant/namer/zk/ZkLeaderTest.scala
@@ -1,6 +1,6 @@
 package io.buoyant.namer.zk
 
-import com.twitter.finagle.Stack
+import com.twitter.finagle.{Path, Stack}
 import com.twitter.finagle.util.LoadService
 import io.buoyant.config.types.{HostAndPort, Port}
 import io.buoyant.namer.NamerInitializer
@@ -16,5 +16,15 @@ class ZkLeaderTest extends FunSuite {
 
   test("service registration") {
     assert(LoadService[NamerInitializer]().exists(_.isInstanceOf[ZkLeaderNamerInitializer]))
+  }
+
+  test("parse zk hosts") {
+    val namer = new leader()
+      .zkLeaderNamer(Path.read("/1.2.3.4:8000::5.6.7.8:8001/path/to/group"))
+    assert(namer.zkAddrs ==
+      Seq(
+        HostAndPort(Some("1.2.3.4"), Some(Port(8000))),
+        HostAndPort(Some("5.6.7.8"), Some(Port(8001)))
+      ))
   }
 }


### PR DESCRIPTION
Fixes #461 

Use `::` as the zk host delimiter instead of `,` because commas are not permitted in finagle Paths.