### PR TITLE
Disable failure accrual for zipkin client

### DIFF
--- a/linkerd/tracer/zipkin/src/main/scala/io/buoyant/linkerd/tracer/ZipkinTracerInitializer.scala
+++ b/linkerd/tracer/zipkin/src/main/scala/io/buoyant/linkerd/tracer/ZipkinTracerInitializer.scala
@@ -38,8 +38,10 @@ case class ZipkinConfig(
         // using an arbitrary, but bounded number of waiters to avoid memory leaks
         .hostConnectionMaxWaiters(250)
         // somewhat arbitrary, but bounded timeouts
-        .timeout(1.second)
+        .timeout(100.millis)
         .daemon(true)
+        .noFailureAccrual
+        .failFast(false)
         .build()
 
       val client = new Scribe.FinagledClient(

--- a/linkerd/tracer/zipkin/src/main/scala/io/buoyant/linkerd/tracer/ZipkinTracerInitializer.scala
+++ b/linkerd/tracer/zipkin/src/main/scala/io/buoyant/linkerd/tracer/ZipkinTracerInitializer.scala
@@ -1,9 +1,17 @@
 package io.buoyant.linkerd.tracer
 
 import com.fasterxml.jackson.annotation.JsonIgnore
-import com.twitter.finagle.tracing.{Record, TraceId, Tracer}
-import com.twitter.finagle.zipkin.thrift.{Sampler, ZipkinTracer}
+import com.twitter.conversions.time._
+import com.twitter.finagle.{Service, SimpleFilter}
+import com.twitter.finagle.builder.ClientBuilder
+import com.twitter.finagle.stats.{ClientStatsReceiver, NullStatsReceiver}
+import com.twitter.finagle.thrift.{Protocols, ThriftClientFramedCodec}
+import com.twitter.finagle.tracing.{Record, Trace, TraceId, Tracer}
+import com.twitter.finagle.util.DefaultTimer
+import com.twitter.finagle.zipkin.thrift.{RawZipkinTracer, Sampler, ZipkinTracer}
+import com.twitter.finagle.zipkin.thriftscala.Scribe
 import io.buoyant.linkerd.{TracerConfig, TracerInitializer}
+import java.net.InetSocketAddress
 
 class ZipkinTracerInitializer extends TracerInitializer {
   val configClass = classOf[ZipkinConfig]
@@ -20,15 +28,50 @@ case class ZipkinConfig(
 
   @JsonIgnore
   override def newTracer(): Tracer = new Tracer {
-    private[this] val underlying: Tracer =
-      ZipkinTracer.mk(
-        host = host.getOrElse("localhost"),
-        port = port.getOrElse(9410),
-        sampleRate = sampleRate.map(_.toFloat).getOrElse(Sampler.DefaultSampleRate)
+    private[this] val underlying: Tracer = {
+      val transport = ClientBuilder()
+        .name("zipkin-tracer")
+        .hosts(new InetSocketAddress(host.getOrElse("localhost"), port.getOrElse(9410)))
+        .codec(ThriftClientFramedCodec())
+        .reportTo(ClientStatsReceiver)
+        .hostConnectionLimit(5)
+        // using an arbitrary, but bounded number of waiters to avoid memory leaks
+        .hostConnectionMaxWaiters(250)
+        // somewhat arbitrary, but bounded timeouts
+        .timeout(1.second)
+        .daemon(true)
+        .build()
+
+      val client = new Scribe.FinagledClient(
+        new TracelessFilter andThen transport,
+        Protocols.binaryFactory()
       )
+
+      val rawTracer = RawZipkinTracer(
+        client,
+        NullStatsReceiver,
+        DefaultTimer.twitter
+      )
+      new ZipkinTracer(
+        rawTracer,
+        sampleRate.map(_.toFloat).getOrElse(Sampler.DefaultSampleRate)
+      )
+    }
 
     def sampleTrace(t: TraceId) = underlying.sampleTrace(t)
     def record(r: Record) = underlying.record(r)
   }
 }
 
+/**
+ * _Copied from Finagle's RawZipkinTracer.scala_
+ *
+ * Makes sure we don't trace the Scribe logging.
+ */
+private class TracelessFilter[Req, Rep] extends SimpleFilter[Req, Rep] {
+  def apply(request: Req, service: Service[Req, Rep]) = {
+    Trace.letClear {
+      service(request)
+    }
+  }
+}


### PR DESCRIPTION
fixes #510 

* disable failure accrual
* disable fail fast
* reduce timeout to 100ms

These changes allow linkerd to continue to saturate the zipkin client's connections, even when total sampled RPS is much higher than what can be sent.  
