### PR TITLE
HTTP Router module to discard proxy side-effects

### DIFF
--- a/router/http/src/main/scala/io/buoyant/router/Http.scala
+++ b/router/http/src/main/scala/io/buoyant/router/Http.scala
@@ -6,7 +6,7 @@ import com.twitter.finagle.param.ProtocolLibrary
 import com.twitter.finagle.server.StackServer
 import com.twitter.finagle.{Http => FinagleHttp, Server => FinagleServer, http => fhttp, _}
 import io.buoyant.router.Http.param.HttpIdentifier
-import io.buoyant.router.http.{ForwardedFilter, MethodAndHostIdentifier, StripConnectionHeader}
+import io.buoyant.router.http.{DiscardProxySideEffects, ForwardedFilter, MethodAndHostIdentifier, StripConnectionHeader}
 import java.net.SocketAddress
 
 object Http extends Router[Request, Response] with FinagleServer[Request, Response] {
@@ -69,6 +69,7 @@ object Http extends Router[Request, Response] with FinagleServer[Request, Respon
   object Server {
     val stack: Stack[ServiceFactory[Request, Response]] =
       (ForwardedFilter.module +: FinagleHttp.Server.stack)
+        .insertBefore(http.TracingFilter.role, DiscardProxySideEffects.module)
 
     val defaultParams: Stack.Params =
       StackServer.defaultParams +

--- a/router/http/src/main/scala/io/buoyant/router/http/DiscardProxySideEffects.scala
+++ b/router/http/src/main/scala/io/buoyant/router/http/DiscardProxySideEffects.scala
@@ -1,0 +1,39 @@
+package io.buoyant.router.http
+
+import com.twitter.finagle.http.{Request, Response}
+import com.twitter.finagle.{Service, ServiceFactory, SimpleFilter, Stack}
+import java.net.URI
+
+object DiscardProxySideEffects {
+
+  /**
+   * Strips host from request URI and drops Proxy-* headers
+   * Those side-effects are added by proxy-aware clients
+   */
+  class DiscardProxySideEffects extends SimpleFilter[Request, Response] {
+    def apply(req: Request, svc: Service[Request, Response]) = {
+      val uri = new URI(req.uri)
+
+      if (uri.isAbsolute) { // Proxied request
+        // TODO: HTTP/2.0 support once finagle supports it
+        val relativeUri = new URI(null, null, uri.getRawPath, uri.getRawQuery, uri.getRawFragment)
+        req.host = uri.getAuthority
+        req.uri = relativeUri.toString
+      }
+
+      req.headerMap.retain { (k, v) => !k.startsWith("Proxy-") }
+      svc(req)
+    }
+  }
+
+  object DiscardProxySideEffects {
+    def apply() = new DiscardProxySideEffects()
+  }
+
+  object module extends Stack.Module0[ServiceFactory[Request, Response]] {
+    val role = Stack.Role("DiscardProxySideEffects")
+    val description = "Strips host from request URI and drops Proxy-* headers"
+    def make(next: ServiceFactory[Request, Response]) =
+      DiscardProxySideEffects() andThen next
+  }
+}

--- a/router/http/src/test/scala/io/buoyant/router/http/DiscardProxySideEffectsTest.scala
+++ b/router/http/src/test/scala/io/buoyant/router/http/DiscardProxySideEffectsTest.scala
@@ -1,0 +1,64 @@
+package io.buoyant.router.http
+
+import com.twitter.finagle._
+import com.twitter.finagle.http.{Status, _}
+import com.twitter.util.Future
+import io.buoyant.test.Awaits
+import org.scalatest.FunSuite
+
+class DiscardProxySideEffectsTest extends FunSuite with Awaits {
+
+  def service: Service[Request, Response] = {
+    val svc = Service.mk[Request, Response] { req =>
+      val rsp = Response()
+      rsp.status = Status.Ok
+      rsp.setContentString(req.uri)
+      rsp.headerMap ++= req.headerMap
+      Future.value(rsp)
+    }
+
+    val stk = DiscardProxySideEffects.module.toStack(
+      Stack.Leaf(DiscardProxySideEffects.module.role, ServiceFactory.const(svc))
+    )
+
+    await(stk.make(Stack.Params.empty)())
+  }
+
+  test("filter rewrites uri and drops Proxy-* headers for proxied requests") {
+    val req = Request(Method.Get, "http://acme.co:8080/foo;matrix=uri;/bar?x=1&y=2")
+    req.host = "example.com:9000"
+    req.headerMap.set("Proxy-Connection", "Keep-Alive")
+    req.headerMap.set("Proxy-Authorization", "Basic QWxhZGRpbjpvcGVuIHNlc2FtZQ==")
+    req.headerMap.set("Proxy-Authenticate", "Basic")
+    req.headerMap.set("Proxy-Foo", "Bar")
+    req.headerMap.set("Pragma", "42")
+
+    val result = await(service(req))
+    assert(result.getContentString() == "/foo;matrix=uri;/bar?x=1&y=2")
+    assert(
+      result.headerMap.toSet == Set(
+        ("Host", "acme.co:8080"),
+        ("Pragma", "42")
+      )
+    )
+  }
+
+  test("filter drop Proxy-* Headers even for requests that doesn't look like proxied") {
+    val req = Request(Method.Get, "/foo;matrix=uri;/bar?x=1&y=2")
+    req.host = "acme.co:8080"
+    req.headerMap.set("Proxy-Connection", "Keep-Alive")
+    req.headerMap.set("Proxy-Authorization", "Basic QWxhZGRpbjpvcGVuIHNlc2FtZQ==")
+    req.headerMap.set("Proxy-Authenticate", "Basic")
+    req.headerMap.set("Proxy-Foo", "Bar")
+    req.headerMap.set("Pragma", "42")
+
+    val result = await(service(req))
+    assert(result.getContentString() == "/foo;matrix=uri;/bar?x=1&y=2")
+    assert(
+      result.headerMap.toSet == Set(
+        ("Host", "acme.co:8080"),
+        ("Pragma", "42")
+      )
+    )
+  }
+}


### PR DESCRIPTION
* Strip host from URI
* Drop `Proxy-*` requests

Request considered being proxied if its URI is absolute