### PR TITLE
Fix handling of Addr.Pending in ServersetNamer

### DIFF
--- a/namer/serversets/src/test/scala/io/buoyant/namer/serversets/ServersetNamerTest.scala
+++ b/namer/serversets/src/test/scala/io/buoyant/namer/serversets/ServersetNamerTest.scala
@@ -1,15 +1,20 @@
 package io.buoyant.namer.serversets
 
 import com.twitter.finagle._
-import com.twitter.util.Var
+import com.twitter.util.{Activity, Var}
 import io.buoyant.namer.NamerTestUtil
 import java.net.{InetAddress, InetSocketAddress}
 import org.scalatest.FunSuite
 
 class ServersetNamerTest extends FunSuite with NamerTestUtil {
   val prefix = Path.read("/#/some/prefix")
+  val loopback = Address(new InetSocketAddress(InetAddress.getLoopbackAddress, 1))
+  val pathAddr = Var[Addr](Addr.Pending)
+  val otherAddr = Var[Addr](Addr.Pending)
 
   test("falls back to path prefixes") {
+    pathAddr() = Addr.Bound(loopback)
+    otherAddr() = Addr.Neg
     namer("/foo/bar").lookup(Path.read("/foo/bar/x/y/z")).sample() match {
       case NameTree.Leaf(name: Name.Bound) =>
         assert(name.id == prefix ++ Path.read("/foo/bar"))
@@ -19,12 +24,14 @@ class ServersetNamerTest extends FunSuite with NamerTestUtil {
   }
 
   test("neg") {
+    otherAddr() = Addr.Neg
     assert(
       namer("/this").lookup(Path.read("/that")).sample() == NameTree.Neg
     )
   }
 
   test("exact match") {
+    pathAddr() = Addr.Bound(loopback)
     namer("/foo/bar").lookup(Path.read("/foo/bar")).sample() match {
       case NameTree.Leaf(name: Name.Bound) =>
         assert(name.id == prefix ++ Path.read("/foo/bar"))
@@ -34,6 +41,8 @@ class ServersetNamerTest extends FunSuite with NamerTestUtil {
   }
 
   test("empty path") {
+    pathAddr() = Addr.Bound(loopback)
+    otherAddr() = Addr.Neg
     namer("/").lookup(Path.read("/x/y/z")).sample() match {
       case NameTree.Leaf(name: Name.Bound) =>
         assert(name.id == prefix)
@@ -43,15 +52,30 @@ class ServersetNamerTest extends FunSuite with NamerTestUtil {
   }
 
   test("id is bound name") {
+    pathAddr() = Addr.Bound(loopback)
     val testNamer = namer("/test")
     assertBoundIdAutobinds(testNamer, prefix ++ Path.read("/test"), prefix)
   }
 
+  test("handles pending") {
+    otherAddr() = Addr.Pending
+    val act = namer("/foo/bar").lookup(Path.read("/foo/bar/x/y/z"))
+    assert(act.run.sample() == Activity.Pending)
+    otherAddr() = Addr.Neg
+    pathAddr() = Addr.Bound(loopback)
+    act.sample() match {
+      case NameTree.Leaf(name: Name.Bound) =>
+        assert(name.id == prefix ++ Path.read("/foo/bar"))
+        assert(name.path == Path.read("/x/y/z"))
+      case x => fail("failed to bind")
+    }
+  }
+
   def namer(path: String) = new ServersetNamer("host", prefix) {
-    val loopback = Address(new InetSocketAddress(InetAddress.getLoopbackAddress, 1))
+
     /** Resolve a resolver string to a Var[Addr]. */
     override protected[this] def resolve(spec: String): Var[Addr] =
-      if (spec == s"zk2!host!$path") Var.value(Addr.Bound(loopback))
-      else Var.value(Addr.Neg)
+      if (spec == s"zk2!host!$path") pathAddr
+      else otherAddr
   }
 }


### PR DESCRIPTION
# Problem

If `resolveServerset` returns `Addr.Pending`, we incorrectly assume that it has successfully bound this path.  This means that this namer may appear to bind paths that it cannot, or might bind entire paths when it should only bind a prefix and leave a residual.

# Solution

Convert the `Var[Name.Bound]` into an Activity to properly reflect the pending state.
