### PR TITLE
Optional dtab query parameter for selected Namerd HTTP Control API endpoints

### DIFF
--- a/namerd/iface/control-http/src/main/scala/io/buoyant/namerd/iface/HttpControlService.scala
+++ b/namerd/iface/control-http/src/main/scala/io/buoyant/namerd/iface/HttpControlService.scala
@@ -160,7 +160,7 @@ class HttpControlService(storage: DtabStore, delegate: Ns => NameInterpreter, na
     case AddrUri(Some(ns), path) =>
       handleGetAddr(ns, path, req)
     case DelegateUri(Some(ns), path) =>
-      handleGetDelegate(ns, path)
+      handleGetDelegate(ns, path, req.getParam("dtab", ""))
     case DelegateUri(None, path) =>
       delegateApiHander(req)
     case _ if req.path == s"$apiPrefix/bound-names" && req.method == Method.Get =>
@@ -392,12 +392,12 @@ class HttpControlService(storage: DtabStore, delegate: Ns => NameInterpreter, na
     }
   }
 
-  private[this] def handleGetDelegate(ns: String, path: Path): Future[Response] = {
+  private[this] def handleGetDelegate(ns: String, path: Path, extraDtab: String): Future[Response] = {
     getDtab(ns).flatMap {
       case Some(dtab) =>
         delegate(ns) match {
           case delegator: Delegator =>
-            DelegateApiHandler.getDelegateRsp(dtab.dtab.show, path.show, delegator)
+            DelegateApiHandler.getDelegateRsp((dtab.dtab ++ Dtab.read(extraDtab)).show, path.show, delegator)
           case _ =>
             val rsp = Response(Status.NotImplemented)
             rsp.contentString = s"Name Interpreter for $ns cannot show delegations"

--- a/namerd/iface/control-http/src/test/scala/io/buoyant/namerd/iface/HttpControlServiceTest.scala
+++ b/namerd/iface/control-http/src/test/scala/io/buoyant/namerd/iface/HttpControlServiceTest.scala
@@ -432,4 +432,34 @@ class HttpControlServiceTest extends FunSuite with Awaits {
       |  }
       |}""".stripMargin.replaceAll("\\s", ""))
   }
+
+  test("delegate a path given a namespace and a dtab") {
+    val service = newService()
+    val resp = await(service(Request("/api/1/delegate/yeezus?path=/yeezy&dtab=/yeezy=>/bar")))
+    assert(resp.status == Status.Ok)
+    assert(resp.contentString == """
+      |{
+      |  "type":"alt",
+      |  "path":"/yeezy",
+      |  "dentry":null,
+      |  "alt":[
+      |    {
+      |      "type": "neg",
+      |      "path": "/bar",
+      |      "dentry":{
+      |        "prefix":"/yeezy",
+      |        "dst":"/bar"
+      |      }
+      |    },
+      |    {
+      |      "type": "neg",
+      |      "path": "/yeezus",
+      |      "dentry": {
+      |        "prefix": "/yeezy",
+      |        "dst":"/yeezus"
+      |      }
+      |    }
+      |  ]
+      |}""".stripMargin.replaceAll("\\s", ""))
+  }
 }

--- a/namerd/iface/control-http/src/test/scala/io/buoyant/namerd/iface/HttpControlServiceTest.scala
+++ b/namerd/iface/control-http/src/test/scala/io/buoyant/namerd/iface/HttpControlServiceTest.scala
@@ -285,6 +285,25 @@ class HttpControlServiceTest extends FunSuite with Awaits {
     assert(resp.contentString == bound + "\n")
   }
 
+  test("bind with an extra dtab") {
+    val ni = new NameInterpreter {
+      override def bind(dtab: Dtab, path: Path): Activity[NameTree[Bound]] = {
+        assert(dtab.show == "/foo=>/bar")
+        Activity.value(NameTree.Leaf(Name.Bound(Var(null), s"/io.l5d.namer${dtab.lookup(path).show}")))
+      }
+    }
+
+    def delegate(ns: Ns): NameInterpreter = {
+      assert(ns == "default")
+      ni
+    }
+    val service = new HttpControlService(NullDtabStore, delegate, Map.empty)
+
+    val resp = await(service(Request("/api/1/bind/default?path=/foo&dtab=/foo=>/bar")))
+    assert(resp.status == Status.Ok)
+    assert(resp.contentString == "/io.l5d.namer/bar\n")
+  }
+
   test("bind watch") {
     val (ni, witness) = interpreter
     def delegate(ns: Ns): NameInterpreter = {


### PR DESCRIPTION
For next Namerd HTTP Control API endpoints:
* `/bind/:ns`
* `/delegate/:ns`

added an optional dtab query parameter for that can be used to supply an extra delegation table that will be appended to the delegation table configured for the namespace.

Addresses #520, implemented according to decisions made in Slack during discussion with @adleong and @olix0r 