### PR TITLE
Upgrade to finagle 6.35

### DIFF
--- a/linkerd/tracer/zipkin/src/main/scala/io/buoyant/linkerd/tracer/ZipkinTracerInitializer.scala
+++ b/linkerd/tracer/zipkin/src/main/scala/io/buoyant/linkerd/tracer/ZipkinTracerInitializer.scala
@@ -2,14 +2,15 @@ package io.buoyant.linkerd.tracer
 
 import com.fasterxml.jackson.annotation.JsonIgnore
 import com.twitter.conversions.time._
-import com.twitter.finagle.{Service, SimpleFilter}
 import com.twitter.finagle.builder.ClientBuilder
 import com.twitter.finagle.stats.{ClientStatsReceiver, NullStatsReceiver}
 import com.twitter.finagle.thrift.{Protocols, ThriftClientFramedCodec}
 import com.twitter.finagle.tracing.{Record, Trace, TraceId, Tracer}
 import com.twitter.finagle.util.DefaultTimer
-import com.twitter.finagle.zipkin.thrift.{RawZipkinTracer, Sampler, ZipkinTracer}
+import com.twitter.finagle.zipkin.core.Sampler
+import com.twitter.finagle.zipkin.thrift.{ScribeRawZipkinTracer, ZipkinTracer}
 import com.twitter.finagle.zipkin.thriftscala.Scribe
+import com.twitter.finagle.{Service, SimpleFilter}
 import io.buoyant.linkerd.{TracerConfig, TracerInitializer}
 import java.net.InetSocketAddress
 
@@ -52,7 +53,7 @@ case class ZipkinConfig(
         Protocols.binaryFactory()
       )
 
-      val rawTracer = RawZipkinTracer(
+      val rawTracer = ScribeRawZipkinTracer(
         client,
         NullStatsReceiver,
         DefaultTimer.twitter

--- a/namer/core/src/test/scala/io/buoyant/namer/DelegateTreeTest.scala
+++ b/namer/core/src/test/scala/io/buoyant/namer/DelegateTreeTest.scala
@@ -13,18 +13,13 @@ class DelegateTreeTest extends FunSuite {
         Delegate(Path.read("/b"), Dentry.read("/a => /b"),
           Alt(Path.read("/b"), Dentry.read("/b => /c|/d"),
             Leaf(Path.read("/c"), Dentry.read("/b => /c|/d"), Path.read("/c")),
-            Leaf(Path.read("/d"), Dentry.read("/b => /c|/d"), Path.read("/d"))
-          )
-        )
-      )
+            Leaf(Path.read("/d"), Dentry.read("/b => /c|/d"), Path.read("/d")))))
 
     val simplified =
       Delegate(Path.read("/a"), Dentry.nop,
         Alt(Path.read("/b"), Dentry.read("/a => /b"),
           Leaf(Path.read("/c"), Dentry.read("/b => /c|/d"), Path.read("/c")),
-          Leaf(Path.read("/d"), Dentry.read("/b => /c|/d"), Path.read("/d"))
-        )
-      )
+          Leaf(Path.read("/d"), Dentry.read("/b => /c|/d"), Path.read("/d"))))
 
     assert(orig.simplified == simplified)
   }
@@ -34,17 +29,12 @@ class DelegateTreeTest extends FunSuite {
       Delegate(Path.read("/a"), Dentry.nop,
         Delegate(Path.read("/b"), Dentry.read("/a => /b"),
           Alt(Path.read("/b"), Dentry.read("/b => /c"),
-            Leaf(Path.read("/c"), Dentry.read("/b => /c"), Path.read("/c"))
-          )
-        )
-      )
+            Leaf(Path.read("/c"), Dentry.read("/b => /c"), Path.read("/c")))))
 
     val simplified =
       Delegate(Path.read("/a"), Dentry.nop,
         Delegate(Path.read("/b"), Dentry.read("/a => /b"),
-          Leaf(Path.read("/c"), Dentry.read("/b => /c"), Path.read("/c"))
-        )
-      )
+          Leaf(Path.read("/c"), Dentry.read("/b => /c"), Path.read("/c"))))
 
     assert(orig.simplified == simplified)
   }
@@ -53,14 +43,11 @@ class DelegateTreeTest extends FunSuite {
     val orig =
       Delegate(Path.read("/a"), Dentry.nop,
         Delegate(Path.read("/b"), Dentry.read("/a => /b"),
-          Alt(Path.read("/b"), Dentry.read("/b => ~"))
-        )
-      )
+          Alt(Path.read("/b"), Dentry.read("/b => ~"))))
 
     val simplified =
       Delegate(Path.read("/a"), Dentry.nop,
-        Neg(Path.read("/b"), Dentry.read("/a => /b"))
-      )
+        Neg(Path.read("/b"), Dentry.read("/a => /b")))
 
     assert(orig.simplified == simplified)
   }
@@ -70,17 +57,12 @@ class DelegateTreeTest extends FunSuite {
       Delegate(Path.read("/a"), Dentry.nop,
         Delegate(Path.read("/b"), Dentry.read("/a => /b"),
           Union(Path.read("/b"), Dentry.read("/b => /c"),
-            Weighted(1.0, Leaf(Path.read("/c"), Dentry.read("/b => /c"), Path.read("/c")))
-          )
-        )
-      )
+            Weighted(1.0, Leaf(Path.read("/c"), Dentry.read("/b => /c"), Path.read("/c"))))))
 
     val simplified =
       Delegate(Path.read("/a"), Dentry.nop,
         Delegate(Path.read("/b"), Dentry.read("/a => /b"),
-          Leaf(Path.read("/c"), Dentry.read("/b => /c"), Path.read("/c"))
-        )
-      )
+          Leaf(Path.read("/c"), Dentry.read("/b => /c"), Path.read("/c"))))
 
     assert(orig.simplified == simplified)
   }
@@ -89,14 +71,11 @@ class DelegateTreeTest extends FunSuite {
     val orig =
       Delegate(Path.read("/a"), Dentry.nop,
         Delegate(Path.read("/b"), Dentry.read("/a => /b"),
-          Union(Path.read("/b"), Dentry.read("/b => ~"))
-        )
-      )
+          Union(Path.read("/b"), Dentry.read("/b => ~"))))
 
     val simplified =
       Delegate(Path.read("/a"), Dentry.nop,
-        Neg(Path.read("/b"), Dentry.read("/a => /b"))
-      )
+        Neg(Path.read("/b"), Dentry.read("/a => /b")))
 
     assert(orig.simplified == simplified)
   }

--- a/namer/serversets/src/test/scala/io/buoyant/namer/serversets/ServersetsTest.scala
+++ b/namer/serversets/src/test/scala/io/buoyant/namer/serversets/ServersetsTest.scala
@@ -4,9 +4,10 @@ import com.fasterxml.jackson.databind.JsonMappingException
 import com.twitter.finagle.util.LoadService
 import io.buoyant.config.Parser
 import io.buoyant.namer.{NamerConfig, NamerInitializer}
+import io.buoyant.test.Exceptions
 import org.scalatest.FunSuite
 
-class ServersetsTest extends FunSuite {
+class ServersetsTest extends FunSuite with Exceptions {
 
   def parse(yaml: String): ServersetsConfig = {
     val mapper = Parser.objectMapper(yaml, Iterable(Seq(ServersetsInitializer)))
@@ -31,6 +32,7 @@ kind: io.l5d.serversets
 zkAddrs:
 - host: foo
   port: 2181
+
 """
     assert(parse(yaml).connectString == "foo:2181")
   }
@@ -41,10 +43,7 @@ kind: io.l5d.serversets
 zkAddrs:
 - port: 2181
 """
-    assert(
-      intercept[JsonMappingException](parse(yaml))
-      .getCause.isInstanceOf[IllegalArgumentException]
-    )
+    assertThrows[JsonMappingException](parse(yaml))
   }
 
   test("default port") {

--- a/namerd/iface/control-http/src/test/scala/io/buoyant/namerd/iface/HttpControlServiceTest.scala
+++ b/namerd/iface/control-http/src/test/scala/io/buoyant/namerd/iface/HttpControlServiceTest.scala
@@ -368,7 +368,7 @@ class HttpControlServiceTest extends FunSuite with Awaits {
     val resp = await(service(Request(s"/api/1/addr/default?path=${prefix.show}$id")))
 
     assert(resp.status == Status.Ok)
-    assert(resp.contentString == "Bound(0.0.0.0/0.0.0.0:1)\n")
+    assert(resp.contentString == "Bound(localhost/127.0.0.1:1)\n")
   }
 
   test("addr watch") {
@@ -384,10 +384,10 @@ class HttpControlServiceTest extends FunSuite with Awaits {
     witness.notify(Return(NameTree.Leaf(Name.Bound(addr, id))))
 
     addr() = Addr.Bound(Address(1))
-    readAndAssert(resp.reader, "Bound(0.0.0.0/0.0.0.0:1)")
+    readAndAssert(resp.reader, "Bound(localhost/127.0.0.1:1)")
 
     addr() = Addr.Bound(Address(1), Address(2))
-    readAndAssert(resp.reader, "Bound(0.0.0.0/0.0.0.0:1,0.0.0.0/0.0.0.0:2)")
+    readAndAssert(resp.reader, "Bound(localhost/127.0.0.1:1,localhost/127.0.0.1:2)")
 
     witness.notify(Return(NameTree.Neg))
     readAndAssert(resp.reader, "Neg")
@@ -395,7 +395,7 @@ class HttpControlServiceTest extends FunSuite with Awaits {
     val addr2 = Var[Addr](Addr.Pending)
     witness.notify(Return(NameTree.Leaf(Name.Bound(addr2, id))))
     addr2() = Addr.Bound(Address(3))
-    readAndAssert(resp.reader, "Bound(0.0.0.0/0.0.0.0:3)")
+    readAndAssert(resp.reader, "Bound(localhost/127.0.0.1:3)")
 
     resp.reader.discard()
   }

--- a/project/Deps.scala
+++ b/project/Deps.scala
@@ -8,16 +8,16 @@ object Deps {
       .exclude("com.twitter", "finagle-zipkin_2.11")
 
   def twitterUtil(mod: String) =
-    "com.twitter" %% s"util-$mod" % "6.34.0"
+    "com.twitter" %% s"util-$mod" % "6.35.0"
 
   // networking
   def finagle(mod: String) =
-    "com.twitter" %% s"finagle-$mod" % "6.35.0"
+    "com.twitter" %% s"finagle-$mod" % "6.36.0"
 
   def zkCandidate = "com.twitter.common.zookeeper" % "candidate" % "0.0.76"
 
   // Jackson (parsing)
-  val jacksonVersion = "2.4.4"
+  val jacksonVersion = "2.6.5"
   val jacksonCore =
     "com.fasterxml.jackson.core" % "jackson-core" % jacksonVersion
   val jacksonAnnotations =

--- a/project/Deps.scala
+++ b/project/Deps.scala
@@ -4,7 +4,7 @@ object Deps {
 
   // process lifecycle
   val twitterServer =
-    ("com.twitter" %% "twitter-server" % "1.20.0")
+    ("com.twitter" %% "twitter-server" % "1.21.0")
       .exclude("com.twitter", "finagle-zipkin_2.11")
 
   def twitterUtil(mod: String) =

--- a/router/core/src/test/scala/io/buoyant/router/ClassifiedTracingTest.scala
+++ b/router/core/src/test/scala/io/buoyant/router/ClassifiedTracingTest.scala
@@ -104,13 +104,4 @@ class ClassifiedTracingTest extends FunSuite with Awaits {
     assert(tracer.iterator.map(_.annotation).toSeq ==
       Seq(Annotation.BinaryAnnotation("l5d.success", 0.84)))
   }
-
-  test("does not trace when is false") {
-    val ctx = new Ctx {}
-    import ctx._
-
-    sampled = Some(false)
-    call("ok")
-    assert(tracer.iterator.map(_.annotation).toSeq == Seq())
-  }
 }

--- a/router/http/src/test/scala/io/buoyant/router/http/TracingFilterTest.scala
+++ b/router/http/src/test/scala/io/buoyant/router/http/TracingFilterTest.scala
@@ -53,35 +53,6 @@ class TracingFilterTest extends FunSuite with Awaits {
     }
   }
 
-  test("tracing filter only applies when tracing is not disabled") {
-    val tracer = new BufferingTracer
-
-    val service = new TracingFilter andThen Service.mk[Request, Response] { req =>
-      val rsp = Response()
-      rsp.status = Status.Ok
-      Future.value(rsp)
-    }
-
-    def req = Request(Method.Head, "")
-
-    Trace.letTracerAndId(tracer, TraceId(None, None, SpanId(100L), Some(false))) {
-      await(service(req))
-      assert(tracer.iterator.isEmpty)
-    }
-
-    tracer.clear()
-    Trace.letTracerAndId(tracer, TraceId(None, None, SpanId(101L), Some(true))) {
-      await(service(req))
-      assert(tracer.iterator.size == 6)
-    }
-
-    tracer.clear()
-    Trace.letTracerAndId(tracer, TraceId(None, None, SpanId(102L), None)) {
-      await(service(req))
-      assert(tracer.iterator.size == 6)
-    }
-  }
-
   test("error message annotations") {
     val tracer = new BufferingTracer
 


### PR DESCRIPTION
The sampling logic for tracing has changed slightly.  (see: https://github.com/twitter/finagle/commit/1b29f4e334f5f24f1c1ff2766369a75cad63561)

`isActivelyTracing` now checks to see if any of the tracers are actively tracing instead checking the `sampled` bit on the trace itself.  Therefore, BufferedTracer will always sample a trace.  On the other hand, SamplingTracer respects the `sampled` bit so I think this only messes up our tests.