### PR TITLE
Memoize status stats

### DIFF
--- a/linkerd/protocol/http/src/main/scala/io/buoyant/linkerd/protocol/http/StatusCodeStatsFilter.scala
+++ b/linkerd/protocol/http/src/main/scala/io/buoyant/linkerd/protocol/http/StatusCodeStatsFilter.scala
@@ -1,8 +1,9 @@
 package io.buoyant.linkerd.protocol.http
 
-import com.twitter.finagle.http.filter.StatsFilter
-import com.twitter.finagle.http.{Request, Response}
-import com.twitter.finagle.{ServiceFactory, Stack, Stackable, param}
+import com.twitter.finagle.{Service, ServiceFactory, SimpleFilter, Stack, Stackable, param}
+import com.twitter.finagle.stats.{Counter, StatsReceiver}
+import com.twitter.finagle.http.{Request, Response, Status}
+import com.twitter.util.{Duration, Future, Memoize, Return, Stopwatch, Throw, Try}
 
 object StatusCodeStatsFilter {
   val role = Stack.Role("StatusCodeStatsFilter")
@@ -15,7 +16,55 @@ object StatusCodeStatsFilter {
       def make(_stats: param.Stats, next: ServiceFactory[Request, Response]) = {
         val param.Stats(statsReceiver) = _stats
         if (statsReceiver.isNull) next
-        else new StatsFilter[Request](statsReceiver) andThen next
+        else new StatusCodeStatsFilter(statsReceiver).andThen(next)
       }
     }
+}
+
+/**
+ * Modified from com.twitter.finagle.http.filter.StatsFilter.
+ *
+ * Emits counters:
+ *
+ *   status/{code}
+ *   status/{class [1-5]XX}
+ *
+ *   time/{code}/<histogram>
+ *   time/{class [1-5]XX}}/<histogram>
+ *   time/error/<histogram>
+ */
+class StatusCodeStatsFilter(stats: StatsReceiver)
+  extends SimpleFilter[Request, Response] {
+
+  private[this] val statusReceiver = stats.scope("status")
+  private[this] val timeReceiver = stats.scope("time")
+
+  private[this] val errorStat = timeReceiver.stat("error")
+
+  private[this] val statusCodeCounters =
+    Memoize { s: Status => statusReceiver.counter(s.code.toString) }
+
+  private[this] val statusClasses = (1 to 5).map(c => s"${c}XX").toIndexedSeq
+  private[this] val statusClassCounters = statusClasses.map(statusReceiver.counter(_))
+  private[this] val statusClassStats = statusClasses.map(timeReceiver.stat(_))
+
+  private[this] def count(rsp: Try[Response], duration: Long): Unit = rsp match {
+    case Throw(_) =>
+      errorStat.add(duration)
+
+    case Return(rsp) =>
+      statusCodeCounters(rsp.status).incr()
+
+      val classIdx = (rsp.statusCode / 100) - 1
+      statusClassCounters(classIdx).incr()
+      statusClassStats(classIdx).add(duration)
+  }
+
+  def apply(request: Request, service: Service[Request, Response]): Future[Response] = {
+    val stopwatch = Stopwatch.start()
+    service(request).respond { ret =>
+      count(ret, stopwatch().inMillis)
+    }
+  }
+
 }

--- a/linkerd/protocol/http/src/test/scala/io/buoyant/linkerd/protocol/http/StatusCodeStatsFilterTest.scala
+++ b/linkerd/protocol/http/src/test/scala/io/buoyant/linkerd/protocol/http/StatusCodeStatsFilterTest.scala
@@ -26,9 +26,7 @@ class StatusCodeStatsFilterTest extends FunSuite with Awaits {
     await(service(Request()))
     assert(stats.counters(Seq("status", "404")) == 1)
     assert(stats.counters(Seq("status", "4XX")) == 1)
-    assert(stats.stats.isDefinedAt(Seq("time", "404")))
     assert(stats.stats.isDefinedAt(Seq("time", "4XX")))
-    assert(stats.stats.isDefinedAt(Seq("response_size")))
   }
 
   test("treats exceptions as 500 failures") {
@@ -40,10 +38,7 @@ class StatusCodeStatsFilterTest extends FunSuite with Awaits {
     val service = await(stk.make(Stack.Params.empty + param.Stats(stats))())
 
     intercept[Throwable] { await(service(Request())) }
-    assert(stats.counters(Seq("status", "500")) == 1)
-    assert(stats.counters(Seq("status", "5XX")) == 1)
-    assert(stats.stats.isDefinedAt(Seq("time", "500")))
-    assert(stats.stats.isDefinedAt(Seq("time", "5XX")))
-    assert(stats.stats.isDefinedAt(Seq("response_size")))
+    assert(stats.counters(Seq("status", "error")) == 1)
+    assert(stats.stats.isDefinedAt(Seq("time", "error")))
   }
 }


### PR DESCRIPTION
Finagle's status stats module does not reuse counters and stats. Furthermore,
it provides a per-status latency histogram, which is pretty wasteful in the
typical case.

So, we memoize stats components; and we only track status-class latency
histograms.

Reported by @stevej.