### PR TITLE
Fix sbt command for `namerd-main`

### DIFF
--- a/namerd/README.md
+++ b/namerd/README.md
@@ -37,7 +37,7 @@ namerd can be run locally with the commands
 ```
 or
 ```
-./sbt 'namerd-main:run path/to/config.yml'
+./sbt 'namerd-main/run path/to/config.yml'
 ```
 
 ## Http Control Interface ##


### PR DESCRIPTION
The command should use a slash to indicate a task within a project.