### PR TITLE
Make config initializers abstract classes for better java compat

### DIFF
--- a/linkerd/core/src/main/scala/io/buoyant/linkerd/IdentifierInitializer.scala
+++ b/linkerd/core/src/main/scala/io/buoyant/linkerd/IdentifierInitializer.scala
@@ -2,4 +2,4 @@ package io.buoyant.linkerd
 
 import io.buoyant.config.ConfigInitializer
 
-trait IdentifierInitializer extends ConfigInitializer
+abstract class IdentifierInitializer extends ConfigInitializer

--- a/linkerd/core/src/main/scala/io/buoyant/linkerd/ProtocolInitializer.scala
+++ b/linkerd/core/src/main/scala/io/buoyant/linkerd/ProtocolInitializer.scala
@@ -18,7 +18,7 @@ import java.net.InetSocketAddress
  * configuration parameters.
  *
  */
-trait ProtocolInitializer extends ConfigInitializer {
+abstract class ProtocolInitializer extends ConfigInitializer {
   import ProtocolInitializer._
 
   /** The protocol name, as read from configuration. */

--- a/linkerd/core/src/main/scala/io/buoyant/linkerd/ResponseClassifierInitializer.scala
+++ b/linkerd/core/src/main/scala/io/buoyant/linkerd/ResponseClassifierInitializer.scala
@@ -4,7 +4,7 @@ import com.fasterxml.jackson.annotation.{JsonIgnore, JsonTypeInfo}
 import com.twitter.finagle.service.ResponseClassifier
 import io.buoyant.config.ConfigInitializer
 
-trait ResponseClassifierInitializer extends ConfigInitializer
+abstract class ResponseClassifierInitializer extends ConfigInitializer
 
 @JsonTypeInfo(
   use = JsonTypeInfo.Id.NAME,

--- a/linkerd/core/src/main/scala/io/buoyant/linkerd/TlsClientInitializer.scala
+++ b/linkerd/core/src/main/scala/io/buoyant/linkerd/TlsClientInitializer.scala
@@ -10,7 +10,7 @@ import io.buoyant.config.ConfigInitializer
  * Implementers may read params from the config file and must produce a
  * TlsClientPrep module which will control how this router makes TLS requests.
  */
-trait TlsClientInitializer extends ConfigInitializer
+abstract class TlsClientInitializer extends ConfigInitializer
 
 @JsonTypeInfo(use = JsonTypeInfo.Id.NAME, include = JsonTypeInfo.As.PROPERTY, property = "kind")
 trait TlsClientConfig {

--- a/namer/core/src/main/scala/io/buoyant/namer/InterpreterInitializer.scala
+++ b/namer/core/src/main/scala/io/buoyant/namer/InterpreterInitializer.scala
@@ -13,4 +13,4 @@ trait InterpreterConfig {
   def newInterpreter(params: Stack.Params): NameInterpreter
 }
 
-trait InterpreterInitializer extends ConfigInitializer
+abstract class InterpreterInitializer extends ConfigInitializer

--- a/namer/core/src/main/scala/io/buoyant/namer/NamerInitializer.scala
+++ b/namer/core/src/main/scala/io/buoyant/namer/NamerInitializer.scala
@@ -56,4 +56,4 @@ object NamerConfig {
   val hash = Path.Utf8("#")
 }
 
-trait NamerInitializer extends ConfigInitializer
+abstract class NamerInitializer extends ConfigInitializer

--- a/namerd/core/src/main/scala/io/buoyant/namerd/DtabStoreInitializer.scala
+++ b/namerd/core/src/main/scala/io/buoyant/namerd/DtabStoreInitializer.scala
@@ -5,7 +5,7 @@ import io.buoyant.config.ConfigInitializer
 import io.buoyant.config.types.Port
 import java.net.{InetAddress, InetSocketAddress}
 
-trait DtabStoreInitializer extends ConfigInitializer
+abstract class DtabStoreInitializer extends ConfigInitializer
 
 @JsonTypeInfo(use = JsonTypeInfo.Id.NAME, include = JsonTypeInfo.As.PROPERTY, property = "kind")
 trait DtabStoreConfig {

--- a/namerd/core/src/main/scala/io/buoyant/namerd/InterfaceConfig.scala
+++ b/namerd/core/src/main/scala/io/buoyant/namerd/InterfaceConfig.scala
@@ -27,4 +27,4 @@ trait InterfaceConfig {
   def mk(store: DtabStore, namers: Map[Path, Namer], stats: StatsReceiver): Servable
 }
 
-trait InterfaceInitializer extends ConfigInitializer
+abstract class InterfaceInitializer extends ConfigInitializer

--- a/namerd/core/src/main/scala/io/buoyant/namerd/InterpreterInterfaceConfig.scala
+++ b/namerd/core/src/main/scala/io/buoyant/namerd/InterpreterInterfaceConfig.scala
@@ -29,4 +29,4 @@ trait InterpreterInterfaceConfig extends InterfaceConfig {
     versioned.map(_.dtab).getOrElse(Dtab.empty)
 }
 
-trait InterpreterInterfaceInitializer extends ConfigInitializer
+abstract class InterpreterInterfaceInitializer extends ConfigInitializer


### PR DESCRIPTION
To implement a plugin, you need to extend the appropriate initialize class.  Extending traits in java is difficult so we make these abstract classes instead to make plugin development in java easier.