### PR TITLE
Configure server-side timeouts

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -11,6 +11,9 @@
     specified by users.
   * `l5d-dst-*` no longer set on responses
 * Fix graceful connection teardown on streaming HTTP responses #482.
+* linkerd routers' `timeoutMs` configuration now applies on the
+  server-side, so that the timeout acts as a global timeout rather
+  than an individual request timeout.
 
 ## 0.6.0
 


### PR DESCRIPTION
Router timeouts are only applied in the client stack, which is below retries, etc. This means that retries could persist forever, since they would never exceed a global timeout.

To fix this, the server is now configured with the router's timeout value, to impose a global timeout requirement.

In the future, it may make sense to admit client and server-specific timeouts.