### PR TITLE
Push ClassifiedTracing filter further down the client stack

### DIFF
--- a/router/core/src/main/scala/io/buoyant/router/Router.scala
+++ b/router/core/src/main/scala/io/buoyant/router/Router.scala
@@ -276,17 +276,16 @@ object StackRouter {
   object Client {
 
     /**
-     * Install ClassifiedTracing to mark each request-response's
-     * classification (success, failure, or retryable), after the
-     * TraceInitializerFilter (note, TraceInitializerFilter's role
-     * is private[finagle], so instead it's hardcoded here).
+     * Install the ClassifiedTracing filter immediately above any
+     * protocol-specific annotating tracing filters, to provide response
+     * classification annotations (success, failure, or retryable).
      *
      * Install the TlsClientPrep module below the endpoint stack so that it
      * may avail itself of any and all params to set TLS params.
      */
     def mkStack[Req, Rsp](orig: Stack[ServiceFactory[Req, Rsp]]): Stack[ServiceFactory[Req, Rsp]] =
       (orig ++ (TlsClientPrep.nop[Req, Rsp] +: stack.nilStack))
-        .insertAfter(Stack.Role("TraceInitializerFilter"), ClassifiedTracing.module[Req, Rsp])
+        .insertBefore(StackClient.Role.protoTracing, ClassifiedTracing.module[Req, Rsp])
   }
 
   def newPathStack[Req, Rsp]: Stack[ServiceFactory[Req, Rsp]] = {


### PR DESCRIPTION
In #478 I moved the ClassifiedTracing filter below the TraceInitializerFilter in the client stack, so that classification annotations would happen after we set the span id for client request spans.  This put the ClassifiedTracing filter between the TraceInitializerFilter and the ClientTracingFilter, but we actually need to install it below the ClientTracingFilter, as advised by this comment in the Finagle codebase:

https://github.com/twitter/finagle/blob/develop/finagle-core/src/main/scala/com/twitter/finagle/client/StackClient.scala#L334

The ClientTracingFilter sets the ClientRecv annotation, at which point finagle-zipkin considers the trace to be complete and flushes the span, so no other annotating filters should be above it in the stack.  In this branch I'm moving ClassifiedTracing to immediately before the ProtoTracing filter, which seems like the right place to put it.

For my own reference, the client stack now looks something like: ... => TraceInitializerFilter => ClientTracingFilter => ProcessFailure => ClassifiedTracing => ProtoTracing => ...