### PR TITLE
Support a Netty4 engine for HTTP routers

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -4,6 +4,7 @@
   recompress bodies.
 * Add a `consume` option to the `io.l5d.path` identifier to strip off the path
   segments that it reads from the URI.
+* Introduce a configurable Netty4 http implementation.
 
 ## 0.7.0
 
@@ -28,7 +29,6 @@
   * Added server success rate graphs to the dashboard, improved responsiveness
   * Added the ability to navigate to a specific router's dashboard
   * Standardized the look and feel of the admin pages
-* Introduce a configurable Netty4 http implementation.
 
 ## 0.6.0
 

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -28,6 +28,7 @@
   * Added server success rate graphs to the dashboard, improved responsiveness
   * Added the ability to navigate to a specific router's dashboard
   * Standardized the look and feel of the admin pages
+* Introduce a configurable Netty4 http implementation.
 
 ## 0.6.0
 

--- a/linkerd/docs/protocol-http.md
+++ b/linkerd/docs/protocol-http.md
@@ -88,6 +88,31 @@ routers:
 A request to `:5000/true/love/waits.php` will be identified as
 `/custom/prefix/true/love` and will be forwarded with `/waits.php` as the URI.
 
+
+## HTTP Engines
+
+An _engine_ may be configured on HTTP clients and servers, causing an
+alternate HTTP implementation to be used. Currently there are two
+supported HTTP implementations: _netty3_ (default) and _netty4_ (will
+become default in an upcoming release).
+
+For example, the following configures an HTTP router that uses the new
+netty4 implementation on both the client and server:
+
+```yaml
+- protocol: http
+  ...
+  servers:
+  - port: 4141
+    ip: 0.0.0.0
+    engine:
+      kind: netty4
+  client:
+    engine:
+      kind: netty4
+```
+
+
 ## HTTP Headers
 
 linkerd reads and sets several headers prefixed by `l5d-`.

--- a/linkerd/examples/acceptance-test.yaml
+++ b/linkerd/examples/acceptance-test.yaml
@@ -51,6 +51,8 @@ routers:
   responseClassifier:
     kind: io.l5d.retryableIdempotent5XX
   client:
+    engine:
+      kind: netty4
     loadBalancer:
       kind: p2c
       maxEffort: 10
@@ -63,6 +65,8 @@ routers:
   - port: 4140
     ip: 0.0.0.0
     maxConcurrentRequests: 1000
+    engine:
+      kind: netty3
 
 # TODO: test thrift traffic
 - protocol: thrift

--- a/linkerd/examples/http.yaml
+++ b/linkerd/examples/http.yaml
@@ -8,14 +8,31 @@ namers:
 # A simple HTTP router that looks up host header values in io.l5d.fs.
 routers:
 - protocol: http
-  identifier:
-    kind: io.l5d.methodAndHost
-    httpUriInDst: true
+  label: netty3
   baseDtab: |
-    /host => /#/io.l5d.fs;
-    /host/127.0.0.1:4140 => /host/default;
-    /host/localhost:4140 => /host/default;
+    /srv => /#/io.l5d.fs;
+    /host => /srv;
     /http/1.1/* => /host;
   servers:
   - port: 4140
     ip: 0.0.0.0
+    engine:
+      kind: netty3
+  client:
+    engine:
+      kind: netty3
+
+- protocol: http
+  label: netty4
+  baseDtab: |
+    /srv => /#/io.l5d.fs;
+    /host => /srv;
+    /http/1.1/* => /host;
+  servers:
+  - port: 4141
+    ip: 0.0.0.0
+    engine:
+      kind: netty4
+  client:
+    engine:
+      kind: netty4

--- a/linkerd/protocol/http/src/integration/scala/io/buoyant/linkerd/protocol/TlsBoundPathTest.scala
+++ b/linkerd/protocol/http/src/integration/scala/io/buoyant/linkerd/protocol/TlsBoundPathTest.scala
@@ -50,6 +50,8 @@ class TlsBoundPathTest extends FunSuite with Awaits {
              |  servers:
              |  - port: 0
              |  client:
+             |    engine:
+             |      kind: netty4
              |    tls:
              |      kind: io.l5d.boundPath
              |      caCertPath: ${certs.caCert.getPath}
@@ -110,6 +112,8 @@ class TlsBoundPathTest extends FunSuite with Awaits {
             |  servers:
             |  - port: 0
             |  client:
+            |    engine:
+            |      kind: netty4
             |    tls:
             |      kind: io.l5d.boundPath
             |      caCertPath: ${certs.caCert.getPath}
@@ -176,6 +180,8 @@ class TlsBoundPathTest extends FunSuite with Awaits {
             |  servers:
             |  - port: 0
             |  client:
+            |    engine:
+            |      kind: netty4
             |    tls:
             |      kind: io.l5d.boundPath
             |      caCertPath: ${certs.caCert.getPath}
@@ -244,6 +250,8 @@ class TlsBoundPathTest extends FunSuite with Awaits {
              |  servers:
              |  - port: 0
              |  client:
+             |    engine:
+             |      kind: netty4
              |    retries:
              |      budget:
              |        minRetriesPerSec: 0

--- a/linkerd/protocol/http/src/main/scala/com/twitter/finagle/buoyant/linkerd/HttpEngine.scala
+++ b/linkerd/protocol/http/src/main/scala/com/twitter/finagle/buoyant/linkerd/HttpEngine.scala
@@ -1,0 +1,31 @@
+package com.twitter.finagle.buoyant.linkerd
+
+import com.fasterxml.jackson.annotation.{JsonIgnore, JsonTypeInfo, JsonSubTypes}
+import com.fasterxml.jackson.core.{io => _}
+import com.twitter.finagle.{Http, Stack}
+import com.twitter.finagle.netty4.http.exp.Netty4Impl
+
+@JsonTypeInfo(
+  use = JsonTypeInfo.Id.NAME,
+  include = JsonTypeInfo.As.PROPERTY,
+  property = "kind"
+)
+@JsonSubTypes(Array(
+  new JsonSubTypes.Type(value = classOf[HttpEngine.Netty3], name = "netty3"),
+  new JsonSubTypes.Type(value = classOf[HttpEngine.Netty4], name = "netty4")
+))
+abstract trait HttpEngine {
+
+  @JsonIgnore
+  def mk(params: Stack.Params): Stack.Params
+}
+
+object HttpEngine {
+  class Netty3 extends HttpEngine {
+    def mk(params: Stack.Params) = params + Http.param.Netty3Impl
+  }
+
+  class Netty4 extends HttpEngine {
+    def mk(params: Stack.Params) = params + Netty4Impl
+  }
+}

--- a/linkerd/protocol/http/src/main/scala/io/buoyant/linkerd/protocol/HttpConfig.scala
+++ b/linkerd/protocol/http/src/main/scala/io/buoyant/linkerd/protocol/HttpConfig.scala
@@ -65,7 +65,7 @@ case class HttpServerConfig(
   engine: Option[HttpEngine]
 ) extends ServerConfig {
   override def serverParams = engine match {
-    case Seme(engine) => engine.mk(super.serverParams)
+    case Some(engine) => engine.mk(super.serverParams)
     case None => super.serverParams
   }
 }

--- a/linkerd/protocol/http/src/main/scala/io/buoyant/linkerd/protocol/HttpConfig.scala
+++ b/linkerd/protocol/http/src/main/scala/io/buoyant/linkerd/protocol/HttpConfig.scala
@@ -55,15 +55,19 @@ object HttpInitializer extends HttpInitializer
 case class HttpClientConfig(
   engine: Option[HttpEngine]
 ) extends ClientConfig {
-  override def clientParams =
-    engine.foldLeft(super.clientParams) { (params, engine) => engine.mk(params) }
+  override def clientParams = engine match {
+    case Some(engine) => engine.mk(super.clientParams)
+    case None => super.clientParams
+  }
 }
 
 case class HttpServerConfig(
   engine: Option[HttpEngine]
 ) extends ServerConfig {
-  override def serverParams =
-    engine.foldLeft(super.serverParams) { (params, engine) => engine.mk(params) }
+  override def serverParams = engine match {
+    case Seme(engine) => engine.mk(super.serverParams)
+    case None => super.serverParams
+  }
 }
 
 case class HttpConfig(

--- a/linkerd/tls/src/main/scala/io/buoyant/linkerd/clientTls/BoundPathInitializer.scala
+++ b/linkerd/tls/src/main/scala/io/buoyant/linkerd/clientTls/BoundPathInitializer.scala
@@ -7,6 +7,7 @@ import com.twitter.finagle.buoyant.TlsClientPrep
 import com.twitter.finagle.buoyant.TlsClientPrep.Module
 import com.twitter.finagle.client.AddrMetadataExtraction.AddrMetadata
 import com.twitter.finagle.ssl.Engine
+import com.twitter.finagle.transport.TlsConfig
 import com.twitter.logging.Logger
 import io.buoyant.config.Parser
 import io.buoyant.linkerd.util.PathMatcher
@@ -23,26 +24,32 @@ object BoundPathInitializer extends BoundPathInitializer
 case class BoundPathConfig(caCertPath: Option[String], names: Seq[NameMatcherConfig], strict: Option[Boolean])
   extends TlsClientConfig {
   @JsonIgnore
-  override def tlsClientPrep[Req, Rsp]: Module[Req, Rsp] = {
-
-    def commonNameFromPath(path: Path): Option[String] =
-      names.map { n =>
-        n.matcher.substitute(path, n.commonNamePattern)
-      }.collectFirst {
-        case Some(result) => result
-      } match {
-        case None if strict.getOrElse(true) =>
-          throw new MatcherError(s"Unable to match ${path.show} with available names: ${names.map(_.prefix).mkString(",")}")
-        case default => default
-      }
-
+  override def tlsClientPrep[Req, Rsp]: Module[Req, Rsp] =
     new TlsClientPrep.Module[Req, Rsp] {
+      val parameters: Seq[Param[_]] = Seq(AddrMetadata.param)
+
       private val log = Logger.get(getClass.getName)
 
-      override def newEngine(params: Params): Option[(SocketAddress) => Engine] =
-        peerCommonName(params).map(TlsClientPrep.addrEngine(_, caCertPath))
+      private[this] def commonNameFromPath(path: Path): Option[String] =
+        names.map { n =>
+          n.matcher.substitute(path, n.commonNamePattern)
+        }.collectFirst {
+          case Some(result) => result
+        } match {
+          case None if strict.getOrElse(true) =>
+            val n = names.map(_.prefix).mkString(",")
+            throw new MatcherError(s"Unable to match ${path.show} with available names: $n")
+          case default => default
+        }
 
-      override def peerCommonName(params: Params): Option[String] =
+      def newEngine(cn: Option[String]): Option[(SocketAddress) => Engine] =
+        cn.map(TlsClientPrep.addrEngine(_, caCertPath))
+
+      def tlsConfig(cn: Option[String]) =
+        cn.map(TlsClientPrep.mkTlsConfig(_, caCertPath))
+          .getOrElse(TlsConfig.Disabled)
+
+      def peerCommonName(params: Params): Option[String] =
         for {
           path <- params[AddrMetadata].metadata("id") match {
             case id: String => Some(Path.read(id))
@@ -53,10 +60,7 @@ case class BoundPathConfig(caCertPath: Option[String], names: Seq[NameMatcherCon
           log.info(s"Using $commonName as the TLS common name for ${path.show}")
           commonName
         }
-
-      override def parameters: Seq[Param[_]] = Seq(AddrMetadata.param)
     }
-  }
 }
 
 class MatcherError(msg: String) extends Throwable(msg)

--- a/project/Base.scala
+++ b/project/Base.scala
@@ -36,6 +36,7 @@ class Base extends Build {
     version := Git.version,
     homepage := Some(url("https://linkerd.io")),
     scalaVersion in GlobalScope := "2.11.7",
+    ivyScala := ivyScala.value.map(_.copy(overrideScalaVersion = true)),
     scalacOptions ++= Seq("-Xfatal-warnings", "-deprecation", "-Ywarn-value-discard"),
     // XXX
     //conflictManager := ConflictManager.strict,

--- a/project/LinkerdBuild.scala
+++ b/project/LinkerdBuild.scala
@@ -42,7 +42,7 @@ object LinkerdBuild extends Base {
 
     val http = projectDir("router/http")
       .dependsOn(core)
-      .withTwitterLib(Deps.finagle("http"))
+      .withTwitterLibs(Deps.finagle("http"))
       .withTests()
       .withE2e()
 
@@ -345,6 +345,7 @@ object LinkerdBuild extends Base {
     object Protocol {
       val http = projectDir("linkerd/protocol/http")
         .withTests().withE2e().withIntegration()
+        .withTwitterLibs(Deps.finagle("netty4-http"))
         .dependsOn(
           core % "compile->compile;e2e->test;integration->test",
           tls % "integration",
@@ -371,7 +372,7 @@ object LinkerdBuild extends Base {
 
     object Tracer {
       val zipkin = projectDir("linkerd/tracer/zipkin")
-        .withTwitterLib(Deps.finagle("zipkin"))
+        .withTwitterLibs(Deps.finagle("zipkin-core"), Deps.finagle("zipkin"))
         .dependsOn(core)
         .withTests()
 


### PR DESCRIPTION
Finagle-6.36 introduces a usable netty4 backend for HTTP. linkerd users should
be able to opt-in to this new backend so that it may be introduced in a
controlled manner (until it's proven to be a suitable default).

Client and Server sections of the HTTP router configuration admit an `engine`
block that controls which HTTP implementation is used.