### PR TITLE
Turn off decompression

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,3 +1,8 @@
+## x.x.x
+
+* Turn off HTTP decompression so that linkerd doesn't decompress and then
+  recompress bodies.
+
 ## 0.7.0
 
 * New default JVM settings scale up with traffic levels.

--- a/router/http/src/main/scala/io/buoyant/router/Http.scala
+++ b/router/http/src/main/scala/io/buoyant/router/Http.scala
@@ -73,6 +73,7 @@ object Http extends Router[Request, Response] with FinagleServer[Request, Respon
     val defaultParams: Stack.Params =
       StackServer.defaultParams +
         FinagleHttp.param.Streaming(true) +
+        FinagleHttp.param.Decompression(false) +
         ProtocolLibrary("http")
   }
 

--- a/router/http/src/main/scala/io/buoyant/router/Http.scala
+++ b/router/http/src/main/scala/io/buoyant/router/Http.scala
@@ -1,6 +1,5 @@
 package io.buoyant.router
 
-import com.twitter.finagle.Http.param.Decompression
 import com.twitter.finagle.client.StackClient
 import com.twitter.finagle.http.{Request, Response, TlsFilter}
 import com.twitter.finagle.param.ProtocolLibrary
@@ -38,8 +37,8 @@ object Http extends Router[Request, Response] with FinagleServer[Request, Respon
     val defaultParams: Stack.Params =
       StackRouter.defaultParams +
         FinagleHttp.param.Streaming(true) +
-        ProtocolLibrary("http") +
-        Decompression(false)
+        FinagleHttp.param.Decompression(false) +
+        ProtocolLibrary("http")
   }
 
   case class Router(

--- a/router/http/src/main/scala/io/buoyant/router/Http.scala
+++ b/router/http/src/main/scala/io/buoyant/router/Http.scala
@@ -1,12 +1,13 @@
 package io.buoyant.router
 
+import com.twitter.finagle.Http.param.Decompression
 import com.twitter.finagle.client.StackClient
 import com.twitter.finagle.http.{Request, Response, TlsFilter}
 import com.twitter.finagle.param.ProtocolLibrary
 import com.twitter.finagle.server.StackServer
 import com.twitter.finagle.{Http => FinagleHttp, Server => FinagleServer, http => fhttp, _}
 import io.buoyant.router.Http.param.HttpIdentifier
-import io.buoyant.router.http.{MethodAndHostIdentifier, ForwardedFilter, StripConnectionHeader}
+import io.buoyant.router.http.{ForwardedFilter, MethodAndHostIdentifier, StripConnectionHeader}
 import java.net.SocketAddress
 
 object Http extends Router[Request, Response] with FinagleServer[Request, Response] {
@@ -37,7 +38,8 @@ object Http extends Router[Request, Response] with FinagleServer[Request, Respon
     val defaultParams: Stack.Params =
       StackRouter.defaultParams +
         FinagleHttp.param.Streaming(true) +
-        ProtocolLibrary("http")
+        ProtocolLibrary("http") +
+        Decompression(false)
   }
 
   case class Router(


### PR DESCRIPTION
Fixes #514 

By turning off decompression on the client side, linkerd will no longer decompress compressed payload responses, instead passing the uncompressed payload along.  Profiling with Java Flight Recorder without this change, serving gzipped responses showed `JdkZlibEncoder.encode` and `InfCodes.inflate_fast` as Hot Methods.  With this change, those methods were absent.

I chose not to disable compression on the server side.  This means that if linkerd gets a request for compressed data but forwards to a service that serves an uncompressed response, linkerd will compress it.  This seems like a useful feature.

