### PR TITLE
linkerd docker image now on 32-bit JVM

### DIFF
--- a/README.md
+++ b/README.md
@@ -247,6 +247,12 @@ the following command:
 $ docker run -p 4140:4140 -p 9990:9990 -v /absolute/path/to/myapp:/myapp buoyantio/linkerd:0.0.10-SNAPSHOT /myapp/linkerd.yml
 ```
 
+For local testing convenience, we supply a config that routes to a single backend on _localhost:8080_.
+
+```
+$ docker run -p 4140:4140 -p 9990:9990 -v /path/to/linkerd/linkerd/examples:/config buoyantio/linkerd:0.7.1-SNAPSHOT /config/static_namer.yaml
+```
+
 The list of image names may be changed with a command like:
 
 ```

--- a/linkerd/examples/static_namer.yaml
+++ b/linkerd/examples/static_namer.yaml
@@ -1,0 +1,9 @@
+# Routes 'default' to a single backend on localhost:8080
+routers:
+- protocol: http
+  baseDtab: |
+    /host/default => /$/inet/127.0.0.1/8080;
+    /http => /host/default;
+  servers:
+  - port: 4140
+    ip: 0.0.0.0

--- a/project/Base.scala
+++ b/project/Base.scala
@@ -123,7 +123,7 @@ class Base extends Build {
 
     docker <<= docker dependsOn (assembly in configuration),
     dockerEnvPrefix := "",
-    dockerJavaImage := "library/java:openjdk-8-jre",
+    dockerJavaImage := "buoyantio/debian-32-bit",
     dockerfile in docker := new Dockerfile {
       val envPrefix = dockerEnvPrefix.value.toUpperCase
       val home = s"/${organization.value}/${name.value}/${version.value}"


### PR DESCRIPTION
* Moves linkerd to the debian 32-bit docker image
* adds a static namer example for even easier local testing
* Updates README to point people towards the simple static_namer config for convenience