### PR TITLE
Overhaul linkerd header handling

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -3,6 +3,14 @@
 * New default JVM settings scale up with traffic levels.
   * `JVM_HEAP` is now deprecated, you can now separately set `JVM_HEAP_MIN` and
     `JVM_HEAP_MAX` but you shouldn't need to adjust them thanks to the new defaults.
+* Overhaul HTTP headers:
+  * `l5d-ctx` renamed to `l5d-ctx-trace`
+  * `l5d-ctx-deadline` now propagates deadlines
+  * `l5d-ctx-dtab` is now read, to replace `dtab-local` later.
+  * `l5d-dtab` now honored as a replacement for `dtab-local` as
+    specified by users.
+  * `l5d-dst-*` no longer set on responses
+
 
 ## 0.6.0
 

--- a/linkerd/docs/protocol-http.md
+++ b/linkerd/docs/protocol-http.md
@@ -96,12 +96,15 @@ _Context headers_ (`l5d-ctx-*`) are generated and read by linkerd
 instances. Applications should forward all context headers in order
 for all linkerd features to work. These headers include:
 
-- `dtab-local`: Currently (until the next release of finagle), the
+- `dtab-local`: currently (until the next release of finagle), the
   `dtab-local` header is used to propagate dtab context. In an
   upcoming release this header will no longer be honored, in favor of
   `l5d-ctx-dtab` and `l5d-dtab`.
-- `l5d-ctx-deadline`:
-- `l5d-ctx-trace`:
+- `l5d-ctx-deadline`: describes time bounds within which a request is
+  expected to be satisfied. Currently deadlines are only advisory and
+  do not factor into request cancellation.
+- `l5d-ctx-trace`: encodes zipkin-style trace IDs and flags so that
+  trace annotations emitted by linkerd may be correlated.
 
 Edge services should take care to ensure these headers are not set
 from untrusted sources.

--- a/linkerd/docs/protocol-http.md
+++ b/linkerd/docs/protocol-http.md
@@ -85,3 +85,58 @@ routers:
 
 A request to `:5000/true/love/waits.php` will be identified as
 `/custom/prefix/true/love`.
+
+## HTTP Headers
+
+linkerd reads and sets several headers prefixed by `l5d-`.
+
+### Context Headers
+
+_Context headers_ (`l5d-ctx-*`) are generated and read by linkerd
+instances. Applications should forward all context headers in order
+for all linkerd features to work. These headers include:
+
+- `dtab-local`: Currently (until the next release of finagle), the
+  `dtab-local` header is used to propagate dtab context. In an
+  upcoming release this header will no longer be honored, in favor of
+  `l5d-ctx-dtab` and `l5d-dtab`.
+- `l5d-ctx-deadline`:
+- `l5d-ctx-trace`:
+
+Edge services should take care to ensure these headers are not set
+from untrusted sources.
+
+### User Headers
+
+_User headers_ are useful to allow user-overrides
+
+- `l5d-dtab`: a client-specified delegation override
+- `l5d-sample`: a client-specified trace sample rate override
+
+Note that if linkerd process incoming requests for applications
+(i.e. in linker-to-linker configurations), applications do not need to
+provide special treatment for these headers since linkerd does _not_
+forward these headers (and instead translates them into context
+headers).
+
+Edge services should take care to ensure these headers are not set
+from untrusted sources.
+
+### Informational Request Headers
+
+In addition to the context headers, linkerd may emit the following
+headers on outgoing requests:
+
+- `l5d-dst-path`: the logical name of the request as identified by linkerd
+- `l5d-dst-bound`: the concrete client name after delegation
+- `l5d-dst-residual`: an optional residual path remaining after delegation
+- `l5d-reqid`: a token that may be used to correlate requests in a
+               callgraph across services and linkerd instances
+
+### Informational Response Headers
+
+And in addition to the context headers, lay may emit the following
+headers on outgoing responses:
+
+- `l5d-err`: indicates a linkerd-generated error. Error responses
+             that do not have this header are application errors.

--- a/linkerd/docs/protocol-http.md
+++ b/linkerd/docs/protocol-http.md
@@ -137,6 +137,10 @@ headers on outgoing requests:
 Applications are not required to forward these headers on downstream
 requests.
 
+The value of the _dst_ headers may include service discovery
+information including host names.  Operators may opt to remove these
+headers from requests sent to the outside world.
+
 ### Informational Response Headers
 
 linkerd may emit the following _informational_ headers on outgoing
@@ -147,3 +151,7 @@ responses:
 
 Applications are not required to forward these headers on upstream
 responses.
+
+The value of this header may include service discovery information
+including host names. Operators may opt to remove this header from
+responses sent to the outside world.

--- a/linkerd/docs/protocol-http.md
+++ b/linkerd/docs/protocol-http.md
@@ -113,11 +113,12 @@ _User headers_ are useful to allow user-overrides
 - `l5d-dtab`: a client-specified delegation override
 - `l5d-sample`: a client-specified trace sample rate override
 
-Note that if linkerd process incoming requests for applications
+Note that if linkerd processes incoming requests for applications
 (i.e. in linker-to-linker configurations), applications do not need to
 provide special treatment for these headers since linkerd does _not_
 forward these headers (and instead translates them into context
-headers).
+headers). If applications receive traffic directly, they _should_
+forward these headers.
 
 Edge services should take care to ensure these headers are not set
 from untrusted sources.
@@ -127,16 +128,22 @@ from untrusted sources.
 In addition to the context headers, linkerd may emit the following
 headers on outgoing requests:
 
-- `l5d-dst-path`: the logical name of the request as identified by linkerd
-- `l5d-dst-bound`: the concrete client name after delegation
+- `l5d-dst-logical`: the logical name of the request as identified by linkerd
+- `l5d-dst-concrete`: the concrete client name after delegation
 - `l5d-dst-residual`: an optional residual path remaining after delegation
 - `l5d-reqid`: a token that may be used to correlate requests in a
                callgraph across services and linkerd instances
 
+Applications are not required to forward these headers on downstream
+requests.
+
 ### Informational Response Headers
 
-And in addition to the context headers, lay may emit the following
-headers on outgoing responses:
+linkerd may emit the following _informational_ headers on outgoing
+responses:
 
 - `l5d-err`: indicates a linkerd-generated error. Error responses
              that do not have this header are application errors.
+
+Applications are not required to forward these headers on upstream
+responses.

--- a/linkerd/protocol/http/src/e2e/scala/io/buoyant/linkerd/protocol/HttpEndToEndTest.scala
+++ b/linkerd/protocol/http/src/e2e/scala/io/buoyant/linkerd/protocol/HttpEndToEndTest.scala
@@ -105,9 +105,6 @@ class HttpEndToEndTest extends FunSuite with Awaits {
 
         val path = "/http/1.1/GET/felix"
         val bound = s"/$$/inet/127.1/${cat.port}"
-        assert(rsp.headerMap.get(Headers.Dst.Path) == Some(path))
-        assert(rsp.headerMap.get(Headers.Dst.Bound) == Some(bound))
-        assert(rsp.headerMap.get(Headers.Dst.Residual) == None)
         withAnnotations { anns =>
           assert(anns.exists(_ == Annotation.BinaryAnnotation("namer.path", path)))
           assert(anns.exists(_ == Annotation.BinaryAnnotation("dst.id", bound)))
@@ -122,9 +119,6 @@ class HttpEndToEndTest extends FunSuite with Awaits {
         val path = "/http/1.1/GET/clifford/the/big/red/dog"
         val bound = s"/$$/inet/127.1/${dog.port}"
         val residual = "/the/big/red/dog"
-        assert(rsp.headerMap.get(Headers.Dst.Path) == Some(path))
-        assert(rsp.headerMap.get(Headers.Dst.Bound) == Some(bound))
-        assert(rsp.headerMap.get(Headers.Dst.Residual) == Some(residual))
         withAnnotations { anns =>
           assert(anns.exists(_ == Annotation.BinaryAnnotation("namer.path", path)))
           assert(anns.exists(_ == Annotation.BinaryAnnotation("dst.id", bound)))

--- a/linkerd/protocol/http/src/e2e/scala/io/buoyant/linkerd/protocol/HttpEndToEndTest.scala
+++ b/linkerd/protocol/http/src/e2e/scala/io/buoyant/linkerd/protocol/HttpEndToEndTest.scala
@@ -128,12 +128,12 @@ class HttpEndToEndTest extends FunSuite with Awaits {
 
       get("ralph-machio") { rsp =>
         assert(rsp.status == Status.BadGateway)
-        assert(rsp.headerMap.contains(Headers.Err))
+        assert(rsp.headerMap.contains(Headers.Err.Key))
       }
 
       get("") { rsp =>
         assert(rsp.status == Status.BadRequest)
-        assert(rsp.headerMap.contains(Headers.Err))
+        assert(rsp.headerMap.contains(Headers.Err.Key))
       }
 
       // todo check stats

--- a/linkerd/protocol/http/src/main/scala/com/twitter/finagle/buoyant/linkerd/Headers.scala
+++ b/linkerd/protocol/http/src/main/scala/com/twitter/finagle/buoyant/linkerd/Headers.scala
@@ -30,8 +30,8 @@ import java.util.Base64
  * In addition to the context headers, linkerd may emit the following
  * headers on outgoing requests:
  *
- *   - `l5d-dst-path`: the logical name of the request as identified by linkerd
- *   - `l5d-dst-bound`: the concrete client name after delegation
+ *   - `l5d-dst-logical`: the logical name of the request as identified by linkerd
+ *   - `l5d-dst-concrete`: the concrete client name after delegation
  *   - `l5d-dst-residual`: an optional residual path remaining after delegation
  *   - `l5d-reqid`: a token that may be used to correlate requests in
  *                  a callgraph across services and linkerd instances
@@ -349,9 +349,9 @@ object Headers {
    * next hop.
    */
   object Dst {
-    val Path = Prefix + "dst-path"
+    val Path = Prefix + "dst-logical"
+    val Bound = Prefix + "dst-concrete"
     val Residual = Prefix + "dst-residual"
-    val Bound = Prefix + "dst-bound"
 
     /** Encodes `l5d-dst-path` on outgoing requests. */
     class PathFilter(path: Path) extends SimpleFilter[Request, Response] {

--- a/linkerd/protocol/http/src/main/scala/com/twitter/finagle/buoyant/linkerd/Headers.scala
+++ b/linkerd/protocol/http/src/main/scala/com/twitter/finagle/buoyant/linkerd/Headers.scala
@@ -116,10 +116,8 @@ object Headers {
           }
         }
 
-      def write(deadline: FDeadline): String = {
-        val FDeadline(ts, d) = deadline
-        ts.inNanoseconds + " " + d.inNanoseconds
-      }
+      def write(d: FDeadline): String =
+        s"${d.timestamp.inNanoseconds} ${d.deadline.inNanoseconds}""
 
       def set(headers: HeaderMap, deadline: FDeadline): Unit = {
         val _ = headers.set(Key, write(deadline))

--- a/linkerd/protocol/http/src/main/scala/com/twitter/finagle/buoyant/linkerd/Headers.scala
+++ b/linkerd/protocol/http/src/main/scala/com/twitter/finagle/buoyant/linkerd/Headers.scala
@@ -9,6 +9,7 @@ import com.twitter.io.Charsets
 import com.twitter.util.{Future, Return, Throw, Time, Try}
 import java.net.URLEncoder
 import java.util.Base64
+import scala.collection.breakOut
 
 /**
  * The finagle http stack manages a set of context headers that are
@@ -211,7 +212,7 @@ object Headers {
 
       def get(headers: HeaderMap, key: String): Try[FDtab] =
         if (!headers.contains(key)) EmptyReturn
-        else Try { FDtab(headers.getAll(key).view.flatMap(FDtab.read(_)).toIndexedSeq) }
+        else Try { FDtab(headers.getAll(key).flatMap(FDtab.read(_))(breakOut)) }
 
       def get(headers: HeaderMap): Try[FDtab] =
         for {

--- a/linkerd/protocol/http/src/main/scala/com/twitter/finagle/buoyant/linkerd/Headers.scala
+++ b/linkerd/protocol/http/src/main/scala/com/twitter/finagle/buoyant/linkerd/Headers.scala
@@ -1,10 +1,11 @@
 package com.twitter.finagle.buoyant.linkerd
 
-import com.twitter.finagle.{Name, Path, Service, ServiceFactory, SimpleFilter, Stack}
+import com.twitter.finagle.{Deadline => FDeadline, Dtab => FDtab, Status => _, _}
 import com.twitter.finagle.buoyant.{Dst => BuoyantDst}
+import com.twitter.finagle.context.Contexts
 import com.twitter.finagle.http._
 import com.twitter.finagle.tracing._
-import com.twitter.util.Try
+import com.twitter.util.{Future, Return, Throw, Time, Try}
 import java.util.Base64
 
 // all of this based on com.twitter.finagle.http.Codec
@@ -12,35 +13,222 @@ import java.util.Base64
 object Headers {
   val Prefix = "l5d-"
 
-  // TODO fold dtabs into this.
   object Ctx {
-    val Key = Prefix + "ctx"
 
     /**
-     * Get a trace id from a base64 encoded buffer.
+     * A serverside stack module that extracts contextual information
+     * from requests and configures the local
+     * `com.twitter.finagle.Context` appropriately. Currently this includes:
+     *   - Deadline
+     *   - Dtab
      *
-     * Based on com.twitter.finagle.tracing.Trace.idCtx.tryUnmarshal
+     * Note that currently, the dtabs read by this module are
+     * appeneded to that specified by the `l5d-dtab` header.  The
+     * `dtab-local` header should be considered deprecated in favor of
+     * `l5d-dtab, and will not be supported in the future.
      *
-     * The wire format is (big-endian):
-     *   ''reqId:8 parentId:8 traceId:8 flags:8''
+     * Note that trace configuration is handled by [[HttpTraceInitializer.server]].
      */
-    def get(b64: String): Try[TraceId] =
-      Try(Base64.getDecoder.decode(b64)).flatMap(TraceId.deserialize)
+    val serverModule: Stackable[ServiceFactory[Request, Response]] =
+      new Stack.Module0[ServiceFactory[Request, Response]] {
+        val role = Stack.Role("DeadlineExtract")
+        val description = "Extracts deadlines from http headers"
 
-    def get(headers: HeaderMap): Option[TraceId] =
-      for {
-        header <- headers.get(Key)
-        traceId <- get(header).toOption
-      } yield traceId
+        val deadline = new Deadline.ServerFilter
+        val dtab = new Dtab.ServerFilter
 
-    def set(headers: HeaderMap, id: TraceId): Unit = {
-      val bytes = TraceId.serialize(id)
-      val b64 = Base64.getEncoder().encodeToString(bytes)
-      val _ = headers.set(Key, b64)
+        def make(next: ServiceFactory[Request, Response]) =
+          deadline.andThen(dtab).andThen(next)
+      }
+
+    /**
+     * A clientside stack module that injects local contextual
+     * information onto downstream requests.  Currently this includes:
+     *   - Deadline
+     *
+     * Note that Dtabs are *not* encoded by this filter, since the
+     * HttpClientDispatcher is currently responsible for encoding the
+     * `dtab-local` header.  In a future release, Dtabs will be
+     * encoded into the `l5d-ctx-dtab` header.
+     *
+     * Note that trace configuration is handled by [[HttpTraceInitializer.client]].
+     */
+    val clientModule: Stackable[ServiceFactory[Request, Response]] =
+      new Stack.Module0[ServiceFactory[Request, Response]] {
+        val role = Stack.Role("DeadlineInject")
+        val description = "Injects deadlines into http headers"
+
+        // TODO use Dtab.ClientFilter once this module can replace finagle's dtab encoding logic.
+        val deadline = new Deadline.ClientFilter
+
+        def make(next: ServiceFactory[Request, Response]) =
+          deadline.andThen(next)
+      }
+
+    val Prefix = Headers.Prefix + "ctx-"
+
+    object Trace {
+      val Key = Prefix + "trace"
+
+      /**
+       * Get a trace id from a base64 encoded buffer.
+       *
+       * Based on com.twitter.finagle.tracing.Trace.idCtx.tryUnmarshal
+       *
+       * The wire format is (big-endian):
+       *   ''reqId:8 parentId:8 traceId:8 flags:8''
+       */
+      def read(b64: String): Try[TraceId] =
+        Try { Base64.getDecoder.decode(b64) }.flatMap(TraceId.deserialize(_))
+
+      def get(headers: HeaderMap): Option[TraceId] =
+        for {
+          header <- headers.get(Key)
+          traceId <- read(header).toOption
+        } yield traceId
+
+      def set(headers: HeaderMap, id: TraceId): Unit = {
+        val bytes = TraceId.serialize(id)
+        val b64 = Base64.getEncoder.encodeToString(bytes)
+        val _ = headers.set(Key, b64)
+      }
+
+      def clear(headers: HeaderMap): Unit = {
+        val _ = headers.remove(Key)
+      }
     }
 
-    def clear(headers: HeaderMap): Unit = {
-      val _ = headers.remove(Key)
+    object Deadline {
+      val Key = Prefix + "deadline"
+
+      def read(v: String): Try[FDeadline] = Try {
+        val values = v.split(' ')
+        val timestamp = Time.fromNanoseconds(values(0).toLong)
+        val deadline = Time.fromNanoseconds(values(1).toLong)
+        FDeadline(timestamp, deadline)
+      }
+
+      def get(headers: HeaderMap): Option[FDeadline] =
+        headers.getAll(Key).foldLeft[Option[FDeadline]](None) { (d0, v) =>
+          (d0, read(v).toOption) match {
+            case (Some(d0), Some(d1)) => Some(FDeadline.combined(d0, d1))
+            case (d0, d1) => d0.orElse(d1)
+          }
+        }
+
+      def write(deadline: FDeadline): String = {
+        val FDeadline(ts, d) = deadline
+        ts.inNanoseconds + " " + d.inNanoseconds
+      }
+
+      def set(headers: HeaderMap, deadline: FDeadline): Unit = {
+        val _ = headers.set(Key, write(deadline))
+      }
+
+      def clear(headers: HeaderMap): Unit = {
+        val _ = headers.remove(Key)
+      }
+
+      /**
+       * Extract the deadline from the request and, if it exists, use
+       * either that deadline or the one already on the local context,
+       * whichever is stricter.
+       */
+      class ServerFilter extends SimpleFilter[Request, Response] {
+        def apply(req: Request, service: Service[Request, Response]) =
+          get(req.headerMap) match {
+            case None => service(req)
+            case Some(reqDeadline) =>
+              clear(req.headerMap)
+              val deadline = FDeadline.current match {
+                case None => reqDeadline
+                case Some(current) => FDeadline.combined(reqDeadline, current)
+              }
+              Contexts.broadcast.let(FDeadline, deadline) {
+                service(req)
+              }
+          }
+      }
+
+      class ClientFilter extends SimpleFilter[Request, Response] {
+        def apply(req: Request, service: Service[Request, Response]) =
+          FDeadline.current match {
+            case None => service(req)
+            case Some(deadline) =>
+              set(req.headerMap, deadline)
+              service(req)
+          }
+      }
+    }
+
+    object Dtab {
+      val UserKey = Headers.Prefix + "dtab"
+      val CtxKey = Ctx.Prefix + "dtab"
+      private val EmptyReturn = Return(FDtab.empty)
+
+      def get(headers: HeaderMap, key: String): Try[FDtab] =
+        if (!headers.contains(key)) EmptyReturn
+        else Try { FDtab(headers.getAll(key).view.flatMap(FDtab.read(_)).toIndexedSeq) }
+
+      def get(headers: HeaderMap): Try[FDtab] =
+        for {
+          ctx <- get(headers, CtxKey)
+          user <- get(headers, UserKey)
+        } yield ctx ++ user
+
+      def clear(headers: HeaderMap): Unit = {
+        val _c = headers.remove(CtxKey)
+        val _u = headers.remove(UserKey)
+      }
+
+      def set(dtab: FDtab, msg: Message): Unit =
+        if (dtab.nonEmpty) {
+          val _ = msg.headerMap.set(CtxKey, dtab.show)
+        }
+
+      /**
+       * Extract a Dtab from the L5d-Ctx-Dtab and L5d-Dtab headers (in
+       * that order) and append them to the local context.
+       *
+       * The L5d-Ctx-Dtab header is intended to be set by a linkerd
+       * instance, while the L5d-Dtab header is intended to be set by
+       * a user who wants to override delegation.
+       *
+       * @todo use DtabFilter.Injector once it is released.
+       */
+      class ServerFilter extends SimpleFilter[Request, Response] {
+
+        def apply(req: Request, service: Service[Request, Response]) =
+          get(req.headerMap) match {
+            case Throw(e) =>
+              invalidResponse(e.getMessage)
+            case Return(dtab) =>
+              clear(req.headerMap)
+              FDtab.local ++= dtab
+              service(req)
+          }
+
+        private[this] def invalidResponse(msg: String): Future[Response] = {
+          val rspTxt = s"Invalid Dtab headers: $msg"
+          val rsp = Response(Status.BadRequest)
+          rsp.contentType = "text/plain; charset=UTF-8"
+          rsp.contentLength = rspTxt.getBytes.length
+          rsp.contentString = rspTxt
+          Future.value(rsp)
+        }
+      }
+
+      /**
+       * Encodes the local dtab into the L5d-Ctx-Dtab header.
+       *
+       * @todo use DtabFilter.Extractor once it is released.
+       */
+      class ClientFilter extends SimpleFilter[Request, Response] {
+        def apply(req: Request, service: Service[Request, Response]) = {
+          set(FDtab.local, req)
+          service(req)
+        }
+      }
     }
   }
 
@@ -52,11 +240,20 @@ object Headers {
     }
   }
 
+  /**
+   * Sets the sample rate to determine whether this span should be traced.
+   */
   object Sample {
     val Key = Prefix + "sample"
 
     def get(headers: HeaderMap): Option[Float] =
-      headers.get(Key).flatMap(s => Try(s.toFloat).toOption).filter(f => f >= 0f && f <= 1f)
+      headers.get(Key).flatMap { s =>
+        Try(s.toFloat).toOption.map {
+          case v if v < 0 => 0.0f
+          case v if v > 1 => 1.0f
+          case v => v
+        }
+      }
 
     def clear(headers: HeaderMap): Unit = {
       val _ = headers.remove(Key)
@@ -70,12 +267,10 @@ object Headers {
 
     class PathFilter(path: Path) extends SimpleFilter[Request, Response] {
       private[this] val pathShow = path.show
+
       def apply(req: Request, service: Service[Request, Response]) = {
-        req.headerMap(Path) = pathShow
-        service(req).map { rsp =>
-          rsp.headerMap(Path) = pathShow
-          rsp
-        }
+        req.headers().set(Path, pathShow)
+        service(req)
       }
     }
 
@@ -86,6 +281,9 @@ object Headers {
         new PathFilter(dst.path).andThen(factory)
     }
 
+    /**
+     * Encodes bound and residual paths onto downstream requests
+     */
     class BoundFilter(bound: Name.Bound) extends SimpleFilter[Request, Response] {
       private[this] val boundShow = bound.idStr
       private[this] val pathShow = bound.path match {
@@ -93,18 +291,18 @@ object Headers {
         case path => Some(path.show)
       }
       private[this] def annotate(msg: Message): Unit = {
-        msg.headerMap(Bound) = boundShow
-        for (p <- pathShow) {
-          msg.headerMap(Residual) = p
+        val headers = msg.headers()
+        val _b = headers.set(Bound, boundShow)
+        pathShow match {
+          case None =>
+          case Some(p) =>
+            val _p = headers.set(Residual, p)
         }
       }
 
       def apply(req: Request, service: Service[Request, Response]) = {
         annotate(req)
-        service(req).map { rsp =>
-          annotate(rsp)
-          rsp
-        }
+        service(req)
       }
     }
 
@@ -114,7 +312,6 @@ object Headers {
       def make(dst: BuoyantDst.Bound, factory: ServiceFactory[Request, Response]) =
         new BoundFilter(dst.name).andThen(factory)
     }
-
   }
 
   val Err = Prefix + "err"

--- a/linkerd/protocol/http/src/main/scala/com/twitter/finagle/buoyant/linkerd/Headers.scala
+++ b/linkerd/protocol/http/src/main/scala/com/twitter/finagle/buoyant/linkerd/Headers.scala
@@ -188,7 +188,7 @@ object Headers {
      * There are two headers used to control local Dtabs in linkerd:
      *
      *   1. `l5d-ctx-dtab` is read and _written_ by linkerd. It is
-     *      intended to managed entirely by linked, and applications
+     *      intended to managed entirely by linkerd, and applications
      *      should only forward requests prefixed by `l5d-ctx-*`.
      *
      *      *NOTE*: the client module does not yet encode

--- a/linkerd/protocol/http/src/main/scala/com/twitter/finagle/buoyant/linkerd/Headers.scala
+++ b/linkerd/protocol/http/src/main/scala/com/twitter/finagle/buoyant/linkerd/Headers.scala
@@ -17,16 +17,19 @@ import java.util.Base64
  * headers (prefixed by l5d-).
  *
  * Context headers, read and written by each linkerd instance, include:
+ *
  *   - `l5d-ctx-deadline`
  *   - `l5d-ctx-dtab`
  *   - `l5d-ctx-trace`
  *
  * Additionally, linkerd honors the following headers on incoming requests:
+ *
  *   - `l5d-dtab`: a client-specified delegation override
  *   - `l5d-sample`: a client-specified trace sample rate override
  *
  * In addition to the context headers, linkerd may emit the following
  * headers on outgoing requests:
+ *
  *   - `l5d-dst-path`: the logical name of the request as identified by linkerd
  *   - `l5d-dst-bound`: the concrete client name after delegation
  *   - `l5d-dst-residual`: an optional residual path remaining after delegation
@@ -35,6 +38,7 @@ import java.util.Base64
  *
  * And in addition to the context headers, lay may emit the following
  * headers on outgoing responses:
+ *
  *   - `l5d-err`: indicates a linkerd-generated error. Error responses
  *                that do not have this header are application errors.
  */

--- a/linkerd/protocol/http/src/main/scala/com/twitter/finagle/buoyant/linkerd/Headers.scala
+++ b/linkerd/protocol/http/src/main/scala/com/twitter/finagle/buoyant/linkerd/Headers.scala
@@ -58,7 +58,7 @@ object Headers {
      * Note that currently, the dtabs read by this module are
      * appeneded to that specified by the `l5d-dtab` header.  The
      * `dtab-local` header should be considered deprecated in favor of
-     * `l5d-dtab, and will not be supported in the future.
+     * `l5d-dtab`, and will not be supported in the future.
      *
      * Note that trace configuration is handled by
      * [[HttpTraceInitializer.serverModule]].

--- a/linkerd/protocol/http/src/main/scala/com/twitter/finagle/buoyant/linkerd/HttpTraceInitializer.scala
+++ b/linkerd/protocol/http/src/main/scala/com/twitter/finagle/buoyant/linkerd/HttpTraceInitializer.scala
@@ -12,79 +12,81 @@ import com.twitter.finagle.tracing._
 object HttpTraceInitializer {
   val role = TraceInitializerFilter.role
 
+  class ServerFilter(tracer: Tracer, defaultSampler: Option[Sampler] = None)
+    extends SimpleFilter[Request, Response] {
+
+    /**
+     * Establish context for this request, as follows:
+     * 1. Set the trace id from the context header, if one was provided.
+     * 2. Get a new span id for the current request.
+     * 3. Use the sample header to determine if the request should be sampled.
+     */
+    def apply(req: Request, service: Service[Request, Response]) = {
+      val headers = req.headerMap
+      val ctx = Headers.Ctx.Trace.get(headers)
+      Headers.Ctx.Trace.clear(headers)
+      val sampler = Headers.Sample.get(headers).map(Sampler(_))
+      Headers.Sample.clear(headers)
+
+      Trace.letIdOption(ctx) {
+        Trace.letTracerAndNextId(tracer) {
+          sample(sampler.orElse(defaultSampler)) {
+            service(req)
+          }
+        }
+      }
+    }
+
+    /**
+     * Only set _sampled on the trace ID if the sample header provided a
+     * sample rate, the sampler determines that the request should be
+     * sampled based on the sample rate, and the _sampled field is unset on
+     * the current trace ID.
+     */
+    def sample[T](sampler: Option[Sampler])(f: => T) =
+      sampler match {
+        case None => f
+        case Some(sampler) =>
+          val id = Trace.id
+          val sampled = id.copy(_sampled = Some(sampler(id.traceId.toLong)))
+          Trace.letId(sampled)(f)
+      }
+  }
+
+  class ClientFilter(tracer: Tracer) extends SimpleFilter[Request, Response] {
+    def apply(req: Request, service: Service[Request, Response]) =
+      Trace.letTracerAndNextId(tracer) {
+        Headers.Ctx.Trace.set(req.headerMap, Trace.id)
+        Headers.RequestId.set(req.headerMap, Trace.id)
+        service(req)
+      }
+  }
+
   /**
    * The server reads the ctx header ([Headers.Ctx.Key]) to load
    * trace information.
    */
-  object server extends Stack.Module1[param.Tracer, ServiceFactory[Request, Response]] {
-    val role = HttpTraceInitializer.role
-    val description = "Reads trace information from incoming request"
+  val serverModule: Stackable[ServiceFactory[Request, Response]] =
+    new Stack.Module1[param.Tracer, ServiceFactory[Request, Response]] {
+      val role = HttpTraceInitializer.role
+      val description = "Reads trace information from incoming request"
 
-    class Filter(tracer: Tracer) extends SimpleFilter[Request, Response] {
-
-      /**
-       * Establish context for this request, as follows:
-       * 1. Set the trace id from the context header, if one was provided.
-       * 2. Get a new span id for the current request.
-       * 3. Use the sample header to determine if the request should be sampled.
-       */
-      def apply(req: Request, service: Service[Request, Response]) = {
-        val headers = req.headerMap
-        val ctx = Headers.Ctx.Trace.get(headers)
-        Headers.Ctx.Trace.clear(headers)
-        val sampler = Headers.Sample.get(headers).map(Sampler(_))
-        Headers.Sample.clear(headers)
-
-        Trace.letIdOption(ctx) {
-          Trace.letTracerAndNextId(tracer) {
-            sample(sampler) {
-              service(req)
-            }
-          }
-        }
+      def make(_tracer: param.Tracer, next: ServiceFactory[Request, Response]) = {
+        val param.Tracer(tracer) = _tracer
+        new ServerFilter(tracer) andThen next
       }
-
-      /**
-       * Only set _sampled on the trace ID if the sample header provided a
-       * sample rate, the sampler determines that the request should be
-       * sampled based on the sample rate, and the _sampled field is unset on
-       * the current trace ID.
-       */
-      def sample[T](sampler: Option[Sampler])(f: => T) =
-        sampler match {
-          case None => f
-          case Some(sampler) =>
-            val id = Trace.id
-            val sampled = id.copy(_sampled = Some(sampler(id.traceId.toLong)))
-            Trace.letId(sampled)(f)
-        }
     }
-
-    def make(_tracer: param.Tracer, next: ServiceFactory[Request, Response]) = {
-      val param.Tracer(tracer) = _tracer
-      new Filter(tracer) andThen next
-    }
-  }
 
   /**
    * So, on the client side, we set headers after initializing a new context.
    */
-  object client extends Stack.Module1[param.Tracer, ServiceFactory[Request, Response]] {
-    val role = HttpTraceInitializer.role
-    val description = "Attaches trace information to the outgoing request"
-
-    class Filter(tracer: Tracer) extends SimpleFilter[Request, Response] {
-      def apply(req: Request, service: Service[Request, Response]) =
-        Trace.letTracerAndNextId(tracer) {
-          Headers.Ctx.Trace.set(req.headerMap, Trace.id)
-          Headers.RequestId.set(req.headerMap, Trace.id.traceId)
-          service(req)
-        }
+  val clientModule: Stackable[ServiceFactory[Request, Response]] =
+    new Stack.Module1[param.Tracer, ServiceFactory[Request, Response]] {
+      val role = HttpTraceInitializer.role
+      val description = "Attaches trace information to the outgoing request"
+      def make(_tracer: param.Tracer, next: ServiceFactory[Request, Response]) = {
+        val param.Tracer(tracer) = _tracer
+        new ClientFilter(tracer) andThen next
+      }
     }
-
-    def make(_tracer: param.Tracer, next: ServiceFactory[Request, Response]) = {
-      val param.Tracer(tracer) = _tracer
-      new Filter(tracer) andThen next
-    }
-  }
 }

--- a/linkerd/protocol/http/src/main/scala/com/twitter/finagle/buoyant/linkerd/HttpTraceInitializer.scala
+++ b/linkerd/protocol/http/src/main/scala/com/twitter/finagle/buoyant/linkerd/HttpTraceInitializer.scala
@@ -6,7 +6,7 @@ import com.twitter.finagle.http._
 import com.twitter.finagle.tracing._
 
 /**
- * Uses [[Headers.Ctx.Trace]] and [[Headers.Sample]] headers
+ * Uses [[Headers.Ctx.Trace]] and [[Headers.Sample]] headers to
  * propagate/control tracing.
  */
 object HttpTraceInitializer {

--- a/linkerd/protocol/http/src/main/scala/io/buoyant/linkerd/protocol/HttpConfig.scala
+++ b/linkerd/protocol/http/src/main/scala/io/buoyant/linkerd/protocol/HttpConfig.scala
@@ -16,10 +16,13 @@ class HttpInitializer extends ProtocolInitializer.Simple {
   protected type Rsp = com.twitter.finagle.http.Response
 
   protected val defaultRouter = {
-    val pathStack = Headers.Dst.PathFilter +: Http.router.pathStack
-    val boundStack = Headers.Dst.BoundFilter +: Http.router.boundStack
-    val clientStack = (http.AccessLogger.module +: Http.router.clientStack)
-      .replace(HttpTraceInitializer.role, HttpTraceInitializer.client)
+    val pathStack = Http.router.pathStack
+      .prepend(Headers.Dst.PathFilter.module)
+    val boundStack = Http.router.boundStack
+      .prepend(Headers.Dst.BoundFilter.module)
+    val clientStack = Http.router.clientStack
+      .prepend(http.AccessLogger.module)
+      .replace(HttpTraceInitializer.role, HttpTraceInitializer.clientModule)
       .insertAfter(Retries.Role, http.StatusCodeStatsFilter.module)
       .insertAfter(StackClient.Role.prepConn, Headers.Ctx.clientModule)
 
@@ -31,9 +34,10 @@ class HttpInitializer extends ProtocolInitializer.Simple {
   }
 
   protected val defaultServer = {
-    val stk = http.ErrorResponder +: Http.server.stack
-      .replace(HttpTraceInitializer.role, HttpTraceInitializer.server)
+    val stk = Http.server.stack
+      .replace(HttpTraceInitializer.role, HttpTraceInitializer.serverModule)
       .prepend(Headers.Ctx.serverModule)
+      .prepend(http.ErrorResponder.module)
     Http.server.withStack(stk)
   }
 

--- a/linkerd/protocol/http/src/test/scala/com/twitter/finagle/buoyant/linkerd/HeadersTest.scala
+++ b/linkerd/protocol/http/src/test/scala/com/twitter/finagle/buoyant/linkerd/HeadersTest.scala
@@ -1,22 +1,28 @@
 package com.twitter.finagle.buoyant.linkerd
 
-import com.twitter.finagle.http.Request
+import com.twitter.conversions.time._
+import com.twitter.finagle.{Addr, Deadline, Dtab, Path, Service, ServiceFactory, Stack}
+import com.twitter.finagle.buoyant.Dst
+import com.twitter.finagle.context.Contexts
+import com.twitter.finagle.http.{Request, Response}
 import com.twitter.finagle.tracing.Trace
+import com.twitter.util.{Future, Time, Var}
+import io.buoyant.test.Awaits
 import org.scalatest.FunSuite
 
-class HeadersTest extends FunSuite {
+class HeadersTest extends FunSuite with Awaits {
 
   test("round trip encoding for ctx header") {
     val orig = Trace.nextId
     val headers = Request().headerMap
 
-    assert(!headers.contains(Headers.Ctx.Key))
-    Headers.Ctx.set(headers, orig)
-    assert(headers.contains(Headers.Ctx.Key))
-    assert(Headers.Ctx.get(headers) == Some(orig))
+    assert(!headers.contains(Headers.Ctx.Trace.Key))
+    Headers.Ctx.Trace.set(headers, orig)
+    assert(headers.contains(Headers.Ctx.Trace.Key))
+    assert(Headers.Ctx.Trace.get(headers) == Some(orig))
 
-    Headers.Ctx.clear(headers)
-    assert(!headers.contains(Headers.Ctx.Key))
+    Headers.Ctx.Trace.clear(headers)
+    assert(!headers.contains(Headers.Ctx.Trace.Key))
   }
 
   test("round trip encoding for request id header") {
@@ -36,6 +42,9 @@ class HeadersTest extends FunSuite {
     headers(Headers.Sample.Key) = "yes"
     assert(Headers.Sample.get(headers).isEmpty)
 
+    headers(Headers.Sample.Key) = "-3"
+    assert(Headers.Sample.get(headers).contains(0f))
+
     headers(Headers.Sample.Key) = "0"
     assert(Headers.Sample.get(headers).contains(0f))
 
@@ -46,6 +55,193 @@ class HeadersTest extends FunSuite {
     assert(Headers.Sample.get(headers).contains(1f))
 
     headers(Headers.Sample.Key) = "1.5"
-    assert(Headers.Sample.get(headers).isEmpty)
+    assert(Headers.Sample.get(headers).contains(1f))
+  }
+
+  test("Headers.Ctx.serverModule sets Dtab.local") {
+    @volatile var dtab: Option[Dtab] = None
+    val svc = {
+      val sf = ServiceFactory.const(Service.mk[Request, Response] { req =>
+        dtab = Some(Dtab.local)
+        Future.value(Response())
+      })
+      val stk = Headers.Ctx.serverModule +: Stack.Leaf(Stack.Role("sf"), sf)
+      await(stk.make(Stack.Params.empty)())
+    }
+
+    val req = Request()
+    req.headerMap("l5d-dtab") = "/a => /d"
+    req.headerMap("l5d-ctx-dtab") = "/a => /c"
+    Dtab.unwind {
+      Dtab.local = Dtab.read("/a => /b")
+      val _ = await(svc(req))
+    }
+    assert(!req.headerMap.contains(Headers.Ctx.Dtab.CtxKey))
+    assert(!req.headerMap.contains(Headers.Ctx.Dtab.UserKey))
+    assert(dtab == Some(Dtab.read("/a=>/b;/a=>/c;/a=>/d")))
+  }
+
+  test("Headers.Ctx.serverModule errors on invalid dtab") {
+    @volatile var dtab: Option[Dtab] = None
+    val svc = {
+      val sf = ServiceFactory.const(Service.mk[Request, Response] { req =>
+        dtab = Some(Dtab.local)
+        Future.value(Response())
+      })
+      val stk = Headers.Ctx.serverModule +: Stack.Leaf(Stack.Role("sf"), sf)
+      await(stk.make(Stack.Params.empty)())
+    }
+
+    val req = Request()
+    req.headerMap("l5d-dtab") = "i am not a dtab"
+    val rsp = await(svc(req))
+    assert(rsp.statusCode == 400)
+  }
+
+  test("Headers.Ctx.serverModule sets Deadline") {
+    @volatile var deadline: Option[Deadline] = None
+    val svc = {
+      val sf = ServiceFactory.const(Service.mk[Request, Response] { req =>
+        deadline = Deadline.current
+        Future.value(Response())
+      })
+      val stk = Headers.Ctx.serverModule +: Stack.Leaf(Stack.Role("sf"), sf)
+      await(stk.make(Stack.Params.empty)())
+    }
+
+    val req = Request()
+    val dl = Deadline(Time.now, Time.now + 5.seconds)
+    Headers.Ctx.Deadline.set(req.headerMap, dl)
+    assert(req.headerMap.contains(Headers.Ctx.Deadline.Key))
+    val _ = await(svc(req))
+    assert(!req.headerMap.contains(Headers.Ctx.Deadline.Key))
+    assert(deadline == Some(dl))
+  }
+
+  test("Headers.Ctx.Dtab.ClientFilter sets Dtab") {
+    @volatile var dtab: Option[String] = None
+    val svc = new Headers.Ctx.Dtab.ClientFilter andThen Service.mk[Request, Response] { req =>
+      dtab = req.headerMap.get(Headers.Ctx.Dtab.CtxKey)
+      Future.value(Response())
+    }
+
+    Dtab.unwind {
+      Dtab.local = Dtab.read("/foo=>/bar")
+      val _ = await(svc(Request()))
+    }
+    assert(dtab == Some("/foo=>/bar"))
+  }
+
+  test("Headers.Ctx.serverModule uses strictest Deadline") {
+    @volatile var deadline: Option[Deadline] = None
+    val svc = {
+      val sf = ServiceFactory.const(Service.mk[Request, Response] { _ =>
+        deadline = Deadline.current
+        Future.value(Response())
+      })
+      val stk = Headers.Ctx.serverModule +: Stack.Leaf(Stack.Role("sf"), sf)
+      await(stk.make(Stack.Params.empty)())
+    }
+
+    val req = Request()
+    val now = Time.now
+    Headers.Ctx.Deadline.set(
+      req.headerMap,
+      Deadline(now + 1.second, now + 10.seconds)
+    )
+    req.headerMap.add(
+      Headers.Ctx.Deadline.Key,
+      Headers.Ctx.Deadline.write(Deadline(now + 2.second, now + 8.seconds))
+    )
+    Contexts.broadcast.let(Deadline, Deadline(now, now + 2.seconds)) {
+      val _ = await(svc(req))
+    }
+    assert(deadline == Some(Deadline(now + 2.second, now + 2.seconds)))
+  }
+
+  test("Headers.Ctx.clientModule sets Deadline") {
+    @volatile var deadline: Option[Deadline] = None
+    val svc = {
+      val sf = ServiceFactory.const(Service.mk[Request, Response] { req =>
+        deadline = Headers.Ctx.Deadline.get(req.headerMap)
+        Future.value(Response())
+      })
+      val stk = Headers.Ctx.clientModule +: Stack.Leaf(Stack.Role("sf"), sf)
+      await(stk.make(Stack.Params.empty)())
+    }
+
+    val req = Request()
+    val dl = Deadline(Time.now, Time.now + 5.seconds)
+    Contexts.broadcast.let(Deadline, dl) {
+      Headers.Ctx.Deadline.set(req.headerMap, dl)
+      val _ = await(svc(req))
+    }
+    assert(req.headerMap.contains(Headers.Ctx.Deadline.Key))
+    assert(deadline == Some(dl))
+  }
+
+  test("Headers.Ctx.clientModule omits Deadline if not set") {
+    @volatile var deadline: Option[Deadline] = None
+    val svc = {
+      val sf = ServiceFactory.const(Service.mk[Request, Response] { req =>
+        deadline = Headers.Ctx.Deadline.get(req.headerMap)
+        Future.value(Response())
+      })
+      val stk = Headers.Ctx.clientModule +: Stack.Leaf(Stack.Role("sf"), sf)
+      await(stk.make(Stack.Params.empty)())
+    }
+
+    val req = Request()
+    val _ = await(svc(req))
+    assert(!req.headerMap.contains(Headers.Ctx.Deadline.Key))
+    assert(deadline == None)
+  }
+
+  test("PathFilter encodes Dst.Path on downstream requests") {
+    @volatile var path: Option[String] = None
+    val svc = {
+      val sf = ServiceFactory.const(Service.mk[Request, Response] { req =>
+        path = req.headerMap.get(Headers.Dst.Path)
+        Future.value(Response())
+      })
+      val stk = Headers.Dst.PathFilter +: Stack.Leaf(Stack.Role("sf"), sf)
+      await(stk.make(Stack.Params.empty + Dst.Path(Path.read("/freedom")))())
+    }
+    val _ = await(svc(Request()))
+    assert(path == Some("/freedom"))
+  }
+
+  test("BoundFilter encodes Dst.Bound on downstream requests") {
+    @volatile var id, residual: Option[String] = None
+    val svc = {
+      val sf = ServiceFactory.const(Service.mk[Request, Response] { req =>
+        id = req.headerMap.get(Headers.Dst.Bound)
+        residual = req.headerMap.get(Headers.Dst.Residual)
+        Future.value(Response())
+      })
+      val stk = Headers.Dst.BoundFilter +: Stack.Leaf(Stack.Role("sf"), sf)
+      val bound = Dst.Bound(Var.value(Addr.Pending), Path.Utf8("id"), Path.Utf8("residual"))
+      await(stk.make(Stack.Params.empty + bound)())
+    }
+    val _ = await(svc(Request()))
+    assert(id == Some("/id"))
+    assert(residual == Some("/residual"))
+  }
+
+  test("BoundFilter encodes Dst.Bound on downstream requests: omits empty residual") {
+    @volatile var id, residual: Option[String] = None
+    val svc = {
+      val sf = ServiceFactory.const(Service.mk[Request, Response] { req =>
+        id = req.headerMap.get(Headers.Dst.Bound)
+        residual = req.headerMap.get(Headers.Dst.Residual)
+        Future.value(Response())
+      })
+      val stk = Headers.Dst.BoundFilter +: Stack.Leaf(Stack.Role("sf"), sf)
+      val bound = Dst.Bound(Var.value(Addr.Pending), Path.Utf8("id"))
+      await(stk.make(Stack.Params.empty + bound)())
+    }
+    val _ = await(svc(Request()))
+    assert(id == Some("/id"))
+    assert(residual == None)
   }
 }

--- a/linkerd/protocol/http/src/test/scala/com/twitter/finagle/buoyant/linkerd/HeadersTest.scala
+++ b/linkerd/protocol/http/src/test/scala/com/twitter/finagle/buoyant/linkerd/HeadersTest.scala
@@ -30,7 +30,7 @@ class HeadersTest extends FunSuite with Awaits {
     val headers = Request().headerMap
 
     assert(!headers.contains(Headers.RequestId.Key))
-    Headers.RequestId.set(headers, orig.traceId)
+    Headers.RequestId.set(headers, orig)
     assert(headers.contains(Headers.RequestId.Key))
     assert(headers.get(Headers.RequestId.Key) == Some(orig.traceId.toString))
   }
@@ -204,7 +204,7 @@ class HeadersTest extends FunSuite with Awaits {
         path = req.headerMap.get(Headers.Dst.Path)
         Future.value(Response())
       })
-      val stk = Headers.Dst.PathFilter +: Stack.Leaf(Stack.Role("sf"), sf)
+      val stk = Headers.Dst.PathFilter.module +: Stack.Leaf(Stack.Role("sf"), sf)
       await(stk.make(Stack.Params.empty + Dst.Path(Path.read("/freedom")))())
     }
     val _ = await(svc(Request()))
@@ -219,7 +219,7 @@ class HeadersTest extends FunSuite with Awaits {
         residual = req.headerMap.get(Headers.Dst.Residual)
         Future.value(Response())
       })
-      val stk = Headers.Dst.BoundFilter +: Stack.Leaf(Stack.Role("sf"), sf)
+      val stk = Headers.Dst.BoundFilter.module +: Stack.Leaf(Stack.Role("sf"), sf)
       val bound = Dst.Bound(Var.value(Addr.Pending), Path.Utf8("id"), Path.Utf8("residual"))
       await(stk.make(Stack.Params.empty + bound)())
     }
@@ -236,7 +236,7 @@ class HeadersTest extends FunSuite with Awaits {
         residual = req.headerMap.get(Headers.Dst.Residual)
         Future.value(Response())
       })
-      val stk = Headers.Dst.BoundFilter +: Stack.Leaf(Stack.Role("sf"), sf)
+      val stk = Headers.Dst.BoundFilter.module +: Stack.Leaf(Stack.Role("sf"), sf)
       val bound = Dst.Bound(Var.value(Addr.Pending), Path.Utf8("id"))
       await(stk.make(Stack.Params.empty + bound)())
     }

--- a/linkerd/protocol/http/src/test/scala/com/twitter/finagle/buoyant/linkerd/HttpTraceInitializerTest.scala
+++ b/linkerd/protocol/http/src/test/scala/com/twitter/finagle/buoyant/linkerd/HttpTraceInitializerTest.scala
@@ -1,5 +1,6 @@
 package com.twitter.finagle.buoyant.linkerd
 
+import com.twitter.finagle.Stack
 import com.twitter.finagle.http.{Request, Response}
 import com.twitter.finagle.tracing.{NullTracer, Trace}
 import com.twitter.finagle.{Service, ServiceFactory, param}
@@ -16,8 +17,9 @@ class HttpTraceInitializerTest extends FunSuite with Awaits {
       Headers.Ctx.Trace.set(rsp.headerMap, Trace.id)
       Future.value(rsp)
     }
-    val tracer = param.Tracer(NullTracer)
-    val factory = HttpTraceInitializer.server.make(tracer, ServiceFactory.const(svc))
+    val factory = HttpTraceInitializer.serverModule
+      .toStack(Stack.Leaf(Stack.Role("ep"), ServiceFactory.const(svc)))
+      .make(Stack.Params.empty + param.Tracer(NullTracer))
     Await.result(factory())
   }
 

--- a/linkerd/protocol/http/src/test/scala/com/twitter/finagle/buoyant/linkerd/HttpTraceInitializerTest.scala
+++ b/linkerd/protocol/http/src/test/scala/com/twitter/finagle/buoyant/linkerd/HttpTraceInitializerTest.scala
@@ -13,7 +13,7 @@ class HttpTraceInitializerTest extends FunSuite with Awaits {
   def tracingService(): Service[Request, Response] = {
     val svc = Service.mk[Request, Response] { req =>
       val rsp = Response()
-      Headers.Ctx.set(rsp.headerMap, Trace.id)
+      Headers.Ctx.Trace.set(rsp.headerMap, Trace.id)
       Future.value(rsp)
     }
     val tracer = param.Tracer(NullTracer)
@@ -26,7 +26,7 @@ class HttpTraceInitializerTest extends FunSuite with Awaits {
     val req = Request()
 
     val rsp = await(service(req))
-    assert(Headers.Ctx.get(rsp.headerMap).exists(_.sampled.isEmpty))
+    assert(Headers.Ctx.Trace.get(rsp.headerMap).exists(_.sampled.isEmpty))
   }
 
   test("does not trace when sample header is set to 0") {
@@ -35,7 +35,7 @@ class HttpTraceInitializerTest extends FunSuite with Awaits {
     req.headerMap(Headers.Sample.Key) = "0"
 
     val rsp = await(service(req))
-    assert(Headers.Ctx.get(rsp.headerMap).exists(_.sampled.contains(false)))
+    assert(Headers.Ctx.Trace.get(rsp.headerMap).exists(_.sampled.contains(false)))
   }
 
   test("traces when sample header is set to 1") {
@@ -44,19 +44,19 @@ class HttpTraceInitializerTest extends FunSuite with Awaits {
     req.headerMap(Headers.Sample.Key) = "1"
 
     val rsp = await(service(req))
-    assert(Headers.Ctx.get(rsp.headerMap).exists(_.sampled.contains(true)))
+    assert(Headers.Ctx.Trace.get(rsp.headerMap).exists(_.sampled.contains(true)))
   }
 
   test("parent/child requests are assigned linked request ids") {
     val service = tracingService()
     val req1 = Request()
     val rsp1 = await(service(req1))
-    val reqId1 = Headers.Ctx.get(rsp1.headerMap).get
+    val reqId1 = Headers.Ctx.Trace.get(rsp1.headerMap).get
 
     val req2 = Request()
-    req2.headerMap(Headers.Ctx.Key) = rsp1.headerMap(Headers.Ctx.Key)
+    req2.headerMap(Headers.Ctx.Trace.Key) = rsp1.headerMap(Headers.Ctx.Trace.Key)
     val rsp2 = await(service(req2))
-    val reqId2 = Headers.Ctx.get(rsp2.headerMap).get
+    val reqId2 = Headers.Ctx.Trace.get(rsp2.headerMap).get
 
     assert(reqId1.spanId == reqId1.parentId)
     assert(reqId2.spanId != reqId2.parentId)
@@ -69,9 +69,9 @@ class HttpTraceInitializerTest extends FunSuite with Awaits {
     val req = Request()
 
     val rsp1 = await(service(req))
-    val reqId1 = Headers.Ctx.get(rsp1.headerMap).get
+    val reqId1 = Headers.Ctx.Trace.get(rsp1.headerMap).get
     val rsp2 = await(service(req))
-    val reqId2 = Headers.Ctx.get(rsp2.headerMap).get
+    val reqId2 = Headers.Ctx.Trace.get(rsp2.headerMap).get
 
     assert(reqId1.traceId != reqId2.traceId)
     assert(reqId1.spanId != reqId2.spanId)

--- a/linkerd/protocol/http/src/test/scala/io/buoyant/linkerd/protocol/http/ErrorResponderTest.scala
+++ b/linkerd/protocol/http/src/test/scala/io/buoyant/linkerd/protocol/http/ErrorResponderTest.scala
@@ -2,11 +2,12 @@ package io.buoyant.linkerd.protocol.http
 
 import com.twitter.finagle.{Service, ServiceFactory, Stack}
 import com.twitter.finagle.buoyant.linkerd.Headers
-import com.twitter.util.Future
 import com.twitter.finagle.http.{Request, Response, Status}
-import java.net.URLEncoder
+import com.twitter.io.Charsets
+import com.twitter.util.Future
 import io.buoyant.router.RoutingFactory
 import io.buoyant.test.Awaits
+import java.net.URLEncoder
 import org.scalatest.FunSuite
 
 class ErrorResponderTest extends FunSuite with Awaits {
@@ -14,8 +15,8 @@ class ErrorResponderTest extends FunSuite with Awaits {
   val svc = Service.mk[Request, Response] { _ =>
     Future.exception(RoutingFactory.UnknownDst(Request(), new Exception(s"foo\nbar")))
   }
-  val stk = ErrorResponder.toStack(
-    Stack.Leaf(ErrorResponder.role, ServiceFactory.const(svc))
+  val stk = ErrorResponder.module.toStack(
+    Stack.Leaf(Stack.Role("endpoint"), ServiceFactory.const(svc))
   )
   val service = await(stk.make(Stack.Params.empty)())
 
@@ -26,8 +27,8 @@ class ErrorResponderTest extends FunSuite with Awaits {
 
   test("correctly encodes error headers") {
     val rsp = await(service(Request()))
-    val headerErr = rsp.headerMap(Headers.Err)
+    val headerErr = rsp.headerMap(Headers.Err.Key)
     assert(!headerErr.contains("\n"))
-    assert(headerErr.contains(URLEncoder.encode("\n", "ISO-8859-1")))
+    assert(headerErr.contains(URLEncoder.encode("\n", Charsets.Iso8859_1.toString)))
   }
 }

--- a/router/core/src/main/scala/com/twitter/finagle/buoyant/Dst.scala
+++ b/router/core/src/main/scala/com/twitter/finagle/buoyant/Dst.scala
@@ -44,7 +44,7 @@ object Dst {
     def apply(name: Name.Bound): Bound =
       new Bound(name)
 
-    def apply(addr: Var[Addr], id: Any, path: FPath = FPath.empty): Bound =
+    def apply(addr: Var[Addr], id: FPath, path: FPath = FPath.empty): Bound =
       new Bound(Name.Bound(addr, id, path))
 
     def unapply(bound: Name.Bound): Option[(Var[Addr], String, FPath)] =


### PR DESCRIPTION
As we introduce additional contextual information to be passed between linkerd
instances, we have an opportunity to establish better conventions that allow
for extension.

Specifically:

- All linkerd-generated headers are to be encoded as `l5d-ctx-*`.  Apps should be
  able to safely forward this prefix and only this prefix for linkerd to
  operate normally. This won't be the case until the next finagle release.
- The `l5d-ctx` header has been renamed to `l5d-ctx-trace`.
- The `l5d-ctx-deadline` header encodes deadlines.  Deadlines are not yet
  enforced.
- We now accept `l5d-dtab` in place of `dtab-local`.  Currently, `l5d-dtab` is
  appended to the `dtab-local` value. In a future release, we will probably
  stop honoring `dtab-local` in linkerd.
- We are now more gracious in accepting `l5d-sample` -- negative numbers are
  treated as 0 and values greater than 1 are treated as 1.
- We stop encoding `l5d-dst-*` headers on responses. These response headers are
  particularly meaningless in linkerd-to-linkerd mode, and generally serve as
  a potential information leak to clients.  These values are reported on
  downstream requests, but do not need to be forwarded by applications.

TODO
- [x] update changes
- [x] update documentation