### PR TITLE
Add a Client Stack Module to rewrite HTTP Host Header/Consul integration for it

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,6 +1,8 @@
 ## x.x.x
 
-* Add `resolve` endpoint to Namerd HTTP API 
+* Add `resolve` endpoint to Namerd HTTP API
+* Add `authority` metadata field to re-write HTTP host/:authority on demand
+* Add `setHost` parameter for Consul CatalogNamer to set `authority` metadata 
 * Add file-system based name interpreter.
 * Add auth `token` parameter to Consul Namer & Dtab Store
 

--- a/consul/src/main/scala/io/buoyant/consul/v1/AgentApi.scala
+++ b/consul/src/main/scala/io/buoyant/consul/v1/AgentApi.scala
@@ -1,0 +1,40 @@
+package io.buoyant.consul.v1
+
+import com.twitter.conversions.time._
+import com.twitter.finagle.http
+import com.twitter.finagle.service.Backoff
+import com.twitter.finagle.stats.{DefaultStatsReceiver, StatsReceiver}
+import com.twitter.util.{Closable, Duration, Future}
+
+object AgentApi {
+  def apply(c: Client): AgentApi = new AgentApi(c, s"/$versionString")
+}
+
+class AgentApi(
+  val client: Client,
+  val uriPrefix: String,
+  val backoffs: Stream[Duration] = Backoff.exponentialJittered(1.milliseconds, 5.seconds),
+  val stats: StatsReceiver = DefaultStatsReceiver
+) extends BaseApi with Closable {
+
+  val agentPrefix = s"$uriPrefix/agent"
+
+  // https://www.consul.io/docs/agent/http/agent.html#agent_self
+  def localAgent(retry: Boolean = false): Future[LocalAgent] = {
+    val req = mkreq(http.Method.Get, s"$agentPrefix/self")
+    executeJson[LocalAgent](req, retry).map(_.value)
+  }
+}
+
+// Classes below are used for JSON parsing hence field names case have to match the on in JSON
+
+// Represents configuration and member information of the local agent
+// For now only Config is parsed as other fields are unused
+case class LocalAgent(
+  Config: Option[Config] // configuration of the local agent stored under the Config key
+)
+
+// Represents configuration of the local agent
+case class Config(
+  Domain: Option[String] // TLD for DNS zone handled by consul, e.g. consul.acme.co.
+)

--- a/consul/src/main/scala/io/buoyant/consul/v1/BaseApi.scala
+++ b/consul/src/main/scala/io/buoyant/consul/v1/BaseApi.scala
@@ -37,7 +37,10 @@ trait BaseApi extends Closable {
   )
 
   def getClient(retry: Boolean) = {
-    val retryFilter = if (retry) infiniteRetryFilter else Filter.identity[http.Request, http.Response]
+    val retryFilter = if (retry)
+      infiniteRetryFilter
+    else
+      Filter.identity[http.Request, http.Response]
     retryFilter andThen apiErrorFilter andThen client
   }
 
@@ -61,7 +64,10 @@ trait BaseApi extends Closable {
     Try(mapper.readValue[T](bytes, begin, end - begin))
   }
 
-  private[v1] def executeJson[T: Manifest](req: http.Request, retry: Boolean): Future[Indexed[T]] = {
+  private[v1] def executeJson[T: Manifest](
+    req: http.Request,
+    retry: Boolean
+  ): Future[Indexed[T]] = {
     for {
       rsp <- Trace.letClear(getClient(retry)(req))
       value <- Future.const(parseJson[T](rsp.content))

--- a/consul/src/main/scala/io/buoyant/consul/v1/CatalogApi.scala
+++ b/consul/src/main/scala/io/buoyant/consul/v1/CatalogApi.scala
@@ -11,10 +11,10 @@ object CatalogApi {
 }
 
 class CatalogApi(
-  override val client: Client,
-  override val uriPrefix: String,
-  override val backoffs: Stream[Duration] = Backoff.exponentialJittered(1.milliseconds, 5.seconds),
-  override val stats: StatsReceiver = DefaultStatsReceiver
+  val client: Client,
+  val uriPrefix: String,
+  val backoffs: Stream[Duration] = Backoff.exponentialJittered(1.milliseconds, 5.seconds),
+  val stats: StatsReceiver = DefaultStatsReceiver
 ) extends BaseApi with Closable {
 
   val catalogPrefix = s"$uriPrefix/catalog"

--- a/consul/src/main/scala/io/buoyant/consul/v1/KvApi.scala
+++ b/consul/src/main/scala/io/buoyant/consul/v1/KvApi.scala
@@ -11,10 +11,10 @@ object KvApi {
 }
 
 class KvApi(
-  override val client: Client,
-  override val uriPrefix: String,
-  override val backoffs: Stream[Duration] = Backoff.exponentialJittered(1.milliseconds, 5.seconds),
-  override val stats: StatsReceiver = DefaultStatsReceiver
+  val client: Client,
+  val uriPrefix: String,
+  val backoffs: Stream[Duration] = Backoff.exponentialJittered(1.milliseconds, 5.seconds),
+  val stats: StatsReceiver = DefaultStatsReceiver
 ) extends BaseApi with Closable {
   val kvPrefix = s"$uriPrefix/kv"
 

--- a/consul/src/test/scala/io/buoyant/consul/v1/AgentApiTest.scala
+++ b/consul/src/test/scala/io/buoyant/consul/v1/AgentApiTest.scala
@@ -1,0 +1,32 @@
+package io.buoyant.consul.v1
+
+import com.twitter.conversions.time._
+import com.twitter.finagle.Service
+import com.twitter.finagle.http.{Request, Response}
+import com.twitter.io.Buf
+import com.twitter.util.Future
+import io.buoyant.test.{Awaits, Exceptions}
+import org.scalatest.FunSuite
+
+class AgentApiTest extends FunSuite with Awaits with Exceptions {
+  val localAgentBuf = Buf.Utf8("""{ "Config": { "Domain": "acme.co." } }""")
+  var lastUri = ""
+
+  override val defaultWait = 2.seconds
+
+  def stubService(buf: Buf) = Service.mk[Request, Response] { req =>
+    val rsp = Response()
+    rsp.setContentTypeJson()
+    rsp.content = buf
+    rsp.headerMap.set("X-Consul-Index", "4")
+    lastUri = req.uri
+    Future.value(rsp)
+  }
+
+  test("localAgent returns LocalAgent instance") {
+    val service = stubService(localAgentBuf)
+
+    val result = await(AgentApi(service).localAgent())
+    assert(result.Config.get.Domain.get == "acme.co.")
+  }
+}

--- a/linkerd/docs/namer.md
+++ b/linkerd/docs/namer.md
@@ -132,6 +132,12 @@ The Consul namer is configured with kind `io.l5d.consul`, and these parameters:
 * *port* --  the Consul port. (default: 8500)
 * *includeTag* -- whether to read a Consul tag from the path.  (default: false)
 * *token* -- Optional. The auth token to use when making API calls.
+* *setHost* --  if set to true (default: false) will instruct Linkerd
+                to override `Host` header value of forwarded HTTP
+                requests to `${name}.service.${datacenter}.${domain}`
+                when Consul concrete name is used to handle the request
+                (`$domain` fetched from Consul).
+
 
 For example:
 ```yaml
@@ -141,6 +147,7 @@ namers:
   host: 127.0.0.1
   port: 2181
   includeTag: true
+  setHost: true
 ```
 
 The default _prefix_ is `io.l5d.consul`.

--- a/linkerd/protocol/http/src/main/scala/io/buoyant/linkerd/protocol/HttpConfig.scala
+++ b/linkerd/protocol/http/src/main/scala/io/buoyant/linkerd/protocol/HttpConfig.scala
@@ -6,9 +6,9 @@ import com.twitter.conversions.storage._
 import com.twitter.finagle.{Path, Stack}
 import com.twitter.finagle.Http.{param => hparam}
 import com.twitter.finagle.buoyant.linkerd.{DelayedRelease, Headers, HttpTraceInitializer, HttpEngine}
-import com.twitter.finagle.client.StackClient
+import com.twitter.finagle.client.{AddrMetadataExtraction, StackClient}
 import com.twitter.finagle.service.Retries
-import io.buoyant.linkerd.protocol.http.{AccessLogger, ResponseClassifiers}
+import io.buoyant.linkerd.protocol.http.{RewriteHostHeader, AccessLogger, ResponseClassifiers}
 import io.buoyant.router.{Http, RoutingFactory}
 
 class HttpInitializer extends ProtocolInitializer.Simple {
@@ -28,6 +28,7 @@ class HttpInitializer extends ProtocolInitializer.Simple {
       .prepend(http.AccessLogger.module)
       .replace(HttpTraceInitializer.role, HttpTraceInitializer.clientModule)
       .insertAfter(Retries.Role, http.StatusCodeStatsFilter.module)
+      .insertAfter(AddrMetadataExtraction.Role, RewriteHostHeader.module)
       .insertAfter(StackClient.Role.prepConn, Headers.Ctx.clientModule)
 
     Http.router

--- a/linkerd/protocol/http/src/main/scala/io/buoyant/linkerd/protocol/http/RewriteHostHeader.scala
+++ b/linkerd/protocol/http/src/main/scala/io/buoyant/linkerd/protocol/http/RewriteHostHeader.scala
@@ -1,0 +1,29 @@
+package io.buoyant.linkerd.protocol.http
+
+import com.twitter.finagle.client.AddrMetadataExtraction.AddrMetadata
+import com.twitter.finagle.http.{Request, Response}
+import com.twitter.finagle.{Service, ServiceFactory, SimpleFilter, Stack}
+import io.buoyant.namer.Metadata
+
+object RewriteHostHeader {
+
+  case class Filter(host: String) extends SimpleFilter[Request, Response] {
+    def apply(req: Request, svc: Service[Request, Response]) = {
+      // TODO: switch between Host/:authority for HTTP1.1/2.0 when Finagle will support it
+      req.host = host
+      svc(req)
+    }
+  }
+
+  object module extends Stack.Module1[AddrMetadata, ServiceFactory[Request, Response]] {
+    val role = Stack.Role("RewriteHostHeader")
+    val description = "Rewrite request Host header according to concrete name metadata"
+
+    def make(param: AddrMetadata, next: ServiceFactory[Request, Response]) = {
+      param.metadata.get(Metadata.authority) match {
+        case Some(host: String) => Filter(host) andThen next
+        case _ => next
+      }
+    }
+  }
+}

--- a/linkerd/protocol/http/src/test/scala/io/buoyant/linkerd/protocol/http/RewriteHostHeaderTest.scala
+++ b/linkerd/protocol/http/src/test/scala/io/buoyant/linkerd/protocol/http/RewriteHostHeaderTest.scala
@@ -1,0 +1,47 @@
+package io.buoyant.linkerd.protocol.http
+
+import com.twitter.finagle._
+import com.twitter.finagle.client.AddrMetadataExtraction.AddrMetadata
+import com.twitter.finagle.http.{Status, _}
+import com.twitter.util.Future
+import io.buoyant.namer.Metadata
+import io.buoyant.test.Awaits
+import org.scalatest.FunSuite
+
+class RewriteHostHeaderTest extends FunSuite with Awaits {
+
+  def makeService(meta: Addr.Metadata) = {
+    val svc = Service.mk[Request, Response] { req =>
+      val rsp = Response()
+      rsp.status = Status.Ok
+      rsp.setContentString(req.host.get)
+      Future.value(rsp)
+    }
+
+    val stk = RewriteHostHeader.module.toStack(
+      Stack.Leaf(RewriteHostHeader.module.role, ServiceFactory.const(svc))
+    )
+
+    await(stk.make(Stack.Params.empty + AddrMetadata(meta))())
+  }
+
+  test("filter rewrites host header when authority meta present") {
+    val service = makeService(Addr.Metadata(Metadata.authority -> "acme.co"))
+
+    val req = Request(Method.Get, "/")
+    req.host = "monkeys"
+
+    val result = await(service(req))
+    assert(result.getContentString() == "acme.co")
+  }
+
+  test("filter doesn't rewrite host header normally") {
+    val service = makeService(Addr.Metadata.empty)
+
+    val req = Request(Method.Get, "/")
+    req.host = "monkeys"
+
+    val result = await(service(req))
+    assert(result.getContentString() == "monkeys")
+  }
+}

--- a/namer/consul/src/main/scala/io/buoyant/namer/consul/ConsulInitializer.scala
+++ b/namer/consul/src/main/scala/io/buoyant/namer/consul/ConsulInitializer.scala
@@ -1,12 +1,12 @@
 package io.buoyant.namer.consul
 
 import com.fasterxml.jackson.annotation.JsonIgnore
-import com.twitter.finagle.http.{Response, Request}
+import com.twitter.finagle.http.{Request, Response}
 import com.twitter.finagle.param.Label
 import com.twitter.finagle.tracing.NullTracer
 import com.twitter.finagle.{Filter, Http, Path, Stack}
-import io.buoyant.consul.{SetAuthTokenFilter, CatalogNamer, SetHostFilter, v1}
 import io.buoyant.config.types.Port
+import io.buoyant.consul.{SetAuthTokenFilter, SetHostFilter, v1}
 import io.buoyant.namer.{NamerConfig, NamerInitializer}
 
 /**
@@ -19,6 +19,7 @@ import io.buoyant.namer.{NamerConfig, NamerInitializer}
  *   host: consul.site.biz
  *   port: 8600
  *   includeTag: true
+ *   setHost: true
  * </pre>
  */
 class ConsulInitializer extends NamerInitializer {
@@ -32,7 +33,8 @@ case class ConsulConfig(
   host: Option[String],
   port: Option[Port],
   includeTag: Option[Boolean],
-  token: Option[String] = None
+  token: Option[String] = None,
+  setHost: Option[Boolean] = None
 ) extends NamerConfig {
 
   @JsonIgnore
@@ -65,6 +67,12 @@ case class ConsulConfig(
       .filtered(filters)
       .newService(s"/$$/inet/$getHost/$getPort")
 
-    new CatalogNamer(prefix, v1.CatalogApi(service), includeTag.getOrElse(false))
+    new CatalogNamer(
+      prefix,
+      v1.CatalogApi(service),
+      v1.AgentApi(service),
+      includeTag = includeTag.getOrElse(false),
+      setHost = setHost.getOrElse(false)
+    )
   }
 }

--- a/namer/consul/src/test/scala/io/buoyant/namer/consul/CatalogNamerTest.scala
+++ b/namer/consul/src/test/scala/io/buoyant/namer/consul/CatalogNamerTest.scala
@@ -1,9 +1,10 @@
-package io.buoyant.consul.v1
+package io.buoyant.namer.consul
 
 import com.twitter.finagle._
 import com.twitter.io.Buf
 import com.twitter.util.{Activity, Future, Promise}
-import io.buoyant.consul.CatalogNamer
+import io.buoyant.consul.v1._
+import io.buoyant.namer.Metadata
 import io.buoyant.test.Awaits
 import org.scalatest.FunSuite
 
@@ -20,24 +21,37 @@ class CatalogNamerTest extends FunSuite with Awaits {
     Some(8080)
   )
 
-  def assertOnAddrs(state: Activity.State[NameTree[Name]])(f: Set[Address] => Unit) = state match {
+  def assertOnAddrs(
+    state: Activity.State[NameTree[Name]]
+  )(f: (Set[Address], Addr.Metadata) => Unit) = state match {
     case Activity.Ok(NameTree.Leaf(bound: Name.Bound)) =>
       bound.addr.sample() match {
-        case Addr.Bound(addrs, metadata) => f(addrs)
+        case Addr.Bound(addrs, metadata) => f(addrs, metadata)
         case _ => assert(false)
       }
     case _ => assert(false)
   }
 
+  class TestAgentApi(domain: String) extends AgentApi(null, "/v1") {
+    override def localAgent(retry: Boolean): Future[LocalAgent] =
+      Future.value(LocalAgent(Config = Some(Config(Domain = Some(domain)))))
+  }
+
   test("Namer stays pending while looking up datacenter for the first time") {
-    class TestApi extends CatalogApi(null, "/v1") {
+    class TestCatalogApi extends CatalogApi(null, "/v1") {
       override def serviceMap(
         datacenter: Option[String] = None,
         blockingIndex: Option[String] = None,
         retry: Boolean = false
       ): Future[Indexed[Map[String, Seq[String]]]] = Future.never
     }
-    val namer = new CatalogNamer(testPath, new TestApi())
+    val namer = new CatalogNamer(
+      testPath,
+      new TestCatalogApi(),
+      new TestAgentApi("acme.co"),
+      includeTag = false,
+      setHost = false
+    )
     @volatile var state: Activity.State[NameTree[Name]] = Activity.Pending
 
     namer.lookup(Path.read("/dc1/servicename/residual")).states respond { state = _ }
@@ -53,7 +67,7 @@ class CatalogNamerTest extends FunSuite with Awaits {
         retry: Boolean = false
       ): Future[Indexed[Map[String, Seq[String]]]] = Future.exception(ChannelWriteException(null))
     }
-    val namer = new CatalogNamer(testPath, new TestApi())
+    val namer = new CatalogNamer(testPath, new TestApi(), new TestAgentApi("acme.co"), false, false)
     @volatile var state: Activity.State[NameTree[Name]] = Activity.Pending
 
     namer.lookup(Path.read("/dc1/servicename/residual")).states respond { state = _ }
@@ -83,7 +97,7 @@ class CatalogNamerTest extends FunSuite with Awaits {
         case _ => Future.never //don't respond to blocking index calls
       }
     }
-    val namer = new CatalogNamer(testPath, new TestApi())
+    val namer = new CatalogNamer(testPath, new TestApi(), new TestAgentApi("acme.co"), false, false)
     @volatile var state: Activity.State[NameTree[Name]] = Activity.Pending
 
     namer.lookup(Path.read("/nosuchdc/servicename/residual")).states respond { state = _ }
@@ -113,7 +127,7 @@ class CatalogNamerTest extends FunSuite with Awaits {
         case _ => Future.never //don't respond to blocking index calls
       }
     }
-    val namer = new CatalogNamer(testPath, new TestApi())
+    val namer = new CatalogNamer(testPath, new TestApi(), new TestAgentApi("acme.co"), false, false)
     @volatile var state: Activity.State[NameTree[Name]] = Activity.Pending
 
     namer.lookup(Path.read("/dc1/nosuchservice/residual")).states respond { state = _ }
@@ -148,14 +162,16 @@ class CatalogNamerTest extends FunSuite with Awaits {
         case _ => Future.never //don't respond to blocking index calls
       }
     }
-    val namer = new CatalogNamer(testPath, new TestApi())
+    val namer = new CatalogNamer(testPath, new TestApi(), new TestAgentApi("acme.co"), false, false)
     @volatile var state: Activity.State[NameTree[Name]] = Activity.Pending
 
     namer.lookup(Path.read("/dc1/servicename/residual")).states respond { state = _ }
 
     assert(state == Activity.Ok(NameTree.Neg))
     blockingCallResponder.setDone()
-    assert(state == Activity.Ok(NameTree.Leaf(Path(Buf.Utf8("test"), Buf.Utf8("dc1"), Buf.Utf8("servicename")))))
+    assert(state == Activity.Ok(
+      NameTree.Leaf(Path(Buf.Utf8("test"), Buf.Utf8("dc1"), Buf.Utf8("servicename")))
+    ))
   }
 
   test("Namer returns leaf with bound addr when serviceNodes exist") {
@@ -178,16 +194,23 @@ class CatalogNamerTest extends FunSuite with Awaits {
         blockingIndex: Option[String] = None,
         retry: Boolean = false
       ): Future[Indexed[Seq[ServiceNode]]] = blockingIndex match {
-        case Some("0") | None => Future.value(Indexed[Seq[ServiceNode]](Seq(testServiceNode), Some("1")))
-        case _ => Future.never //don't respond to blocking index calls
+        case Some("0") | None =>
+          Future.value(Indexed[Seq[ServiceNode]](Seq(testServiceNode), Some("1")))
+        case _ => Future.never // don't respond to blocking index calls
       }
     }
 
-    val namer = new CatalogNamer(Path.read("/test"), new TestApi())
+    val namer = new CatalogNamer(
+      Path.read("/test"),
+      new TestApi(),
+      new TestAgentApi("acme.co"),
+      includeTag = false,
+      setHost = false
+    )
     @volatile var state: Activity.State[NameTree[Name]] = Activity.Pending
     namer.lookup(Path.read("/dc1/servicename/residual")).states respond { state = _ }
 
-    assertOnAddrs(state) { addrs =>
+    assertOnAddrs(state) { (addrs, _) =>
       assert(addrs.size == 1)
       assert(addrs.head.toString.contains("192.168.1.35:8080"))
     }
@@ -215,17 +238,25 @@ class CatalogNamerTest extends FunSuite with Awaits {
         blockingIndex: Option[String] = None,
         retry: Boolean = false
       ): Future[Indexed[Seq[ServiceNode]]] = blockingIndex match {
-        case Some("0") | None => Future.value(Indexed[Seq[ServiceNode]](Seq(testServiceNode), Some("1")))
-        case Some("1") => blockingCallResponder before Future.value(Indexed[Seq[ServiceNode]](Seq.empty, Some("2")))
+        case Some("0") | None =>
+          Future.value(Indexed[Seq[ServiceNode]](Seq(testServiceNode), Some("1")))
+        case Some("1") =>
+          blockingCallResponder before Future.value(Indexed[Seq[ServiceNode]](Seq.empty, Some("2")))
         case _ => Future.never
       }
     }
 
-    val namer = new CatalogNamer(Path.read("/test"), new TestApi())
+    val namer = new CatalogNamer(
+      Path.read("/test"),
+      new TestApi(),
+      new TestAgentApi("acme.co"),
+      includeTag = false,
+      setHost = false
+    )
     @volatile var state: Activity.State[NameTree[Name]] = Activity.Pending
     namer.lookup(Path.read("/dc1/servicename/residual")).states respond { state = _ }
 
-    assertOnAddrs(state) { addrs => assert(addrs.size == 1) }
+    assertOnAddrs(state) { (addrs, _) => assert(addrs.size == 1) }
 
     blockingCallResponder.setDone()
 
@@ -236,6 +267,52 @@ class CatalogNamerTest extends FunSuite with Awaits {
   }
 
   test("Namer filters by tag") {
+    class TestApi extends CatalogApi(null, "/v1") {
+      override def serviceMap(
+        datacenter: Option[String] = None,
+        blockingIndex: Option[String] = None,
+        retry: Boolean = false
+      ): Future[Indexed[Map[String, Seq[String]]]] = blockingIndex match {
+        case Some("0") | None =>
+          val rsp = Map("consul" -> Seq(), "servicename" -> Seq("master", "staging"))
+          Future.value(Indexed(rsp, Some("1")))
+        case _ => Future.never // don't respond to blocking index calls
+      }
+
+      override def serviceNodes(
+        serviceName: String,
+        datacenter: Option[String],
+        tag: Option[String] = None,
+        blockingIndex: Option[String] = None,
+        retry: Boolean = false
+      ): Future[Indexed[Seq[ServiceNode]]] = blockingIndex match {
+        case Some("0") | None =>
+          tag match {
+            case Some("master") =>
+              Future.value(Indexed[Seq[ServiceNode]](Seq(testServiceNode), Some("1")))
+            case _ => Future.value(Indexed(Nil, Some("1")))
+          }
+        case _ => Future.never // don't respond to blocking index calls
+      }
+    }
+
+    val namer = new CatalogNamer(
+      Path.read("/test"),
+      new TestApi(),
+      new TestAgentApi("acme.co"),
+      includeTag = true,
+      setHost = false
+    )
+    @volatile var state: Activity.State[NameTree[Name]] = Activity.Pending
+    namer.lookup(Path.read("/dc1/master/servicename/residual")).states respond { state = _ }
+
+    assertOnAddrs(state) { (addrs, _) =>
+      assert(addrs.size == 1)
+      assert(addrs.head.toString.contains("192.168.1.35:8080"))
+    }
+  }
+
+  test("Namer returns authority in bound address metadata when setHost is true") {
     class TestApi extends CatalogApi(null, "/v1") {
       override def serviceMap(
         datacenter: Option[String] = None,
@@ -257,20 +334,26 @@ class CatalogNamerTest extends FunSuite with Awaits {
       ): Future[Indexed[Seq[ServiceNode]]] = blockingIndex match {
         case Some("0") | None =>
           tag match {
-            case Some("master") => Future.value(Indexed[Seq[ServiceNode]](Seq(testServiceNode), Some("1")))
+            case Some("master") =>
+              Future.value(Indexed[Seq[ServiceNode]](Seq(testServiceNode), Some("1")))
             case _ => Future.value(Indexed(Nil, Some("1")))
           }
         case _ => Future.never //don't respond to blocking index calls
       }
     }
 
-    val namer = new CatalogNamer(Path.read("/test"), new TestApi(), includeTag = true)
+    val namer = new CatalogNamer(
+      Path.read("/test"),
+      new TestApi(),
+      new TestAgentApi("consul.acme.co"),
+      includeTag = true,
+      setHost = true
+    )
     @volatile var state: Activity.State[NameTree[Name]] = Activity.Pending
     namer.lookup(Path.read("/dc1/master/servicename/residual")).states respond { state = _ }
 
-    assertOnAddrs(state) { addrs =>
-      assert(addrs.size == 1)
-      assert(addrs.head.toString.contains("192.168.1.35:8080"))
+    assertOnAddrs(state) { (_, metadata) =>
+      assert(metadata == Addr.Metadata(Metadata.authority -> "servicename.service.dc1.consul.acme.co"))
     }
   }
 }

--- a/namer/consul/src/test/scala/io/buoyant/namer/consul/ConsulTest.scala
+++ b/namer/consul/src/test/scala/io/buoyant/namer/consul/ConsulTest.scala
@@ -11,20 +11,35 @@ class ConsulTest extends FunSuite {
 
   test("sanity") {
     // ensure it doesn't totally blowup
-    val _ = ConsulConfig(None, None, None).newNamer(Stack.Params.empty)
+    val _ = ConsulConfig(None, None, None, None).newNamer(Stack.Params.empty)
   }
 
   test("service registration") {
     assert(LoadService[NamerInitializer]().exists(_.isInstanceOf[ConsulInitializer]))
   }
 
-  test("parse config") {
+  test("parse minimal config") {
+    val yaml = s"""
+                  |kind: io.l5d.consul
+                  |experimental: true
+      """.stripMargin
+
+    val mapper = Parser.objectMapper(yaml, Iterable(Seq(ConsulInitializer)))
+    val consul = mapper.readValue[NamerConfig](yaml).asInstanceOf[ConsulConfig]
+    assert(consul.setHost.isEmpty)
+    assert(consul.includeTag.isEmpty)
+    assert(!consul.disabled)
+  }
+
+  test("parse all options config") {
     val yaml = s"""
                     |kind: io.l5d.consul
                     |experimental: true
                     |host: consul.site.biz
-                    |token: some-token
                     |port: 8600
+                    |token: some-token
+                    |includeTag: true
+                    |setHost: true
       """.stripMargin
 
     val mapper = Parser.objectMapper(yaml, Iterable(Seq(ConsulInitializer)))
@@ -32,6 +47,8 @@ class ConsulTest extends FunSuite {
     assert(consul.host == Some("consul.site.biz"))
     assert(consul.port == Some(Port(8600)))
     assert(consul.token == Some("some-token"))
+    assert(consul.setHost == Some(true))
+    assert(consul.includeTag == Some(true))
     assert(!consul.disabled)
   }
 

--- a/namer/core/src/main/scala/io/buoyant/namer/Metadata.scala
+++ b/namer/core/src/main/scala/io/buoyant/namer/Metadata.scala
@@ -1,0 +1,5 @@
+package io.buoyant.namer
+
+object Metadata {
+  val authority = "authority" // HTTP/1.1 Host or HTTP/2.0 :authority
+}

--- a/namerd/iface/interpreter-thrift-idl/src/main/thrift/namer.thrift
+++ b/namerd/iface/interpreter-thrift-idl/src/main/thrift/namer.thrift
@@ -81,6 +81,7 @@ struct AddrReq {
 }
 
 struct AddrMeta {
+  1: optional string authority // HTTP/1.1 Host or HTTP/2.0 :authority
 }
 
 struct TransportAddress {

--- a/namerd/iface/interpreter-thrift/src/test/scala/io/buoyant/namerd/iface/ThriftNamerClientTest.scala
+++ b/namerd/iface/interpreter-thrift/src/test/scala/io/buoyant/namerd/iface/ThriftNamerClientTest.scala
@@ -3,7 +3,7 @@ package io.buoyant.namerd.iface
 import com.twitter.conversions.time._
 import com.twitter.finagle._
 import com.twitter.util._
-import io.buoyant.namer.DelegateTree
+import io.buoyant.namer.{Metadata, DelegateTree}
 import io.buoyant.namerd.iface.{thriftscala => thrift}
 import io.buoyant.test.Awaits
 import java.net.{InetAddress, InetSocketAddress}
@@ -181,12 +181,14 @@ class ThriftNamerClientTest extends FunSuite with Awaits {
             }
             addrPromise.setValue(thrift.Addr(
               TStamp.mk(2),
-              thrift.AddrVal.Bound(thrift.BoundAddr(ips))
+              thrift.AddrVal.Bound(
+                thrift.BoundAddr(ips, Some(thrift.AddrMeta(Some("acme.co"))))
+              )
             ))
             val addrs = tidalIps.map { ip =>
               Address(new InetSocketAddress(ip, 80))
             }
-            assert(addr == Addr.Bound(addrs.toSet))
+            assert(addr == Addr.Bound(addrs.toSet, Addr.Metadata(Metadata.authority -> "acme.co")))
 
             service.addrsMu.synchronized {
               val key = (tidalPath, TStamp.mk(2))


### PR DESCRIPTION
This PR introduces following features:
1) Consul Catalog Namer now has an extra option `domain` - when set it makes it to embed `l5d-http-host` meta field with value `$name.service.$dc.$domain` into `Addr.Bound`
2) Namerd Thrift Interface/Client now can pass around `Addr.Metadata` for `Addr.Bound` and `Addr.Inet` but only those with values of `String` type
3) `clientStack` within `io.buoyant.linkerd.protocol.HttpInitializer#defaultRouter` now includes `RewriteHostHeader` module that rewrites outgoing request's `Host` header but only if `l5d-http-host` meta field is present within `Addr.Bound` metadata

All changes are covered with tests.