### PR TITLE
Add a consume option to the io.l5d.path identifier

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -2,6 +2,8 @@
 
 * Turn off HTTP decompression so that linkerd doesn't decompress and then
   recompress bodies.
+* Add a `consume` option to the `io.l5d.path` identifier to strip off the path
+  segments that it reads from the URI.
 
 ## 0.7.0
 

--- a/linkerd/docs/protocol-http.md
+++ b/linkerd/docs/protocol-http.md
@@ -69,6 +69,7 @@ segments from the start of their HTTP path.
 
 * *segments* -- Number of segments from the path that are appended to
   destinations. (default: 1)
+* *consume* -- Strip the read segments from the HTTP path.  (default: false)
 
 For instance, here's a router configured with an http path identifier:
 
@@ -79,12 +80,13 @@ routers:
   identifier:
     kind: io.l5d.path
     segments: 2
+    consume: true
   servers:
     port: 5000
 ```
 
 A request to `:5000/true/love/waits.php` will be identified as
-`/custom/prefix/true/love`.
+`/custom/prefix/true/love` and will be forwarded with `/waits.php` as the URI.
 
 ## HTTP Headers
 

--- a/linkerd/protocol/http/src/main/scala/io/buoyant/linkerd/protocol/http/PathIdentifierConfig.scala
+++ b/linkerd/protocol/http/src/main/scala/io/buoyant/linkerd/protocol/http/PathIdentifierConfig.scala
@@ -19,10 +19,11 @@ object PathIdentifierConfig {
 
 class PathIdentifierConfig extends HttpIdentifierConfig {
   var segments: Option[Int] = None
+  var consume: Option[Boolean] = None
 
   @JsonIgnore
   override def newIdentifier(
     prefix: Path,
     baseDtab: () => Dtab = () => Dtab.base
-  ) = PathIdentifier(prefix, segments.getOrElse(1), baseDtab)
+  ) = PathIdentifier(prefix, segments.getOrElse(1), consume.getOrElse(false), baseDtab)
 }

--- a/linkerd/protocol/http/src/test/scala/io/buoyant/linkerd/protocol/http/PathIdentifierConfigTest.scala
+++ b/linkerd/protocol/http/src/test/scala/io/buoyant/linkerd/protocol/http/PathIdentifierConfigTest.scala
@@ -21,11 +21,13 @@ class PathIdentifierConfigTest extends FunSuite {
     val yaml = s"""
                   |kind: io.l5d.path
                   |segments: 2
+                  |consume: true
       """.stripMargin
 
     val mapper = Parser.objectMapper(yaml, Iterable(Seq(PathIdentifierInitializer)))
     val config = mapper.readValue[HttpIdentifierConfig](yaml).asInstanceOf[PathIdentifierConfig]
     assert(config.segments == Some(2))
+    assert(config.consume == Some(true))
   }
 
 }

--- a/router/http/src/main/scala/io/buoyant/router/http/PathIdentifier.scala
+++ b/router/http/src/main/scala/io/buoyant/router/http/PathIdentifier.scala
@@ -8,12 +8,16 @@ import io.buoyant.router.RoutingFactory
 case class PathIdentifier(
   prefix: Path,
   segments: Int = 1,
+  consume: Boolean = false,
   baseDtab: () => Dtab = () => Dtab.base
 ) extends RoutingFactory.Identifier[http.Request] {
 
   def apply(req: http.Request): Future[(Dst, http.Request)] =
     Path.read(req.path) match {
       case path if path.size >= segments =>
+        if (consume) {
+          req.uri = req.uri.split("/").drop(segments + 1).mkString("/", "/", "")
+        }
         Future.value(
           (Dst.Path(prefix ++ path.take(segments), baseDtab(), Dtab.local), req)
         )

--- a/router/http/src/test/scala/io/buoyant/router/http/PathIdentifierTest.scala
+++ b/router/http/src/test/scala/io/buoyant/router/http/PathIdentifierTest.scala
@@ -30,4 +30,22 @@ class PathIdentifierTest extends FunSuite with Awaits with Exceptions {
       await(identifier(req))
     }
   }
+
+  test("consumes path segments") {
+    val identifier = PathIdentifier(Path.Utf8("http"), 2, consume = true)
+    val req0 = Request()
+    req0.uri = "/mysvc/subsvc/some/path?other=stuff"
+    val (dst, req1) = await(identifier(req0))
+    assert(dst == Dst.Path(Path.read("/http/mysvc/subsvc")))
+    assert(req1.uri == "/some/path?other=stuff")
+  }
+
+  test("consumes entire path") {
+    val identifier = PathIdentifier(Path.Utf8("http"), 2, consume = true)
+    val req0 = Request()
+    req0.uri = "/mysvc/subsvc"
+    val (dst, req1) = await(identifier(req0))
+    assert(dst == Dst.Path(Path.read("/http/mysvc/subsvc")))
+    assert(req1.uri == "/")
+  }
 }


### PR DESCRIPTION
Fixes #458 