### PR TITLE
Add the ability to go to a specific routers dashboard

### DIFF
--- a/admin/src/main/resources/io/buoyant/admin/js/dashboard.js
+++ b/admin/src/main/resources/io/buoyant/admin/js/dashboard.js
@@ -1,5 +1,5 @@
 "use strict";
-/* globals getSelectedRouter, MetricsCollector, ProcInfo, RequestTotals, Routers, RouterController */
+/* globals MetricsCollector, ProcInfo, RequestTotals, Routers, RouterController */
 
 /**
  * Number of millis to wait between data updates.
@@ -30,7 +30,7 @@ $.when(
     overviewStatsRsp,
     requestTotalsRsp,
     metricsJson) {
-  var selectedRouter = getSelectedRouter(); // TODO: update this to avoid passing params in urls #198
+
   var routerTemplates = {
     summary: Handlebars.compile(routerSummaryRsp[0]),
     container: Handlebars.compile(routerContainerRsp[0]),
@@ -45,10 +45,12 @@ $.when(
   var metricsCollector = MetricsCollector(metricsJson[0]);
   var routers = Routers(metricsJson[0], metricsCollector);
 
-  var buildVersion = $(".server-data").data("linkerd-version");
+  var $serverData = $(".server-data");
+  var buildVersion = $serverData.data("linkerd-version");
+  var selectedRouter = $serverData.data("router-name");
 
   ProcInfo(metricsCollector, $(".proc-info"), Handlebars.compile(overviewStatsRsp[0]), buildVersion);
-  RequestTotals(metricsCollector, $(".request-totals"), Handlebars.compile(requestTotalsRsp[0]), _.keys(metricsJson[0]));
+  RequestTotals(metricsCollector, selectedRouter, $(".request-totals"), Handlebars.compile(requestTotalsRsp[0]), _.keys(metricsJson[0]));
   RouterController(metricsCollector, selectedRouter, routers, routerTemplates, $(".dashboard-container"));
 
   $(function() {

--- a/admin/src/main/resources/io/buoyant/admin/js/request_totals.js
+++ b/admin/src/main/resources/io/buoyant/admin/js/request_totals.js
@@ -33,7 +33,7 @@ var RequestTotals = (function() {
     }));
   }
 
-  return function(metricsCollector, $root, template) {
+  return function(metricsCollector, selectedRouter, $root, template) {
     function onMetricsUpdate(data) {
       var transformedData = _.map(metricDefinitions, function(defn) {
         var metricsByQuery = Query.filter(defn.query, data.specific);
@@ -47,8 +47,12 @@ var RequestTotals = (function() {
       render($root, template, transformedData);
     }
 
-    render($root, template, metricDefinitions);
-    metricsCollector.registerListener(onMetricsUpdate, desiredMetrics);
+    if (!selectedRouter) {
+      render($root, template, metricDefinitions);
+      metricsCollector.registerListener(onMetricsUpdate, desiredMetrics);
+    } else {
+      $root.hide();
+    }
     return {};
   }
 })();

--- a/admin/src/main/resources/io/buoyant/admin/js/router_controller.js
+++ b/admin/src/main/resources/io/buoyant/admin/js/router_controller.js
@@ -70,8 +70,19 @@ var RouterController = (function () {
     }
   });
 
+  function getSelectedRouterData(selectedRouter, routers) {
+    var routerData = {};
+
+    if (!selectedRouter || !routers.data[selectedRouter]) {
+      routerData = routers.data;
+    } else {
+      routerData[selectedRouter] = routers.data[selectedRouter];
+    }
+    return routerData;
+  }
+
   function initializeRouterContainers(selectedRouter, routers, $parentContainer, template) {
-    var routerData = !selectedRouter ? routers.data : { router: routers.data[selectedRouter] };
+    var routerData = getSelectedRouterData(selectedRouter, routers);
     var containers = template({ routers: _.keys(routerData) });
     $parentContainer.html(containers);
 

--- a/linkerd/admin/src/main/scala/io/buoyant/linkerd/admin/DashboardHandler.scala
+++ b/linkerd/admin/src/main/scala/io/buoyant/linkerd/admin/DashboardHandler.scala
@@ -6,20 +6,25 @@ import com.twitter.util.Future
 import io.buoyant.linkerd.Build
 
 private[admin] class DashboardHandler extends Service[Request, Response] {
-  lazy val html = dashboardHtml
+  import DashboardHandler._
 
   override def apply(req: Request): Future[Response] = req.path match {
-    case "/" =>
-      AdminHandler.mkResponse(html)
+    case "/" | "/routers" =>
+      AdminHandler.mkResponse(dashboardHtml())
+    case rexp(router) =>
+      AdminHandler.mkResponse(dashboardHtml(router))
     case _ =>
       Future.value(Response(Status.NotFound))
   }
 
-  def dashboardHtml = {
+  def dashboardHtml(router: String = "") = {
     AdminHandler.html(
       content = s"""
         <div class="request-totals"></div>
-        <div class="server-data" data-linkerd-version="${Build.load().version}" style="visibility:hidden"></div>
+        <div class="server-data"
+          data-linkerd-version="${Build.load().version}"
+          data-router-name="${router}"
+          style="visibility:hidden"></div>
         <div class="dashboard-container"></div>
         <div class="row proc-info">
         </div>
@@ -44,4 +49,8 @@ private[admin] class DashboardHandler extends Service[Request, Response] {
       navbar = AdminHandler.version2NavBar
     )
   }
+}
+
+object DashboardHandler {
+  val rexp = "^/routers/(.*)/?".r
 }


### PR DESCRIPTION
... via visiting /routers/<routername> in the url.
Removes use of getSelectedRouter() from the dashboard code which didn't work anyway.

It definitely still needs UI improvements. The blue summary banner at the top still displays metrics for all the routers, so maybe we should remove it or clarify that that is across all routers.

(Not even sure if we even still want single router pages, but here's a stab at it.)

![screen shot 2016-06-10 at 5 27 06 pm](https://cloud.githubusercontent.com/assets/549258/15982092/6e4030ee-2f34-11e6-98de-2114ca796249.png)


