### PR TITLE
Remove leading spaces from code tag code (minor)

### DIFF
--- a/linkerd/admin/src/main/scala/io/buoyant/linkerd/admin/HelpPageHandler.scala
+++ b/linkerd/admin/src/main/scala/io/buoyant/linkerd/admin/HelpPageHandler.scala
@@ -43,10 +43,10 @@ object HelpPageHandler {
             linkerd is doing. You can accomplish this by running the following script:
           </p>
           <pre><code class="language-bash">#!/bin/bash
-      while true; do
-        curl -s http://localhost:9990/admin/metrics.json &gt; l5d_metrics_`date -u +'%s'`.json
-        sleep 60;
-      done</code></pre>
+while true; do
+  curl -s http://localhost:9990/admin/metrics.json &gt; l5d_metrics_`date -u +'%s'`.json
+  sleep 60;
+done</code></pre>
           <p>This script will produce one file a minute.</p>
           <p>If these metrics are insufficient, we may also ask you to capture some network traffic. One way to do this is with tcpdump:</p>
           <pre><code class="language-bash">tcpdump -s 0 -w linkerd.pcap 'tcp port 4140 or tcp port 3591'`</code></pre>


### PR DESCRIPTION
I forgot when transferring the html that the code tag leaves the leading spaces in. Small fix.

![screen shot 2016-06-28 at 11 55 21 am](https://cloud.githubusercontent.com/assets/549258/16428577/60e9f79e-3d27-11e6-8bc8-de4f6f94355b.png)
![screen shot 2016-06-28 at 11 55 35 am](https://cloud.githubusercontent.com/assets/549258/16428581/61d8795a-3d27-11e6-95eb-dde21d731509.png)
