### PR TITLE
Make the logging page look more like the dashboard page

### DIFF
--- a/admin/src/main/resources/io/buoyant/admin/css/logger-overrides.css
+++ b/admin/src/main/resources/io/buoyant/admin/css/logger-overrides.css
@@ -1,0 +1,53 @@
+/*
+* Overrides the twitter server logging page styles
+*/
+
+#navbar {
+  float: left;
+  padding-left: 0px;
+  padding-right: 0px;
+}
+
+#navbar ul.nav>li {
+  padding-left: 0px;
+  padding-right: 0px;
+}
+
+#navbar ul.nav>li>a {
+  font-size: 18px;
+  font-weight: 300;
+  line-height: 1.1;
+}
+
+#navbar ul.nav {
+  margin-top: -12px;
+}
+
+#contents {
+  margin-left: 0px;
+  padding-top: 0px;
+}
+
+.table-striped>tbody>tr:nth-child(odd)>td, .table-striped>tbody>tr:nth-child(odd)>th {
+  background-color: #161963;
+}
+
+.table-striped>tbody>tr>td {
+  border-top: 2px solid gray;
+}
+
+.table-striped>thead>tr {
+  border-bottom: 3px solid gray;
+}
+
+.table>thead>tr>th {
+  border-bottom: none;
+}
+
+.table h5 {
+  color: white;
+}
+
+table>caption{
+  color: red;
+}

--- a/admin/src/main/resources/io/buoyant/admin/js/logger-overrides.js
+++ b/admin/src/main/resources/io/buoyant/admin/js/logger-overrides.js
@@ -1,0 +1,26 @@
+$(function() {
+  $("nav#sidebar").remove();
+  $("#toggle").remove();
+
+  $("td>div.btn-group").addClass("pull-right");
+  $("thead>tr>th:eq(1)").addClass("pull-right");
+
+  var navbar = '<nav class="navbar navbar-inverse">' +
+  '      <div class="navbar-container">' +
+  '        <div class="navbar-header">' +
+  '          <a class="navbar-brand-img" href="/">' +
+  '            <img alt="Logo" src="/files/images/linkerd-horizontal-white-transbg-vectorized.svg">' +
+  '          </a>' +
+  '        </div>' +
+  '        <div id="navbar" class="collapse navbar-collapse">' +
+  '          <ul class="nav navbar-nav">' +
+  '            <li><a href="/delegator">dtab</a></li>' +
+  '            <li><a href="/admin/logging">logging</a></li>' +
+  '            <li><a href="https://linkerd.io/help/">help</a></li>' +
+  '          </ul>' +
+  '        </div>' +
+  '      </div>' +
+  '    </nav>"';
+
+  $(navbar).prependTo($("body"));
+});

--- a/admin/src/main/scala/io/buoyant/admin/Admin.scala
+++ b/admin/src/main/scala/io/buoyant/admin/Admin.scala
@@ -29,7 +29,7 @@ class Admin(app: TApp) {
     "/admin/ping" -> new ReplyHandler("pong"),
     "/admin/shutdown" -> new ShutdownHandler(app),
     "/admin/tracing" -> new TracingHandler,
-    "/admin/logging" -> new LoggingHandler,
+    "/admin/logging" -> (new StyleOverrideFilter andThen new LoggingHandler),
     "/admin/metrics" -> new MetricsQueryHandler,
     "/admin/metrics/prometheus" -> new PrometheusStatsHandler(MetricsStatsReceiver.defaultRegistry),
     Path.Clients -> new ClientRegistryHandler(Path.Clients),

--- a/admin/src/main/scala/io/buoyant/admin/StyleOverrideFilter.scala
+++ b/admin/src/main/scala/io/buoyant/admin/StyleOverrideFilter.scala
@@ -1,0 +1,24 @@
+package io.buoyant.admin
+
+import com.twitter.finagle.{Service, SimpleFilter}
+import com.twitter.finagle.http.{Request, Response}
+import com.twitter.util.{Await, Future}
+
+class StyleOverrideFilter extends SimpleFilter[Request, Response] {
+  // inject some js and css into the Logging page so we can style it ourselves
+
+  val stylesAndJavascripts =
+    s"""
+    <link type="text/css" href="/files/css/logger-overrides.css" rel="stylesheet"/>
+    <link type="text/css" href="/files/css/dashboard.css" rel="stylesheet"/>
+    <link type="text/css" href="/files/css/dashboard-shared.css" rel="stylesheet"/>
+    <script src="/files/js/logger-overrides.js"></script>
+      """
+
+  def apply(req: Request, svc: Service[Request, Response]) = {
+    svc(req).map { response =>
+      response.setContentString(response.contentString + stylesAndJavascripts)
+      response
+    }
+  }
+}


### PR DESCRIPTION
`parent: rmars/style-followup`

Follow up to #499 and #497

I've added our own js/css by creating a filter that adds things to the response body. Let me know your opinions on this.

Also colors/styles can be tweaked, opinions welcome.

![screen shot 2016-06-22 at 4 33 31 pm](https://cloud.githubusercontent.com/assets/549258/16287391/7ecf7d5e-3897-11e6-8e38-12aa2af1c146.png)
