### PR TITLE
Allow linkerd-examples to accept arguments

### DIFF
--- a/project/Base.scala
+++ b/project/Base.scala
@@ -1,6 +1,7 @@
 import com.typesafe.sbt.SbtScalariform.{scalariformSettings => baseScalariformSettings, _}
 import sbt._
 import sbt.Keys._
+import complete.Parsers.spaceDelimited
 import sbtassembly.AssemblyKeys._
 import sbtassembly.AssemblyPlugin.assemblySettings
 import sbtassembly.MergeStrategy
@@ -117,10 +118,11 @@ class Base extends Build {
     // The runtime configuration may be different from the example configuration.
     runtimeConfiguration := configuration.value,
     run := // call linkerd's run command with a config file
-      Def.taskDyn {
+      Def.inputTaskDyn {
         val path = configFile.value.getPath
-        (run in runtime in runtimeConfiguration.value).toTask(s" $path")
-      }.value
+        val args = spaceDelimited("<args>").parsed.mkString(" ")
+        (run in runtime in runtimeConfiguration.value).toTask(s" $path $args")
+      }.evaluated
   )
 
   // Helper method for constructing projects from directory structure


### PR DESCRIPTION
# Problem

The run task on the linkerd example configurations does not accept arguments:

```
$ ./sbt 'linkerd-examples/transit:run --log.level=DEBUG'
[info] Loading project definition from /Users/alex/workspace/linkerd/project
[info] Set current project to all (in build file:/Users/alex/workspace/linkerd/)
[error] Expected key
[error] Expected '::'
[error] Expected end of input.
[error] linkerd-examples/transit:run --log.level=DEBUG
```

# Solution

Parse arguments using "the exotic, elusive creature known as inputTaskDyn, with which even Stack Overflow cannot help you" (1) and feed them into `run`.


(1) https://github.com/sbt/sbt/issues/999