### PR TITLE
Dashboard style tweaks related to responsiveness

### DIFF
--- a/admin/src/main/resources/io/buoyant/admin/css/dashboard.css
+++ b/admin/src/main/resources/io/buoyant/admin/css/dashboard.css
@@ -24,7 +24,7 @@ body {
 }
 
 .row {
-  margin: 0 -27px 0 0;
+  margin: 0;
 }
 
 .container-fluid {
@@ -43,7 +43,6 @@ nav {
 
 .navbar-container {
   padding: 20px 27px 9px 27px;
-  width: 1215px; /*1161 + 27 + 27 (padding)*/
 }
 
 .nav {
@@ -70,7 +69,7 @@ nav ul.navbar-nav {
 /* request totals */
 
 .request-totals {
-  height: 72px;
+  min-height: 72px;
   padding: 15px 27px;
   background: #163F79; /* For browsers that do not support gradients */
   background: -webkit-linear-gradient(left top, #163F79, #4076C4);
@@ -104,7 +103,6 @@ nav ul.navbar-nav {
 
 .dashboard-container {
   margin: 0 27px 0;
-  width: 1161px;
   border-bottom: 2px solid grey;
 }
 
@@ -113,7 +111,6 @@ nav ul.navbar-nav {
   font-size: 13px;
   line-height: 16px;
   margin: 10px 27px 0;
-  width: 1161px;
 }
 
 .router:not(:last-child) {
@@ -195,6 +192,10 @@ nav ul.navbar-nav {
   border-radius: 2px;
   height: 12px;
   margin-right: 5px;
+}
+
+.metrics-container {
+  padding: 0;
 }
 
 /**

--- a/admin/src/main/resources/io/buoyant/admin/js/combined_client_graph.js
+++ b/admin/src/main/resources/io/buoyant/admin/js/combined_client_graph.js
@@ -1,8 +1,6 @@
 /* globals Query, UpdateableChart */
 /* exported CombinedClientGraph */
 var CombinedClientGraph = (function() {
-  var defaultWidth = 1181;
-
   function clientToMetric(client) {
     return {name: client, color: ""}; //TODO: move to clientName only after v2 migration
   }
@@ -36,8 +34,7 @@ var CombinedClientGraph = (function() {
       },
       $root[0],
       function() {
-        var containerWidth = $(".router-clients").first().width(); // get this to display nicely on wide screens
-        return containerWidth || defaultWidth;
+        return $(".router").first().width();  // get this to display nicely on various screen widths
       },
       timeseriesParams
     );

--- a/admin/src/main/resources/io/buoyant/admin/js/success_rate_graph.js
+++ b/admin/src/main/resources/io/buoyant/admin/js/success_rate_graph.js
@@ -1,8 +1,8 @@
 /* globals UpdateableChart */
 /* exported SuccessRateGraph */
 var SuccessRateGraph = (function() {
-  var columnGridPadding = 27; // from our css grid setup
   var neutralLineColor = "#878787"; // greys.neutral
+  var defaultWidth = 1181;
 
   // set default y range such that a graph of purely 100% success rate doesn't
   // blend in to the very top of the graph, and doesn't center
@@ -21,9 +21,13 @@ var SuccessRateGraph = (function() {
     } else {
       return function() {
         var containerWidth = $(".client-container").first().width();
-        var metricsWidth = $(".metrics-container").first().width();
 
-        return containerWidth - metricsWidth - columnGridPadding; // get this to display nicely on wide screens
+        if (containerWidth > defaultWidth) {
+          var metricsWidth = $(".metrics-container").first().width();
+          return containerWidth - metricsWidth; // get this to display nicely on wide screens
+        } else {
+          return containerWidth;
+        }
       }
     }
   }


### PR DESCRIPTION
Despite the branch name and ticket name, note that there was not actually a lag bug :)

* removed the 1181 widths - since the dashboard expands on larger screens, having this as the width didn't have much meaning
* charts now determine their widths in a more sensible manner

Should make the dashboard display a little better on small screens, and fix the bug where part of the graph is cut off.

We definitely do some weird things when we co-opt the bootstrap grid (e.g. row margins to 0, container fluid padding to 0) - the -27px row margin was causing the weird white column on the right that you saw (that made it look like the graph was lagging).

Fixes  #456 
I'll say this also ~ fixes #234


![screen shot 2016-06-09 at 1 28 52 pm](https://cloud.githubusercontent.com/assets/549258/15945227/36c486a4-2e46-11e6-9df2-35b60bd79a17.png)
