### PR TITLE
Unify client and server sections of the dashboard

### DIFF
--- a/admin/src/main/resources/io/buoyant/admin/css/dashboard.css
+++ b/admin/src/main/resources/io/buoyant/admin/css/dashboard.css
@@ -126,7 +126,7 @@ nav ul.navbar-nav {
 }
 
 .router .summary {
-  margin-top: 9px;
+  margin: 9px 0 20px 0;
 }
 
 .router-graph-header {
@@ -150,7 +150,7 @@ nav ul.navbar-nav {
   padding-bottom: 30px;
 }
 
-.server-metric-container {
+.server-metric-container, .server-success-chart {
   margin-top: 20px; /* to match metric-container */
 }
 

--- a/admin/src/main/resources/io/buoyant/admin/js/router_server.js
+++ b/admin/src/main/resources/io/buoyant/admin/js/router_server.js
@@ -88,7 +88,7 @@ var RouterServer = (function() {
     template = serverTemplate;
     var $metricsEl = $serverEl.find(".server-metrics");
     var $chartEl = $serverEl.find(".server-success-chart");
-    var chart = SuccessRateGraph($chartEl, "#4AD8AC", true);
+    var chart = SuccessRateGraph($chartEl, "#4AD8AC");
 
     var metricsHandler = function(data) {
       var filteredData = _.filter(data.specific, function (d) { return d.name.indexOf(routerName) !== -1 });

--- a/admin/src/main/resources/io/buoyant/admin/js/success_rate_graph.js
+++ b/admin/src/main/resources/io/buoyant/admin/js/success_rate_graph.js
@@ -3,6 +3,7 @@
 var SuccessRateGraph = (function() {
   var neutralLineColor = "#878787"; // greys.neutral
   var defaultWidth = 1181;
+  var colMd6Width = 594; // from our css grid layout spec
 
   // set default y range such that a graph of purely 100% success rate doesn't
   // blend in to the very top of the graph, and doesn't center
@@ -15,21 +16,12 @@ var SuccessRateGraph = (function() {
     }
   }
 
-  function getChartWidthFn(isFullWidthChart, $chartEl) {
-    if (isFullWidthChart) {
-      return function() { return $chartEl.width(); }
-    } else {
-      return function() {
-        var containerWidth = $(".client-container").first().width();
-
-        if (containerWidth > defaultWidth) {
-          var metricsWidth = $(".metrics-container").first().width();
-          return containerWidth - metricsWidth; // get this to display nicely on wide screens
-        } else {
-          return containerWidth;
-        }
-      }
+  function chartWidthFn() {
+    var serverWidth = $(".router-server").width();
+    if (serverWidth < defaultWidth) {
+      return serverWidth;
     }
+    return serverWidth - colMd6Width;
   }
 
   function yRangeFunction(range) {
@@ -70,11 +62,11 @@ var SuccessRateGraph = (function() {
     return chart;
   }
 
-  return function($chartEl, clientColor, isFullWidth) {
+  return function($chartEl, clientColor) {
     var chartLegend = createChartLegend(clientColor);
-    var chart = initializeChart($chartEl, timeseriesParams, getChartWidthFn(isFullWidth, $chartEl));
+    var chart = initializeChart($chartEl, timeseriesParamsFn, chartWidthFn);
 
-    function timeseriesParams(name) {
+    function timeseriesParamsFn(name) {
       return {
         strokeStyle: chartLegend[name],
         lineWidth: 2

--- a/admin/src/main/resources/io/buoyant/admin/template/router_container.template
+++ b/admin/src/main/resources/io/buoyant/admin/template/router_container.template
@@ -1,7 +1,7 @@
 {{#each routers}}
-  <div class="router router-{{this}}" data-router="{{this}}">
+  <div class="router router-{{this}} row" data-router="{{this}}">
     <div class="summary row"></div>
-    <div class="clients router-clients row">
+    <div class="clients router-clients">
       <div class="router-graph-header">Requests per client</div>
       <canvas class="router-graph" height="181"></canvas>
       <div class="router-subsection-title">Clients</div>

--- a/admin/src/main/resources/io/buoyant/admin/template/router_server.template
+++ b/admin/src/main/resources/io/buoyant/admin/template/router_server.template
@@ -2,11 +2,8 @@
   {{server}}
 </div>
 
-<div class="server-metrics">
-  <div class="row">
-    {{> rateMetricPartial metrics.requests containerClass="metric-container col-md-2" metricClass="metric-large"}}
-    {{> rateMetricPartial metrics.load containerClass="metric-container col-md-2" metricClass="metric-large"}}
-    {{> rateMetricPartial metrics.success containerClass="success-metric-container metric-container col-md-2" metricClass="metric-large success-metric"}}
-    {{> rateMetricPartial metrics.failures containerClass="failure-metric-container metric-container col-md-2" metricClass="metric-large failure-metric"}}
-  </div>
+<div class="container-fluid clearfix col-md-6">
+  {{> rateMetricPartial metrics.requests containerClass="metric-container col-md-2" metricClass="metric-large"}}
+  {{> rateMetricPartial metrics.success containerClass="success-metric-container metric-container col-md-2" metricClass="metric-large success-metric"}}
+  {{> rateMetricPartial metrics.failures containerClass="failure-metric-container metric-container col-md-2" metricClass="metric-large failure-metric"}}
 </div>

--- a/admin/src/main/resources/io/buoyant/admin/template/router_server_container.template
+++ b/admin/src/main/resources/io/buoyant/admin/template/router_server_container.template
@@ -1,5 +1,6 @@
 <div class="router-server">
   <div class="server-metrics"></div>
-  <div class="router-graph-header">Server success rate</div>
-  <div class="server-success-chart"></div>
+  <div class="server-success-chart col-md-6">
+    <div class="router-graph-header">Server success rate</div>
+  </div>
 </div>


### PR DESCRIPTION
* Align server success rate graph with client graphs
* Remove pending requests count from server summary stats

![screen shot 2016-06-14 at 2 18 06 pm](https://cloud.githubusercontent.com/assets/549258/16060414/7203a1c4-323c-11e6-87b2-5060c6a9a44c.png)
![screen shot 2016-06-14 at 2 18 12 pm](https://cloud.githubusercontent.com/assets/549258/16060424/7b6c3974-323c-11e6-80de-664c9c2ddfe4.png)
![screen shot 2016-06-14 at 2 18 25 pm](https://cloud.githubusercontent.com/assets/549258/16060427/7f44c0ac-323c-11e6-80fe-49da05fb7eb2.png)


Continuing from #436 