### PR TITLE
Fix netty merge strategy

### DIFF
--- a/project/Base.scala
+++ b/project/Base.scala
@@ -116,6 +116,7 @@ class Base extends Build {
     assemblyJarName in assembly := s"${name.value}-${version.value}-${configuration.value}-exec",
     assemblyMergeStrategy in assembly := {
       case "com/twitter/common/args/apt/cmdline.arg.info.txt.1" => MergeStrategy.discard
+      case "META-INF/io.netty.versions.properties" => MergeStrategy.last
       case path => (assemblyMergeStrategy in assembly).value(path)
     },
 


### PR DESCRIPTION
Each netty dependency includes a `META-INF/io.netty.versions.properties` file that includes information such as build time.  Since these jars were not all built at the same time, the contents of these files differ and therefore conflict.  