### PR TITLE
Track status codes on each linkerd http server

### DIFF
--- a/linkerd/protocol/http/src/main/scala/io/buoyant/linkerd/protocol/HttpConfig.scala
+++ b/linkerd/protocol/http/src/main/scala/io/buoyant/linkerd/protocol/HttpConfig.scala
@@ -41,6 +41,7 @@ class HttpInitializer extends ProtocolInitializer.Simple {
       .replace(HttpTraceInitializer.role, HttpTraceInitializer.serverModule)
       .prepend(Headers.Ctx.serverModule)
       .prepend(http.ErrorResponder.module)
+      .prepend(http.StatusCodeStatsFilter.module)
     Http.server.withStack(stk)
   }
 


### PR DESCRIPTION
We track status codes on clients, but we do not track server side statuses.

Fixes #503.