### PR TITLE
Improve java compat for Namers

### DIFF
--- a/namer/core/src/main/scala/io/buoyant/namer/JNamer.scala
+++ b/namer/core/src/main/scala/io/buoyant/namer/JNamer.scala
@@ -1,0 +1,6 @@
+package io.buoyant.namer
+
+import com.twitter.finagle.Namer
+
+/** For better java compatibility */
+abstract class JNamer extends Namer

--- a/namer/core/src/main/scala/io/buoyant/namer/NamerInitializer.scala
+++ b/namer/core/src/main/scala/io/buoyant/namer/NamerInitializer.scala
@@ -23,7 +23,7 @@ import io.buoyant.config.ConfigInitializer
  */
 @JsonTypeInfo(use = JsonTypeInfo.Id.NAME, include = JsonTypeInfo.As.PROPERTY, property = "kind")
 @JsonAutoDetect(fieldVisibility = Visibility.PUBLIC_ONLY)
-trait NamerConfig {
+abstract class NamerConfig {
   @JsonProperty("prefix")
   var _prefix: Option[Path] = None
 


### PR DESCRIPTION
Since `Namer` is a trait, it is very difficult to extend in java which makes it difficult to write namer plugins in java.  We provide `JNamer` which is easier to extend from java as well as switching NamerConfig to an abstract class.

With these changes I was able to write a namer plugin in java. It was horrible, but possible.