### PR TITLE
linkerd-protocol-http: Handle client exceptions in the path stack

### DIFF
--- a/linkerd/protocol/http/src/main/scala/io/buoyant/linkerd/protocol/HttpConfig.scala
+++ b/linkerd/protocol/http/src/main/scala/io/buoyant/linkerd/protocol/HttpConfig.scala
@@ -20,6 +20,7 @@ class HttpInitializer extends ProtocolInitializer.Simple {
     val pathStack = Http.router.pathStack
       .prepend(Headers.Dst.PathFilter.module)
       .replace(StackClient.Role.prepFactory, DelayedRelease.module)
+      .prepend(http.ErrorResponder.module)
     val boundStack = Http.router.boundStack
       .prepend(Headers.Dst.BoundFilter.module)
     val clientStack = Http.router.clientStack

--- a/linkerd/protocol/http/src/main/scala/io/buoyant/linkerd/protocol/http/ErrorResponder.scala
+++ b/linkerd/protocol/http/src/main/scala/io/buoyant/linkerd/protocol/http/ErrorResponder.scala
@@ -24,7 +24,11 @@ class ErrorResponder extends SimpleFilter[Request, Response] {
           log.error(e, "service failure")
           Status.BadGateway
       }
-      Headers.Err.respond(e.getMessage, status)
+      val message = e.getMessage match {
+        case null => e.getClass.getName
+        case msg => msg
+      }
+      Headers.Err.respond(message, status)
   }
 }
 

--- a/linkerd/protocol/http/src/test/scala/io/buoyant/linkerd/protocol/HttpInitializerTest.scala
+++ b/linkerd/protocol/http/src/test/scala/io/buoyant/linkerd/protocol/HttpInitializerTest.scala
@@ -5,6 +5,7 @@ import com.twitter.finagle.{Service, ServiceFactory, Stack, param}
 import com.twitter.finagle.http.{Request, Response, Status, Version}
 import com.twitter.finagle.service.{Retries, RetryBudget}
 import com.twitter.finagle.stack.nilStack
+import com.twitter.finagle.stats.InMemoryStatsReceiver
 import com.twitter.io.Reader
 import com.twitter.util.{Future, MockTimer, Promise, Time}
 import io.buoyant.linkerd.protocol.http.ResponseClassifiers
@@ -120,12 +121,16 @@ class HttpInitializerTest extends FunSuite with Awaits with Eventually {
         (defaultRouter.pathStack ++ Stack.Leaf(Stack.Role("leaf"), sf)).make(params)
     }
 
-    val factory = http.make(Stack.Params.empty)
+    val stats = new InMemoryStatsReceiver
+    val factory = http.make(Stack.Params.empty + param.Stats(stats))
     val service = await(factory())
 
     val response = await(service(Request()))
     assert(requests == 1)
     assert(response.status == Status.BadGateway)
     assert(response.headerMap.contains("l5d-err"))
+
+    val counter = Seq("failures", "io.buoyant.linkerd.protocol.HttpInitializerTest$WildErr")
+    assert(stats.counters.get(counter) == Some(1))
   }
 }


### PR DESCRIPTION
Problem

When an exception is raised in the linkerd client, it is thrown into the
server.  This means that client connection errors are measuerd as server
connection errors in stats, etc.

Solution

Handle exceptions at the top of the router's path stack so that the server
isn't exposed to client-generated exceptions.