### PR TITLE
Update identifier interface to return a modified request

### DIFF
--- a/linkerd/core/src/test/scala/io/buoyant/linkerd/TestProtocol.scala
+++ b/linkerd/core/src/test/scala/io/buoyant/linkerd/TestProtocol.scala
@@ -76,7 +76,7 @@ abstract class TestProtocol(val name: String) extends ProtocolInitializer.Simple
       val RoutingFactory.BaseDtab(dtab) = params[RoutingFactory.BaseDtab]
       val RoutingFactory.DstPrefix(pfx) = params[RoutingFactory.DstPrefix]
       val path = pfx ++ Path.read(req)
-      Future.value(Dst.Path(path, dtab(), Dtab.local))
+      Future.value((Dst.Path(path, dtab(), Dtab.local), req))
     }
   }
 

--- a/router/core/src/e2e/scala/io/buoyant/router/EchoEndToEndTest.scala
+++ b/router/core/src/e2e/scala/io/buoyant/router/EchoEndToEndTest.scala
@@ -174,9 +174,9 @@ object Echo extends Router[String, String] with Server[String, String] {
     case class Identifier(prefix: Path = Path.empty, dtab: () => Dtab = () => Dtab.base)
         extends RoutingFactory.Identifier[String] {
 
-      def apply(req: String): Future[Dst] = {
+      def apply(req: String): Future[(Dst, String)] = {
         val path = Path.read(if (req startsWith "/") req else s"/$req")
-        Future.value(Dst.Path(prefix ++ path, dtab(), Dtab.local))
+        Future.value((Dst.Path(prefix ++ path, dtab(), Dtab.local), req))
       }
     }
 

--- a/router/core/src/test/scala/io/buoyant/router/RouterTest.scala
+++ b/router/core/src/test/scala/io/buoyant/router/RouterTest.scala
@@ -55,7 +55,9 @@ class RouterTest extends FunSuite with Awaits with Exceptions {
     protected def newIdentifier(): RoutingFactory.Identifier[String] = {
       val RoutingFactory.DstPrefix(pfx) = params[RoutingFactory.DstPrefix]
       val RoutingFactory.BaseDtab(baseDtab) = params[RoutingFactory.BaseDtab]
-      in => Future.value(Dst.Path(pfx ++ Path.Utf8(in), baseDtab(), Dtab.local))
+      in => Future.value(
+        (Dst.Path(pfx ++ Path.Utf8(in), baseDtab(), Dtab.local), in)
+      )
     }
   }
 

--- a/router/core/src/test/scala/io/buoyant/router/RoutingFactoryTest.scala
+++ b/router/core/src/test/scala/io/buoyant/router/RoutingFactoryTest.scala
@@ -39,7 +39,7 @@ class RoutingFactoryTest extends FunSuite with Awaits with Exceptions {
     }
 
   def mkService(
-    pathMk: RoutingFactory.Identifier[Request] = (_: Request) => Future.value(Dst.Path.empty),
+    pathMk: RoutingFactory.Identifier[Request] = (req: Request) => Future.value((Dst.Path.empty, req)),
     cache: DstBindingFactory[Request, Response] = mkClientFactory(),
     label: String = ""
   ) = new RoutingFactory(pathMk, cache, label).toService

--- a/router/http/src/main/scala/io/buoyant/router/http/MethodAndHostIdentifier.scala
+++ b/router/http/src/main/scala/io/buoyant/router/http/MethodAndHostIdentifier.scala
@@ -24,14 +24,18 @@ case class MethodAndHostIdentifier(
   private[this] def mkPath(path: Path): Dst.Path =
     Dst.Path(prefix ++ path, baseDtab(), Dtab.local)
 
-  def apply(req: http.Request): Future[Dst] = req.version match {
+  def apply(req: http.Request): Future[(Dst, http.Request)] = req.version match {
     case http.Version.Http10 =>
-      Future.value(mkPath(Path.Utf8("1.0", req.method.toString) ++ suffix(req)))
+      Future.value(
+        (mkPath(Path.Utf8("1.0", req.method.toString) ++ suffix(req)), req)
+      )
 
     case http.Version.Http11 =>
       req.host match {
         case Some(host) if host.nonEmpty =>
-          Future.value(mkPath(Path.Utf8("1.1", req.method.toString, host) ++ suffix(req)))
+          Future.value(
+            (mkPath(Path.Utf8("1.1", req.method.toString, host) ++ suffix(req)), req)
+          )
         case _ =>
           Future.exception(new IllegalArgumentException(s"${http.Version.Http11} request missing hostname: $req"))
       }

--- a/router/http/src/main/scala/io/buoyant/router/http/PathIdentifier.scala
+++ b/router/http/src/main/scala/io/buoyant/router/http/PathIdentifier.scala
@@ -11,10 +11,12 @@ case class PathIdentifier(
   baseDtab: () => Dtab = () => Dtab.base
 ) extends RoutingFactory.Identifier[http.Request] {
 
-  def apply(req: http.Request): Future[Dst] =
+  def apply(req: http.Request): Future[(Dst, http.Request)] =
     Path.read(req.path) match {
       case path if path.size >= segments =>
-        Future.value(Dst.Path(prefix ++ path.take(segments), baseDtab(), Dtab.local))
+        Future.value(
+          (Dst.Path(prefix ++ path.take(segments), baseDtab(), Dtab.local), req)
+        )
       case _ =>
         Future.exception(new IllegalArgumentException(s"not enough segments in path ${req.path}"))
     }

--- a/router/http/src/test/scala/io/buoyant/router/http/MethodAndHostIdentifierTest.scala
+++ b/router/http/src/test/scala/io/buoyant/router/http/MethodAndHostIdentifierTest.scala
@@ -24,7 +24,7 @@ class MethodAndHostIdentifierTest extends FunSuite with Awaits with Exceptions {
     val req = Request()
     req.uri = "/some/path?other=stuff"
     req.host = "domain"
-    assert(await(identifier(req)) == Dst.Path(Path.read("/https/1.1/GET/domain")))
+    assert(await(identifier(req))._1 == Dst.Path(Path.read("/https/1.1/GET/domain")))
   }
 
   test("http/1.1 with URIs") {
@@ -32,20 +32,20 @@ class MethodAndHostIdentifierTest extends FunSuite with Awaits with Exceptions {
     val req = Request()
     req.uri = "/some/path?other=stuff"
     req.host = "domain"
-    assert(await(identifier(req)) == Dst.Path(Path.read("/https/1.1/GET/domain/some/path")))
+    assert(await(identifier(req))._1 == Dst.Path(Path.read("/https/1.1/GET/domain/some/path")))
   }
 
   test("http/1.0") {
     val identifier = MethodAndHostIdentifier(Path.Utf8("prefix"), false)
     val req = Request(Method.Post, "/drum/bass")
     req.version = Version.Http10
-    assert(await(identifier(req)) == Dst.Path(Path.read("/prefix/1.0/POST")))
+    assert(await(identifier(req))._1 == Dst.Path(Path.read("/prefix/1.0/POST")))
   }
 
   test("http/1.0 with uri") {
     val identifier = MethodAndHostIdentifier(Path.Utf8("prefix"), true)
     val req = Request(Method.Post, "/drum/bass")
     req.version = Version.Http10
-    assert(await(identifier(req)) == Dst.Path(Path.read("/prefix/1.0/POST/drum/bass")))
+    assert(await(identifier(req))._1 == Dst.Path(Path.read("/prefix/1.0/POST/drum/bass")))
   }
 }

--- a/router/http/src/test/scala/io/buoyant/router/http/PathIdentifierTest.scala
+++ b/router/http/src/test/scala/io/buoyant/router/http/PathIdentifierTest.scala
@@ -12,14 +12,14 @@ class PathIdentifierTest extends FunSuite with Awaits with Exceptions {
     val identifier = PathIdentifier(Path.Utf8("http"), 2)
     val req = Request()
     req.uri = "/mysvc/subsvc"
-    assert(await(identifier(req)) == Dst.Path(Path.read("/http/mysvc/subsvc")))
+    assert(await(identifier(req))._1 == Dst.Path(Path.read("/http/mysvc/subsvc")))
   }
 
   test("request with more segments than requested") {
     val identifier = PathIdentifier(Path.Utf8("http"), 2)
     val req = Request()
     req.uri = "/mysvc/subsvc/some/path?other=stuff"
-    assert(await(identifier(req)) == Dst.Path(Path.read("/http/mysvc/subsvc")))
+    assert(await(identifier(req))._1 == Dst.Path(Path.read("/http/mysvc/subsvc")))
   }
 
   test("request with fewer segments than requested") {

--- a/router/mux/src/main/scala/io/buoyant/router/Mux.scala
+++ b/router/mux/src/main/scala/io/buoyant/router/Mux.scala
@@ -31,8 +31,10 @@ object Mux extends Router[Request, Response] with Server[Request, Response] {
       prefix: Path = Path.empty,
       dtab: () => Dtab = () => Dtab.base
     ) extends RoutingFactory.Identifier[Request] {
-      def apply(req: Request): Future[Dst] =
-        Future.value(Dst.Path(prefix ++ req.destination, dtab(), Dtab.local))
+      def apply(req: Request): Future[(Dst, Request)] =
+        Future.value(
+          (Dst.Path(prefix ++ req.destination, dtab(), Dtab.local), req)
+        )
     }
 
   }

--- a/router/thrift/src/main/scala/io/buoyant/router/thrift/Identifier.scala
+++ b/router/thrift/src/main/scala/io/buoyant/router/thrift/Identifier.scala
@@ -26,6 +26,8 @@ case class Identifier(
     }
   }
 
-  def apply(req: ThriftClientRequest): Future[Dst] =
-    Future.value(Dst.Path(name ++ suffix(req), dtab(), Dtab.local))
+  def apply(req: ThriftClientRequest): Future[(Dst, ThriftClientRequest)] =
+    Future.value(
+      (Dst.Path(name ++ suffix(req), dtab(), Dtab.local), req)
+    )
 }

--- a/router/thrift/src/test/scala/io/buoyant/router/thrift/IdentifierTest.scala
+++ b/router/thrift/src/test/scala/io/buoyant/router/thrift/IdentifierTest.scala
@@ -29,12 +29,12 @@ class IdentifierTest extends FunSuite with Awaits {
   test("thrift request") {
     val identifier = Identifier(Path.Utf8("thrift"))
     val req = encodeRequest(PingService.Ping)(PingService.Ping.Args("hi"))
-    assert(await(identifier(req)) == Dst.Path(Path.read("/thrift")))
+    assert(await(identifier(req))._1 == Dst.Path(Path.read("/thrift")))
   }
 
   test("thrift request with method") {
     val identifier = Identifier(Path.Utf8("thrift"), methodInDst = true)
     val req = encodeRequest(PingService.Ping)(PingService.Ping.Args("hi"))
-    assert(await(identifier(req)) == Dst.Path(Path.read("/thrift/ping")))
+    assert(await(identifier(req))._1 == Dst.Path(Path.read("/thrift/ping")))
   }
 }


### PR DESCRIPTION
The Identifier interface now returns a 2-tuple of `(Dst, Request)`.  This allows Identifiers to pass along a modified request in place of the original.  This can be useful for Identifiers that consume segments of the URI, for example.