### PR TITLE
Fix incorrect dentry in simplified DelegateTrees

### DIFF
--- a/namer/core/src/test/scala/io/buoyant/namer/DelegateTreeTest.scala
+++ b/namer/core/src/test/scala/io/buoyant/namer/DelegateTreeTest.scala
@@ -1,0 +1,104 @@
+package io.buoyant.namer
+
+import com.twitter.finagle.{Dentry, Path}
+import io.buoyant.namer.DelegateTree._
+import org.scalatest.FunSuite
+
+class DelegateTreeTest extends FunSuite {
+
+  test("simplify collapses nodes with the same path") {
+
+    val orig =
+      Delegate(Path.read("/a"), Dentry.nop,
+        Delegate(Path.read("/b"), Dentry.read("/a => /b"),
+          Alt(Path.read("/b"), Dentry.read("/b => /c|/d"),
+            Leaf(Path.read("/c"), Dentry.read("/b => /c|/d"), Path.read("/c")),
+            Leaf(Path.read("/d"), Dentry.read("/b => /c|/d"), Path.read("/d"))
+          )
+        )
+      )
+
+    val simplified =
+      Delegate(Path.read("/a"), Dentry.nop,
+        Alt(Path.read("/b"), Dentry.read("/a => /b"),
+          Leaf(Path.read("/c"), Dentry.read("/b => /c|/d"), Path.read("/c")),
+          Leaf(Path.read("/d"), Dentry.read("/b => /c|/d"), Path.read("/d"))
+        )
+      )
+
+    assert(orig.simplified == simplified)
+  }
+
+  test("simplify converts single branch alts into delegates") {
+    val orig =
+      Delegate(Path.read("/a"), Dentry.nop,
+        Delegate(Path.read("/b"), Dentry.read("/a => /b"),
+          Alt(Path.read("/b"), Dentry.read("/b => /c"),
+            Leaf(Path.read("/c"), Dentry.read("/b => /c"), Path.read("/c"))
+          )
+        )
+      )
+
+    val simplified =
+      Delegate(Path.read("/a"), Dentry.nop,
+        Delegate(Path.read("/b"), Dentry.read("/a => /b"),
+          Leaf(Path.read("/c"), Dentry.read("/b => /c"), Path.read("/c"))
+        )
+      )
+
+    assert(orig.simplified == simplified)
+  }
+
+  test("simplify converts no branch alts into neg") {
+    val orig =
+      Delegate(Path.read("/a"), Dentry.nop,
+        Delegate(Path.read("/b"), Dentry.read("/a => /b"),
+          Alt(Path.read("/b"), Dentry.read("/b => ~"))
+        )
+      )
+
+    val simplified =
+      Delegate(Path.read("/a"), Dentry.nop,
+        Neg(Path.read("/b"), Dentry.read("/a => /b"))
+      )
+
+    assert(orig.simplified == simplified)
+  }
+
+  test("simplify converts single branch unions into delegates") {
+    val orig =
+      Delegate(Path.read("/a"), Dentry.nop,
+        Delegate(Path.read("/b"), Dentry.read("/a => /b"),
+          Union(Path.read("/b"), Dentry.read("/b => /c"),
+            Weighted(1.0, Leaf(Path.read("/c"), Dentry.read("/b => /c"), Path.read("/c")))
+          )
+        )
+      )
+
+    val simplified =
+      Delegate(Path.read("/a"), Dentry.nop,
+        Delegate(Path.read("/b"), Dentry.read("/a => /b"),
+          Leaf(Path.read("/c"), Dentry.read("/b => /c"), Path.read("/c"))
+        )
+      )
+
+    assert(orig.simplified == simplified)
+  }
+
+  test("simplify converts no branch unions into neg") {
+    val orig =
+      Delegate(Path.read("/a"), Dentry.nop,
+        Delegate(Path.read("/b"), Dentry.read("/a => /b"),
+          Union(Path.read("/b"), Dentry.read("/b => ~"))
+        )
+      )
+
+    val simplified =
+      Delegate(Path.read("/a"), Dentry.nop,
+        Neg(Path.read("/b"), Dentry.read("/a => /b"))
+      )
+
+    assert(orig.simplified == simplified)
+  }
+
+}


### PR DESCRIPTION
# Problem

In the delegator UI, the delegation before a union or alt shows the wrong dentry:

<img width="248" alt="screen shot 2016-07-07 at 12 56 55 pm" src="https://cloud.githubusercontent.com/assets/3979810/16668318/5404eeba-4445-11e6-9f9e-365298c09e01.png">

# Solution

When simplifying a delegate tree, use the parent dentry instead of the child dentry.

# Result

<img width="251" alt="screen shot 2016-07-07 at 1 16 14 pm" src="https://cloud.githubusercontent.com/assets/3979810/16668489/0d8300f2-4446-11e6-8ae7-6b4a37c49e51.png">

