### PR TITLE
Support client- and server-timeout configuration

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -14,6 +14,10 @@
 * linkerd routers' `timeoutMs` configuration now applies on the
   server-side, so that the timeout acts as a global timeout rather
   than an individual request timeout.
+  * Added server `timeoutMs` configuration, which controls global
+    timeout.
+  * Added client `timeoutMs` configuration, which controls individual
+    request timeout.
 
 ## 0.6.0
 

--- a/linkerd/core/src/test/scala/io/buoyant/linkerd/RouterTest.scala
+++ b/linkerd/core/src/test/scala/io/buoyant/linkerd/RouterTest.scala
@@ -1,9 +1,10 @@
 package io.buoyant.linkerd
 
 import com.twitter.conversions.time._
-import com.twitter.finagle.{Dtab, Stack}
+import com.twitter.finagle.{Dtab, Service, ServiceFactory, Stack, Stackable}
 import com.twitter.finagle.buoyant.DstBindingFactory
 import com.twitter.finagle.service.TimeoutFilter
+import com.twitter.util.Duration
 import io.buoyant.config.Parser
 import io.buoyant.namer.{ConfiguredNamersInterpreter, InterpreterInitializer, TestInterpreterInitializer, TestInterpreter}
 import io.buoyant.router.RoutingFactory
@@ -32,12 +33,12 @@ class RouterTest extends FunSuite with Exceptions {
   }
 
   test("with label") {
-    val yaml = """
-protocol: plain
-label: yoghurt
-servers:
-- port: 1234
-"""
+    val yaml =
+      """|protocol: plain
+         |label: yoghurt
+         |servers:
+         |- port: 1234
+         |""".stripMargin
     val router = parse(yaml)
     assert(router.protocol == TestProtocol.Plain)
     assert(router.label == "yoghurt")
@@ -49,60 +50,113 @@ servers:
     assert(interpreter.isInstanceOf[ConfiguredNamersInterpreter])
   }
 
-  test("with timeout") {
+  test("with timeouts") {
     val yaml =
       """|protocol: plain
          |timeoutMs: 1234
+         |client:
+         |  timeoutMs: 2345
          |servers:
-         |- port: 4321
+         |- port: 8888
+         |  timeoutMs: 3456
          |""".stripMargin
     val router = parse(yaml)
+
     assert(router.servers.size == 1)
-    assert(router.servers.head.params[TimeoutFilter.Param] ==
-      TimeoutFilter.Param(1234.millis))
-    assert(router.params[TimeoutFilter.Param] ==
-      TimeoutFilter.Param(1234.millis))
+    val server = router.servers.head
+
+    assert(router.params[Router.RouterTimeout] == Router.RouterTimeout(1234.millis))
+    assert(router.params[Router.ClientTimeout] == Router.ClientTimeout(2345.millis))
+    assert(server.params[Router.ServerTimeout] == Router.ServerTimeout(3456.millis))
+
+    assert(Router.serverParams(router, server)[Router.RouterTimeout] ==
+      Router.RouterTimeout(1234.millis))
+  }
+
+  private val timeoutStack = {
+    val leaf: Stackable[Duration] =
+      new Stack.Module1[TimeoutFilter.Param, Duration] {
+        val role = Stack.Role("leaf")
+        val description = "checks timeouts"
+        def make(_timeout: TimeoutFilter.Param, _next: Duration): Duration = _timeout.timeout
+      }
+    leaf +: Stack.Leaf(Stack.Role("ep"), Duration.Top)
+  }
+
+  private val clientStack = Router.ClientTimeout.module[Duration] +: timeoutStack
+  private val serverStack = Router.ServerTimeout.module[Duration] +: timeoutStack
+
+  test("ClientTimeout.module") {
+    val params = Stack.Params.empty +
+      Router.ClientTimeout(1234.millis)
+    assert(clientStack.make(params) == 1234.millis)
+  }
+
+  test("ClientTimeout.module: lesser of router and client timeouts") {
+    val params = Stack.Params.empty +
+      Router.ClientTimeout(234.millis) +
+      Router.RouterTimeout(123.millis)
+    assert(clientStack.make(params) == 123.millis)
+  }
+
+  test("ServerTimeout.module") {
+    val params = Stack.Params.empty +
+      Router.ServerTimeout(1234.millis)
+    assert(serverStack.make(params) == 1234.millis)
+  }
+
+  test("ServerTimeout.module: use router timeout if server timeout is not specified") {
+    val params = Stack.Params.empty +
+      Router.RouterTimeout(4321.millis)
+    assert(serverStack.make(params) == 4321.millis)
+  }
+
+  test("ServerTimeout.module: do not use router timeout if server timeout is specified") {
+    val params = Stack.Params.empty +
+      Router.RouterTimeout(4321.millis) +
+      Router.ServerTimeout(1234.millis)
+    assert(serverStack.make(params) == 1234.millis)
   }
 
   test("loopback & protocol-specific default port used when no ports specified") {
-    val yaml = """
-protocol: plain
-label: yoghurt
-servers:
-  - {}
-"""
+    val yaml =
+      """|protocol: plain
+         |label: yoghurt
+         |servers:
+         |- {}
+         |""".stripMargin
     val router = parse(yaml)
     assert(router.servers.head.ip.isLoopbackAddress)
     assert(router.servers.head.port == 13)
   }
 
   test("no protocol") {
-    val yaml = """
-label: yoghurt
-servers:
-- port: 1234
-"""
+    val yaml =
+      """|label: yoghurt
+         |servers:
+         |- port: 1234
+         |""".stripMargin
     assertThrows[com.fasterxml.jackson.databind.JsonMappingException] { parse(yaml) }
   }
 
   test("unknown protocol") {
-    val yaml = """
-protocol: boring
-label: hummus
-servers:
-- port: 1234
-"""
+    val yaml =
+      """|protocol: boring
+         |label: hummus
+         |servers:
+         |- port: 1234
+         |""".stripMargin
     assertThrows[com.fasterxml.jackson.databind.JsonMappingException] { parse(yaml) }
   }
 
   test("router overrides global params") {
-    val yaml = """
-protocol: plain
-label: yoghurt
-baseDtab: /foo => /bah
-servers:
-- port: 1234
-"""
+    val yaml =
+      """|protocol: plain
+         |label: yoghurt
+         |baseDtab: /foo => /bah
+         |servers:
+         |- port: 1234
+         |""".stripMargin
     val defaultDtab = RoutingFactory.BaseDtab(() => Dtab.read("/foo => /bar"))
     val router = parse(yaml, Stack.Params.empty + defaultDtab)
     val RoutingFactory.BaseDtab(dtab) = router.params[RoutingFactory.BaseDtab]
@@ -111,10 +165,10 @@ servers:
 
   test("name interpreter specification") {
     val yaml =
-      """protocol: plain
-        |interpreter:
-        |  kind: test
-      """.stripMargin
+      """|protocol: plain
+         |interpreter:
+         |  kind: test
+         |""".stripMargin
     val router = parse(yaml, Stack.Params.empty)
     val DstBindingFactory.Namer(interpreter) = router.params[DstBindingFactory.Namer]
     assert(interpreter.isInstanceOf[TestInterpreter])

--- a/linkerd/docs/config.md
+++ b/linkerd/docs/config.md
@@ -148,7 +148,9 @@ Each router must be configured as an object with the following params:
   (default is protocol dependent)
 * *failFast* -- If `true`, connection failures are punished more aggressively.
   Should not be used with small destination pools. (default: false)
-* *timeoutMs* -- Per-request timeout in milliseconds. (default: no timeout)
+* *timeoutMs* -- Base timeout in milliseconds. If not overridden in
+  [_client_](#client_timeout) or [_server_](#server_timeout)
+  configurations, this base timeout is used. (default: no timeout)
 * *bindingTimeoutMs* -- Optional.  The maximum amount of time in milliseconds to
   spend binding a path.  (default: 10 seconds)
 * *bindingCache* -- Optional.  Configure the size of binding cache.  It must be
@@ -172,6 +174,9 @@ local IPv4 interfaces.
   * *keyPath* -- File path to the TLS key file
 * *maxConcurrentRequests* -- Optional.  The maximum number of concurrent
 requests the server will accept.  (default: unlimited)
+<a name="server_timeout"></a>
+* *timeoutMs* -- Global timeout for requests processed by this server,
+  encompassing all retries.
 
 <a name="basic-client-params"></a>
 ### Basic client parameters
@@ -203,6 +208,8 @@ maintain to each destination host.  It must be an object containing keys:
 <a name="retries"></a>
 * *retries* -- Optional. A [retry policy](retries.md) for all clients created by
   this router.
+<a name="client_timeout"></a>
+* *timeoutMs* -- Individual request timeout, not including retries etc.
 
 <a name="namers"></a>
 ## Service discovery and naming


### PR DESCRIPTION
Add `timeoutMs` configurations to the client and server sections of router
configs.

The server timeout configures an explicit global timeout for all requests
received on the given server. If not specified, the base router timeout may
be used.

The client timeout configures individual request timeouts. This timeout is
applied between retries, whereas the server timeout applies across retries. If
the base router timeout is specified, the lesser timeout value is applied.

This change introduces three new stack parameters: Router.RouterTimeout,
Router.ServerTimeout, nad Router.ClientTimeout. These timeouts are converted to
a TimeoutFilter.Param by stack modules, Router.ServerTimeout.module and
Router.ClientTimeout.module.

Furthermore, this changes the manner in which servers are configured by
linkerd.  Instead of updating server params as router configurations are
updated, we simply compute server configuration during router initialization.