### PR TITLE
Delay service closure while streams are open

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -10,7 +10,7 @@
   * `l5d-dtab` now honored as a replacement for `dtab-local` as
     specified by users.
   * `l5d-dst-*` no longer set on responses
-
+* Fix graceful connection teardown on streaming HTTP responses #482.
 
 ## 0.6.0
 

--- a/linkerd/protocol/http/src/main/scala/com/twitter/finagle/buoyant/linkerd/DelayedRelease.scala
+++ b/linkerd/protocol/http/src/main/scala/com/twitter/finagle/buoyant/linkerd/DelayedRelease.scala
@@ -1,0 +1,16 @@
+package com.twitter.finagle
+package buoyant.linkerd
+
+import com.twitter.finagle.client.StackClient
+import com.twitter.finagle.http.{DelayedReleaseService, Request, Response}
+
+object DelayedRelease {
+
+  val module: Stackable[ServiceFactory[Request, Response]] =
+    new Stack.Module0[ServiceFactory[Request, Response]] {
+      val role = StackClient.Role.prepFactory
+      val description = "Prevents an HTTP service from being closed until its response completes"
+      def make(next: ServiceFactory[Request, Response]) =
+        next.map(new DelayedReleaseService(_))
+    }
+}

--- a/linkerd/protocol/http/src/main/scala/io/buoyant/linkerd/protocol/HttpConfig.scala
+++ b/linkerd/protocol/http/src/main/scala/io/buoyant/linkerd/protocol/HttpConfig.scala
@@ -16,24 +16,22 @@ class HttpInitializer extends ProtocolInitializer.Simple {
   protected type Req = com.twitter.finagle.http.Request
   protected type Rsp = com.twitter.finagle.http.Response
 
-  protected val defaultRouter = {
-    val pathStack = Http.router.pathStack
-      .prepend(Headers.Dst.PathFilter.module)
-      .replace(StackClient.Role.prepFactory, DelayedRelease.module)
-    val boundStack = Http.router.boundStack
-      .prepend(Headers.Dst.BoundFilter.module)
-    val clientStack = Http.router.clientStack
-      .prepend(http.AccessLogger.module)
-      .replace(HttpTraceInitializer.role, HttpTraceInitializer.clientModule)
-      .insertAfter(Retries.Role, http.StatusCodeStatsFilter.module)
-      .insertAfter(StackClient.Role.prepConn, Headers.Ctx.clientModule)
+  protected val pathStack = Http.router.pathStack
+    .prepend(Headers.Dst.PathFilter.module)
+    .replace(StackClient.Role.prepFactory, DelayedRelease.module)
+  protected val boundStack = Http.router.boundStack
+    .prepend(Headers.Dst.BoundFilter.module)
+  protected val clientStack = Http.router.clientStack
+    .prepend(http.AccessLogger.module)
+    .replace(HttpTraceInitializer.role, HttpTraceInitializer.clientModule)
+    .insertAfter(Retries.Role, http.StatusCodeStatsFilter.module)
+    .insertAfter(StackClient.Role.prepConn, Headers.Ctx.clientModule)
 
-    Http.router
-      .withPathStack(pathStack)
-      .withBoundStack(boundStack)
-      .withClientStack(clientStack)
-      .configured(RoutingFactory.DstPrefix(Path.Utf8(name)))
-  }
+  protected val defaultRouter = Http.router
+    .withPathStack(pathStack)
+    .withBoundStack(boundStack)
+    .withClientStack(clientStack)
+    .configured(RoutingFactory.DstPrefix(Path.Utf8(name)))
 
   protected val defaultServer = {
     val stk = Http.server.stack

--- a/linkerd/protocol/http/src/main/scala/io/buoyant/linkerd/protocol/HttpConfig.scala
+++ b/linkerd/protocol/http/src/main/scala/io/buoyant/linkerd/protocol/HttpConfig.scala
@@ -3,6 +3,7 @@ package protocol
 
 import com.fasterxml.jackson.annotation.JsonIgnore
 import com.twitter.finagle.{Path, Stack}
+import com.twitter.finagle.buoyant.linkerd.DelayedRelease
 import com.twitter.finagle.client.StackClient
 import com.twitter.finagle.buoyant.linkerd.{Headers, HttpTraceInitializer}
 import com.twitter.finagle.service.Retries
@@ -18,6 +19,7 @@ class HttpInitializer extends ProtocolInitializer.Simple {
   protected val defaultRouter = {
     val pathStack = Http.router.pathStack
       .prepend(Headers.Dst.PathFilter.module)
+      .replace(StackClient.Role.prepFactory, DelayedRelease.module)
     val boundStack = Http.router.boundStack
       .prepend(Headers.Dst.BoundFilter.module)
     val clientStack = Http.router.clientStack

--- a/linkerd/protocol/http/src/main/scala/io/buoyant/linkerd/protocol/HttpConfig.scala
+++ b/linkerd/protocol/http/src/main/scala/io/buoyant/linkerd/protocol/HttpConfig.scala
@@ -16,22 +16,24 @@ class HttpInitializer extends ProtocolInitializer.Simple {
   protected type Req = com.twitter.finagle.http.Request
   protected type Rsp = com.twitter.finagle.http.Response
 
-  protected val pathStack = Http.router.pathStack
-    .prepend(Headers.Dst.PathFilter.module)
-    .replace(StackClient.Role.prepFactory, DelayedRelease.module)
-  protected val boundStack = Http.router.boundStack
-    .prepend(Headers.Dst.BoundFilter.module)
-  protected val clientStack = Http.router.clientStack
-    .prepend(http.AccessLogger.module)
-    .replace(HttpTraceInitializer.role, HttpTraceInitializer.clientModule)
-    .insertAfter(Retries.Role, http.StatusCodeStatsFilter.module)
-    .insertAfter(StackClient.Role.prepConn, Headers.Ctx.clientModule)
+  protected val defaultRouter = {
+    val pathStack = Http.router.pathStack
+      .prepend(Headers.Dst.PathFilter.module)
+      .replace(StackClient.Role.prepFactory, DelayedRelease.module)
+    val boundStack = Http.router.boundStack
+      .prepend(Headers.Dst.BoundFilter.module)
+    val clientStack = Http.router.clientStack
+      .prepend(http.AccessLogger.module)
+      .replace(HttpTraceInitializer.role, HttpTraceInitializer.clientModule)
+      .insertAfter(Retries.Role, http.StatusCodeStatsFilter.module)
+      .insertAfter(StackClient.Role.prepConn, Headers.Ctx.clientModule)
 
-  protected val defaultRouter = Http.router
-    .withPathStack(pathStack)
-    .withBoundStack(boundStack)
-    .withClientStack(clientStack)
-    .configured(RoutingFactory.DstPrefix(Path.Utf8(name)))
+    Http.router
+      .withPathStack(pathStack)
+      .withBoundStack(boundStack)
+      .withClientStack(clientStack)
+      .configured(RoutingFactory.DstPrefix(Path.Utf8(name)))
+  }
 
   protected val defaultServer = {
     val stk = Http.server.stack

--- a/linkerd/protocol/http/src/test/scala/io/buoyant/linkerd/protocol/HttpInitializerTest.scala
+++ b/linkerd/protocol/http/src/test/scala/io/buoyant/linkerd/protocol/HttpInitializerTest.scala
@@ -1,0 +1,76 @@
+package io.buoyant.linkerd.protocol
+
+import com.twitter.finagle.{Service, ServiceFactory, Stack}
+import com.twitter.finagle.http.{Request, Response, Status, Version}
+import com.twitter.finagle.stack.nilStack
+import com.twitter.io.Reader
+import com.twitter.util.{Future, Promise, Time}
+import io.buoyant.test.Awaits
+import org.scalatest.FunSuite
+import org.scalatest.concurrent.Eventually
+import scala.language.reflectiveCalls
+
+class HttpInitializerTest extends FunSuite with Awaits with Eventually {
+
+  test("path stack: services are not closed until streams are complete") {
+    // Build a path stack that is controllable with promises (for only
+    // one request).
+    val serviceP, responseP, bodyP, respondingP, closedP = Promise[Unit]
+    val http = new HttpInitializer {
+      val svc = new Service[Request, Response] {
+        def apply(req: Request) = {
+          val rw = Reader.writable()
+          val rsp = Response(req.version, Status.Ok, rw)
+          val _ = bodyP.before(rw.close())
+          respondingP.setDone()
+          responseP.before(Future.value(rsp))
+        }
+
+        override def close(d: Time) = {
+          closedP.setDone()
+          Future.Unit
+        }
+      }
+      val sf = ServiceFactory { () => serviceP.before(Future.value(svc)) }
+
+      def make(params: Stack.Params = Stack.Params.empty) =
+        (pathStack ++ Stack.Leaf(Stack.Role("leaf"), sf)).make(params)
+    }
+
+    // The factory is returned immediately because it is wrapped in a
+    // FactoryToService.
+    val factory = http.make()
+    val svcf = factory()
+    assert(svcf.isDefined)
+    val svc = await(svcf)
+
+    // When a request is processed, first the service must be acquired
+    // from the service factroy, and then the response must be
+    // returned from the service.
+    val rspf = svc(Request())
+    assert(!rspf.isDefined)
+    assert(!respondingP.isDefined)
+
+    serviceP.setDone()
+    eventually { assert(respondingP.isDefined) }
+    assert(!rspf.isDefined)
+
+    responseP.setDone()
+    eventually { assert(rspf.isDefined) }
+
+    // Once the response is returned, FactoryToService tries to close
+    // the service factory. Ensure that the service is not closed
+    // until the response body is completely sent.
+    val rsp = await(rspf)
+    assert(rsp.isChunked)
+    assert(!closedP.isDefined)
+
+    // When the response body is written, it must be fully read from
+    // response before the service will be closed.
+    bodyP.setDone()
+    assert(!closedP.isDefined)
+
+    assert(await(rsp.reader.read(1)) == None)
+    eventually { assert(closedP.isDefined) }
+  }
+}

--- a/router/core/src/main/scala/io/buoyant/router/Router.scala
+++ b/router/core/src/main/scala/io/buoyant/router/Router.scala
@@ -313,6 +313,7 @@ object StackRouter {
      */
     val stk = new StackBuilder[ServiceFactory[Req, Rsp]](stack.nilStack)
     stk.push(failureRecording)
+    stk.push(StackClient.Role.prepFactory, identity[ServiceFactory[Req, Rsp]](_))
     stk.push(factoryToService)
     stk.push(ClassifiedRetries.module)
     stk.push(StatsFilter.module)


### PR DESCRIPTION
With the introduction of retries, a subtle bug was introduced to HTTP session management. When a server responded with `Transfer-encoding: chunked` and `Connection: close`, connections could be incorrectly returned to the connection pool.

By applying Finagle's DelayedReleaseService after FactoryToService, connections are not relinquished to the connection pools until the response stream completes.

Fixes #482.
More details at twitter/finagle#517.