### PR TITLE
Optional recursive fetch strategy in ConsulDtabStore

### DIFF
--- a/consul/src/main/scala/io/buoyant/consul/v1/BaseApi.scala
+++ b/consul/src/main/scala/io/buoyant/consul/v1/BaseApi.scala
@@ -61,17 +61,11 @@ trait BaseApi extends Closable {
     Try(mapper.readValue[T](bytes, begin, end - begin))
   }
 
-  private[v1] def executeJson[T: Manifest](req: http.Request, retry: Boolean): Future[Indexed[T]] = {
+  private[v1] def execute[T: Manifest](req: http.Request, retry: Boolean): Future[Indexed[T]] = {
     for {
       rsp <- Trace.letClear(getClient(retry)(req))
       value <- Future.const(parseJson[T](rsp.content))
     } yield Indexed[T](value, rsp.headerMap.get(Headers.Index))
-  }
-
-  private[v1] def executeRaw(req: http.Request, retry: Boolean): Future[Indexed[String]] = {
-    Trace.letClear(getClient(retry)(req)).map { rsp =>
-      Indexed[String](rsp.contentString, rsp.headerMap.get(Headers.Index))
-    }
   }
 }
 

--- a/consul/src/main/scala/io/buoyant/consul/v1/CatalogApi.scala
+++ b/consul/src/main/scala/io/buoyant/consul/v1/CatalogApi.scala
@@ -22,7 +22,7 @@ class CatalogApi(
   // https://www.consul.io/docs/agent/http/catalog.html#catalog_datacenters
   def datacenters(retry: Boolean = false): Future[Seq[String]] = {
     val req = mkreq(http.Method.Get, s"$catalogPrefix/datacenters")
-    executeJson[Seq[String]](req, retry).map(_.value)
+    execute[Seq[String]](req, retry).map(_.value)
   }
 
   // https://www.consul.io/docs/agent/http/catalog.html#catalog_services
@@ -37,7 +37,7 @@ class CatalogApi(
       "index" -> blockingIndex,
       "dc" -> datacenter
     )
-    executeJson[Map[String, Seq[String]]](req, retry)
+    execute[Map[String, Seq[String]]](req, retry)
   }
 
   // https://www.consul.io/docs/agent/http/catalog.html#catalog_service
@@ -55,7 +55,7 @@ class CatalogApi(
       "dc" -> datacenter,
       "tag" -> tag
     )
-    executeJson[Seq[ServiceNode]](req, retry)
+    execute[Seq[ServiceNode]](req, retry)
   }
 }
 

--- a/consul/src/test/scala/io/buoyant/consul/v1/KvApiV1Test.scala
+++ b/consul/src/test/scala/io/buoyant/consul/v1/KvApiV1Test.scala
@@ -8,11 +8,14 @@ import com.twitter.util.Future
 import io.buoyant.test.{Awaits, Exceptions}
 import org.scalatest.FunSuite
 
-class KvApiTest extends FunSuite with Awaits with Exceptions {
+class KvApiV1Test extends FunSuite with Awaits with Exceptions {
   val listBuf = Buf.Utf8("""["foo/bar/", "foo/baz/"]""")
-  val getBuf = Buf.Utf8("""foobar""")
+  val getBuf = Buf.Utf8("""[{"LockIndex":0,"Key":"sample","Flags":0,"Value":"Zm9vYmFy","CreateIndex":10,"ModifyIndex":12}]""")
   val putOkBuf = Buf.Utf8("""true""")
   val putFailBuf = Buf.Utf8("""false""")
+  val deleteOkBuf = Buf.Utf8("""true""")
+  val deleteFailBuf = Buf.Utf8("""false""")
+
   var lastUri = ""
 
   override val defaultWait = 2.seconds
@@ -29,7 +32,7 @@ class KvApiTest extends FunSuite with Awaits with Exceptions {
   test("list returns an indexed seq of key names") {
     val service = stubService(listBuf)
 
-    val result = await(KvApi(service).list("/foo/"))
+    val result = await(KvApiV1(service).list("/foo/"))
 
     assert(result.index == Some("4"))
     assert(result.value.size == 2)
@@ -45,23 +48,52 @@ class KvApiTest extends FunSuite with Awaits with Exceptions {
       Future.value(rsp)
     }
     assertThrows[NotFound](
-      await(KvApi(failureService).list("/wrong/path/"))
+      await(KvApiV1(failureService).list("/wrong/path/"))
     )
   }
 
-  test("get returns an indexed value") {
-    val service = stubService(getBuf)
+  test("list doesn't set separator by default") {
+    val service = stubService(listBuf)
 
-    val result = await(KvApi(service).get("/some/path/to/key"))
-    assert(result.index == Some("4"))
-    assert(result.value == "foobar")
+    await(KvApiV1(service).list("/foo/"))
+    assert(!lastUri.contains("separator"))
   }
 
-  test("get uses raw values") {
-    val service = stubService(putFailBuf)
+  test("list sets separator if given") {
+    val service = stubService(listBuf)
 
-    await(KvApi(service).get("/path/to/key"))
-    assert(lastUri.contains(s"raw=true"))
+    await(KvApiV1(service).list("/foo/", separator = Some("/")))
+    assert(lastUri.contains("separator"))
+  }
+
+  test("get returns an indexed seq of values") {
+    val service = stubService(getBuf)
+
+    val result = await(KvApiV1(service).get("/sample"))
+    assert(result.index == Some("4"))
+    assert(result.value.size == 1)
+    assert(result.value.head.DecodedValue == Some("foobar"))
+  }
+
+  test("get by default is non-recurse") {
+    val service = stubService(getBuf)
+
+    await(KvApiV1(service).get("/path/to/key"))
+    assert(!lastUri.contains("recurse"))
+  }
+
+  test("get with recurse set to true adds a recurse parameter") {
+    val service = stubService(getBuf)
+
+    await(KvApiV1(service).get("/path/to/key", recurse = true))
+    assert(lastUri.contains("recurse"))
+  }
+
+  test("get with recurse set to false doesn't add recurse parameter") {
+    val service = stubService(getBuf)
+
+    await(KvApiV1(service).get("/path/to/key", recurse = false))
+    assert(!lastUri.contains("recurse"))
   }
 
   test("get reports wrong paths with an error") {
@@ -73,63 +105,84 @@ class KvApiTest extends FunSuite with Awaits with Exceptions {
       Future.value(rsp)
     }
     assertThrows[NotFound](
-      await(KvApi(failureService).get("/wrong/path"))
+      await(KvApiV1(failureService).get("/wrong/path"))
     )
   }
 
   test("put returns true on success") {
     val service = stubService(putOkBuf)
 
-    val result = await(KvApi(service).put("/path/to/key", "foobar"))
+    val result = await(KvApiV1(service).put("/path/to/key", "foobar"))
     assert(result)
   }
 
   test("put returns false on failure") {
     val service = stubService(putFailBuf)
 
-    val result = await(KvApi(service).put("/path/to/key", "foobar"))
+    val result = await(KvApiV1(service).put("/path/to/key", "foobar"))
     assert(!result)
   }
 
   test("put cas flag") {
     val service = stubService(putFailBuf)
 
-    await(KvApi(service).put("/path/to/key", "foobar", cas = Some("0")))
+    await(KvApiV1(service).put("/path/to/key", "foobar", cas = Some("0")))
     assert(lastUri.contains(s"cas=0"))
 
-    await(KvApi(service).put("/path/to/key", "foobar"))
+    await(KvApiV1(service).put("/path/to/key", "foobar"))
     assert(!lastUri.contains(s"cas"))
   }
 
   test("delete returns true on success") {
-    val service = stubService(putOkBuf)
+    val service = stubService(deleteOkBuf)
 
-    val result = await(KvApi(service).delete("/path/to/key"))
+    val result = await(KvApiV1(service).delete("/path/to/key"))
     assert(result)
   }
 
   test("delete returns false on failure") {
     val service = stubService(putFailBuf)
 
-    val result = await(KvApi(service).delete("/path/to/key"))
+    val result = await(KvApiV1(service).delete("/path/to/key"))
     assert(!result)
   }
 
   test("delete cas flag") {
-    val service = stubService(putFailBuf)
+    val service = stubService(deleteFailBuf)
 
-    await(KvApi(service).delete("/path/to/key", cas = Some("0")))
+    await(KvApiV1(service).delete("/path/to/key", cas = Some("0")))
     assert(lastUri.contains(s"cas=0"))
 
-    await(KvApi(service).delete("/path/to/key"))
+    await(KvApiV1(service).delete("/path/to/key"))
     assert(!lastUri.contains(s"cas"))
+  }
+
+  test("delete by default is non-recurse") {
+    val service = stubService(deleteOkBuf)
+
+    await(KvApiV1(service).delete("/path/to/key"))
+    assert(!lastUri.contains("recurse"))
+  }
+
+  test("delete with recurse set to true adds a recurse parameter") {
+    val service = stubService(deleteOkBuf)
+
+    await(KvApiV1(service).delete("/path/to/key", recurse = true))
+    assert(lastUri.contains("recurse"))
+  }
+
+  test("delete with recurse set to false doesn't add recurse parameter") {
+    val service = stubService(deleteOkBuf)
+
+    await(KvApiV1(service).delete("/path/to/key", recurse = false))
+    assert(!lastUri.contains("recurse"))
   }
 
   test("blocking index returned from one call can be used to set index on subsequent calls") {
     val service = stubService(getBuf)
-    val index = await(KvApi(service).get("/some/path")).index.get
+    val index = await(KvApiV1(service).get("/some/path")).index.get
 
-    await(KvApi(service).get("/some/path", blockingIndex = Some(index)))
+    await(KvApiV1(service).get("/some/path", blockingIndex = Some(index)))
     assert(lastUri.contains(s"index=$index"))
   }
 
@@ -138,7 +191,7 @@ class KvApiTest extends FunSuite with Awaits with Exceptions {
       Future.exception(new Exception("I have no idea who to talk to"))
     }
     assertThrows[Exception](
-      await(KvApi(failureService).list("/foo/"))
+      await(KvApiV1(failureService).list("/foo/"))
     )
   }
 
@@ -156,7 +209,7 @@ class KvApiTest extends FunSuite with Awaits with Exceptions {
         Future.exception(new Exception("I have no idea who to talk to"))
       }
     }
-    val result = await(KvApi(failureService).list("/some/path/", retry = true))
+    val result = await(KvApiV1(failureService).list("/some/path/", retry = true))
     assert(result.index == Some("4"))
     assert(result.value == List("foo/bar/", "foo/baz/"))
   }
@@ -172,7 +225,7 @@ class KvApiTest extends FunSuite with Awaits with Exceptions {
     }
 
     assertThrows[UnexpectedResponse](
-      await(KvApi(failureService).list("/some/path/", datacenter = Some("non-existent dc")))
+      await(KvApiV1(failureService).list("/some/path/", datacenter = Some("non-existent dc")))
     )
   }
 
@@ -184,7 +237,7 @@ class KvApiTest extends FunSuite with Awaits with Exceptions {
       Future.value(rsp)
     }
     assertThrows[Forbidden](
-      await(KvApi(failureService).get("/some/path"))
+      await(KvApiV1(failureService).get("/some/path"))
     )
   }
 }

--- a/namerd/docs/storage.md
+++ b/namerd/docs/storage.md
@@ -85,3 +85,61 @@ Stores the dtab in Consul KV storage.  Supports the following options
 * *host* -- Optional. The location of the etcd API.  (default: localhost)
 * *port* -- Optional. The port used to connect to the etcd API.  (default: 8500)
 * *pathPrefix* -- Optional.  The key path under which dtabs should be stored.  (default: "/namerd/dtabs")
+* *recursive* -- Optional.  Whether to use recursive strategy to fetch namespaces.  (default: "false")
+
+In `recursive` mode the storage will look not only at keys that are immediate children of the `pathPrefix`
+but it will traverse the whole tree beneath recursively. The resulting dtab is composed from all non-empty
+valid values beneath the given namespace (sorted in alphabetical order of keys).
+
+This may be very useful when you need to modify your dtab in runtime in automated manner and you don't want
+to bother with dealing with dtabs syntax - you can just put mutable parts into separate keys and update them as needed.  
+
+Although `recursive` strategy may sound as something complicated at first it's actually very simple. Let's just
+look at an example and see how it will work in `recusrive` and non-`recursive` modes. 
+
+Let's assume that we configured storage `pathPrefix=/namerd/dtabs` and the KV in Consul is as below:
+
+```
+namerd/
+       dtabs/
+             sample = "/foo=>/bar"
+             nested/
+                    example = "/fiz=>/baz"
+                    broken = "invalid dtab"
+             mydtab = "/1st=>line"
+             mydtab/
+                    a = "/2nd=>/line"
+                    a/
+                      a = "/3rd=>/line"
+                      b = "/4th=>/line"
+                    b = "/5th=>/line"
+                    c/
+                      1 = "/6th=>/line"
+                    empty = ""
+```
+
+If we list namespaces in non-recursive mode, we will see just 2 of them (with their Dtabs given in parenthesis):
+* `sample` (`"/foo=>/bar"`)
+* `mydtab` (`"/1st=>line"`)
+
+On the other hand, in recursive mode we will see a slightly bigger list of namespaces:
+* `sample` (`"/foo=>/bar"`)
+* `nested/` (`"/fiz=>/baz"`)
+* `nested/example` (`"/fiz=>/baz"`)
+* `nested/broken` (`""`)
+* `mydtab` (`"/1st=>line"`)
+* `mydtab/` (`/1st=>/line;/2nd=>/line;/3rd=>/line;/4th=>/line;/5th=>/line;/6th=>/line;`)
+* `mydtab/a` (`"/2nd=>/line"`)
+* `mydtab/a/` (`"/3rd=>/line;/4th=>/line"`)
+* `mydtab/a/a` (`"/3rd=>/line"`)
+* `mydtab/a/b` (`"/4th=>/line"`)
+* `mydtab/b` (`"/5th=>/line"`)
+* `mydtab/c/` (`"/6th=>/line"`)
+* `mydtab/c/1` (`"/6th=>/line"`)
+* `mydtab/empty` (`""`)
+
+So the rule is simple: everything that doesn't end with `/` is a key that can has some value.
+Everything that ends with `/` is a 'virtual namespace' that aggregates other keys.
+ 
+With regards to `namerd` API there is only 1 restriction - you cannot create/update 'virtual namespaces'.
+But you can read and delete them (removal of a 'virtual namespace' will recursively remove everything beneath it).

--- a/namerd/iface/control-http/src/main/scala/io/buoyant/namerd/iface/HttpControlService.scala
+++ b/namerd/iface/control-http/src/main/scala/io/buoyant/namerd/iface/HttpControlService.scala
@@ -217,7 +217,7 @@ class HttpControlService(storage: DtabStore, delegate: Ns => NameInterpreter, na
 
   private[this] def isStreaming(req: Request): Boolean = req.getBooleanParam("watch")
 
-  private[this] def renderList(list: Set[Ns]): Buf = Json.write(list).concat(newline)
+  private[this] def renderList(list: Iterable[Ns]): Buf = Json.write(list).concat(newline)
 
   private[this] def handleList(req: Request): Future[Response] =
     if (isStreaming(req)) {
@@ -226,7 +226,7 @@ class HttpControlService(storage: DtabStore, delegate: Ns => NameInterpreter, na
       storage.list().toFuture.map { namespaces =>
         val rsp = Response()
         rsp.contentType = MediaType.Json
-        rsp.content = renderList(namespaces)
+        rsp.content = renderList(namespaces.toSeq.sorted)
         rsp
       }
     }

--- a/namerd/iface/control-http/src/test/scala/io/buoyant/namerd/iface/HttpControlServiceTest.scala
+++ b/namerd/iface/control-http/src/test/scala/io/buoyant/namerd/iface/HttpControlServiceTest.scala
@@ -55,7 +55,7 @@ class HttpControlServiceTest extends FunSuite with Awaits {
     val rsp = Await.result(service(req), 1.second)
     assert(rsp.status == Status.Ok)
     assert(rsp.contentType == Some(MediaType.Json))
-    val expected = HttpControlService.Json.write(defaultDtabs.keys).concat(HttpControlService.newline)
+    val expected = HttpControlService.Json.write(defaultDtabs.keys.toSeq.sorted).concat(HttpControlService.newline)
     assert(rsp.content == expected)
   }
 
@@ -112,7 +112,7 @@ class HttpControlServiceTest extends FunSuite with Awaits {
     val rsp = Await.result(service(req), 1.second)
     assert(rsp.status == Status.Ok)
     assert(rsp.contentType == Some(MediaType.Json))
-    val expected = HttpControlService.Json.write(defaultDtabs.keys).concat(HttpControlService.newline)
+    val expected = HttpControlService.Json.write(defaultDtabs.keys.toSeq.sorted).concat(HttpControlService.newline)
     assert(rsp.content == expected)
   }
 

--- a/namerd/main/src/main/scala/io/buoyant/namerd/DtabListHandler.scala
+++ b/namerd/main/src/main/scala/io/buoyant/namerd/DtabListHandler.scala
@@ -12,11 +12,11 @@ class DtabListHandler(
     store.list().toFuture.map { list =>
       val response = Response()
       response.contentType = MediaType.Html + ";charset=UTF-8"
-      response.contentString = render(list)
+      response.contentString = render(list.toSeq.sorted)
       response
     }
 
-  def render(list: Set[String]) = {
+  def render(list: Iterable[String]) = {
     val listHtml = list.map { ns =>
       s"""
         <a class="list-group-item" href="dtab/$ns">$ns</a>

--- a/namerd/storage/consul/src/main/scala/io/buoyant/namerd/storage/consul/ConsulDtabStore.scala
+++ b/namerd/storage/consul/src/main/scala/io/buoyant/namerd/storage/consul/ConsulDtabStore.scala
@@ -7,20 +7,35 @@ import com.twitter.util._
 import io.buoyant.consul.v1._
 import io.buoyant.namerd.DtabStore.{DtabNamespaceAlreadyExistsException, DtabNamespaceDoesNotExistException, DtabVersionMismatchException, Version}
 
-class ConsulDtabStore(api: KvApi, root: Path) extends DtabStore {
+class ConsulDtabStore(api: KvApi, root: Path, recursive: Boolean) extends DtabStore {
+
+  /**
+   * *
+   * Generate list of  'ephemeral' dirs from the path - list of all intermediate dirs
+   * For instance - for a/b/c that would be a/ and a/b/
+   */
+  private[this] def getDirs(key: String): Seq[String] = {
+    def cycle(parts: Seq[String]): Stream[String] =
+      if (parts.isEmpty) Stream.empty else parts.mkString("", "/", "/") #:: cycle(parts.init)
+    cycle(key.split("/").toSeq.init).toList.toSeq
+  }
 
   override def list(): Activity[Set[Ns]] = {
-    def namespace(key: String): Ns = key.stripPrefix("/").stripSuffix("/").substring(root.show.length)
+    def namespace(key: String): Ns = key.stripPrefix("/").substring(root.show.length)
 
     val run = Var.async[Activity.State[Set[Ns]]](Activity.Pending) { updates =>
       @volatile var running = true
 
       def cycle(index: Option[String]): Future[Unit] =
-        if (running)
-          api.list(s"${root.show}/", blockingIndex = index).transform {
+        if (running) {
+          val separator = if (recursive) None else Some("/") // filter out nested keys in non-recursive mode
+          api.list(s"${root.show}/", blockingIndex = index, separator = separator).transform {
             case Return(result) =>
-              val namespaces = result.value.map(namespace).toSet
-              updates() = Activity.Ok(namespaces)
+              // Filter out dirs from 'root'
+              val namespaces = result.value.map(namespace).filter { ns => recursive || !ns.endsWith("/") }
+              // Generate 'ephemeral' namespaces - if we have a key a/b we want to report a/ as a namespace too
+              val extraNamespaces = if (recursive) namespaces.map { ns => getDirs(ns) }.reduceLeft(_ ++ _) else Seq.empty
+              updates() = Activity.Ok((namespaces ++ extraNamespaces).toSet)
               cycle(result.index)
             case Throw(e: NotFound) =>
               updates() = Activity.Ok(Set.empty[Ns])
@@ -29,7 +44,7 @@ class ConsulDtabStore(api: KvApi, root: Path) extends DtabStore {
               updates() = Activity.Failed(e)
               cycle(None)
           }
-        else
+        } else
           Future.Unit
       val pending = cycle(None)
 
@@ -43,46 +58,70 @@ class ConsulDtabStore(api: KvApi, root: Path) extends DtabStore {
     Activity(run)
   }
 
-  def create(ns: Ns, dtab: Dtab): Future[Unit] =
-    api.put(s"${root.show}/$ns", dtab.show, cas = Some("0")).flatMap { result =>
+  def create(ns: Ns, dtab: Dtab): Future[Unit] = {
+    val key = s"${root.show}/${ns.stripSuffix("/")}" // cannot create 'dirs' - strip '/' suffix
+    api.put(key, dtab.show, cas = Some("0")).flatMap { result =>
       if (result) Future.Done else Future.exception(new DtabNamespaceAlreadyExistsException(ns))
     }
+  }
 
   def delete(ns: Ns): Future[Unit] = {
-    val key = s"${root.show}/$ns"
-    api.get(key).transform {
-      case Return(_) => api.delete(key).unit
+    // In non-recursive mode - always delete just a key
+    // In recursive mode - delete a key or a dir depending on presence of '/' suffix
+    val recursiveCall = recursive && ns.endsWith("/")
+    val namespace = if (recursive) ns else ns.stripSuffix("/")
+
+    val key = s"${root.show}/$namespace"
+    api.get(key, recurse = recursiveCall).transform {
+      case Return(_) => api.delete(key, recurse = recursive).unit
       case Throw(e: NotFound) => Future.exception(new DtabNamespaceDoesNotExistException(ns))
       case Throw(e) => Future.exception(e)
     }
   }
 
   def update(ns: Ns, dtab: Dtab, version: Version): Future[Unit] = {
+    val key = s"${root.show}/${ns.stripSuffix("/")}" // cannot update 'dirs' - strip '/' suffix
     val Buf.Utf8(vstr) = version
     Try(vstr.toLong) match {
       case Return(_) =>
-        api.put(s"${root.show}/$ns", dtab.show, cas = Some(vstr)).flatMap { result =>
+        api.put(key, dtab.show, cas = Some(vstr)).flatMap { result =>
           if (result) Future.Done else Future.exception(new DtabVersionMismatchException)
         }
       case _ => Future.exception(new DtabVersionMismatchException)
     }
   }
 
-  def put(ns: Ns, dtab: Dtab): Future[Unit] =
-    api.put(s"${root.show}/$ns", dtab.show).unit
+  def put(ns: Ns, dtab: Dtab): Future[Unit] = {
+    val key = s"${root.show}/${ns.stripSuffix("/")}" // cannot put a 'dir' - strip '/' suffix
+    api.put(key, dtab.show).unit
+  }
+
+  def readDtab(key: Key) = {
+    if (key.DecodedValue.isDefined) {
+      Try { Dtab.read(key.DecodedValue.get) } match {
+        case Return(d: Dtab) => d
+        case _ => Dtab.empty
+      }
+    } else Dtab.empty
+  }
 
   def observe(ns: Ns): Activity[Option[VersionedDtab]] = {
-    val key = s"${root.show}/$ns"
+    val (recursiveCall, namespace) = if (recursive && ns.endsWith("/")) (true, ns.stripSuffix("/")) else (false, ns)
+    val key = s"${root.show}/$namespace"
     val run = Var.async[Activity.State[Option[VersionedDtab]]](Activity.Pending) { updates =>
       @volatile var running = true
 
       def cycle(index: Option[String]): Future[Unit] =
         if (running)
-          api.get(key, blockingIndex = index).transform {
+          api.get(key, recurse = recursiveCall, blockingIndex = index).transform {
             case Return(result) =>
               val version = Buf.Utf8(result.index.get)
-              val dtab = Dtab.read(result.value)
-              updates() = Activity.Ok(Some(VersionedDtab(dtab, version)))
+              // Consul uses prefix-match - when fetching recursively /foo it will not only return /foo/a but also /foobar
+              val pattern = s"${key.stripPrefix("/")}(/.*)?"
+              val filteredKeys = result.value.filter(_.Key.get.matches(pattern))
+              val sortedKeys = filteredKeys.sortBy[String](_.Key.get)
+              val mergedDtab = sortedKeys.map(readDtab).reduceLeft(_ ++ _)
+              updates() = Activity.Ok(Some(VersionedDtab(mergedDtab, version)))
               cycle(result.index)
             case Throw(e: NotFound) =>
               updates() = Activity.Ok(None)

--- a/namerd/storage/consul/src/main/scala/io/buoyant/namerd/storage/consul/ConsulDtabStoreInitializer.scala
+++ b/namerd/storage/consul/src/main/scala/io/buoyant/namerd/storage/consul/ConsulDtabStoreInitializer.scala
@@ -5,13 +5,14 @@ import com.twitter.finagle.tracing.NullTracer
 import com.twitter.finagle.{Http, Path}
 import io.buoyant.config.types.Port
 import io.buoyant.consul.SetHostFilter
-import io.buoyant.consul.v1.KvApi
+import io.buoyant.consul.v1.KvApiV1
 import io.buoyant.namerd.{DtabStore, DtabStoreConfig, DtabStoreInitializer}
 
 case class ConsulConfig(
   host: Option[String],
   port: Option[Port],
-  pathPrefix: Option[Path]
+  pathPrefix: Option[Path],
+  recursive: Option[Boolean]
 ) extends DtabStoreConfig {
   import ConsulConfig._
 
@@ -28,8 +29,9 @@ case class ConsulConfig(
       .filtered(new SetHostFilter(serviceHost, servicePort))
       .newService(s"/$$/inet/$serviceHost/$servicePort")
     new ConsulDtabStore(
-      KvApi(service),
-      pathPrefix.getOrElse(Path.read("/namerd/dtabs"))
+      KvApiV1(service),
+      pathPrefix.getOrElse(Path.read("/namerd/dtabs")),
+      recursive.getOrElse(false)
     )
   }
 }

--- a/namerd/storage/consul/src/test/scala/io/buoyant/namerd/storage/consul/ConsulConfigTest.scala
+++ b/namerd/storage/consul/src/test/scala/io/buoyant/namerd/storage/consul/ConsulConfigTest.scala
@@ -8,7 +8,7 @@ import org.scalatest.{FunSuite, OptionValues}
 
 class ConsulConfigTest extends FunSuite with OptionValues {
   test("sanity") {
-    val store = ConsulConfig(None, None, Some(Path.read("/foo/bar"))).mkDtabStore
+    val store = ConsulConfig(None, None, Some(Path.read("/foo/bar")), None).mkDtabStore
   }
 
   test("parse config") {
@@ -17,13 +17,15 @@ class ConsulConfigTest extends FunSuite with OptionValues {
          |experimental: true
          |pathPrefix: /foo/bar
          |host: consul.local
+         |recursive: true
          |port: 80
       """.stripMargin
     val mapper = Parser.objectMapper(yaml, Iterable(Seq(ConsulDtabStoreInitializer)))
-    val etcd = mapper.readValue[DtabStoreConfig](yaml).asInstanceOf[ConsulConfig]
-    assert(etcd.host.value == "consul.local")
-    assert(etcd.port.value == Port(80))
-    assert(etcd.pathPrefix == Some(Path.read("/foo/bar")))
+    val consul = mapper.readValue[DtabStoreConfig](yaml).asInstanceOf[ConsulConfig]
+    assert(consul.host.value == "consul.local")
+    assert(consul.port.value == Port(80))
+    assert(consul.pathPrefix == Some(Path.read("/foo/bar")))
+    assert(consul.recursive.getOrElse(false))
   }
 
 }

--- a/namerd/storage/consul/src/test/scala/io/buoyant/namerd/storage/consul/ConsulDtabStoreTest.scala
+++ b/namerd/storage/consul/src/test/scala/io/buoyant/namerd/storage/consul/ConsulDtabStoreTest.scala
@@ -1,0 +1,107 @@
+package io.buoyant.namerd.storage.consul
+
+import com.twitter.finagle.{Dtab, Path}
+import com.twitter.io.Buf
+import com.twitter.util.Future
+import io.buoyant.consul.v1.{Indexed, Key, KvApi}
+import io.buoyant.test.Awaits
+import org.scalatest.FunSuite
+
+class ConsulDtabStoreTest extends FunSuite with Awaits {
+
+  class KvApiStub(keys: Seq[Key]) extends KvApi {
+    override def get(
+      path: String,
+      datacenter: Option[String],
+      blockingIndex: Option[String],
+      recurse: Boolean,
+      retry: Boolean
+    ): Future[Indexed[Seq[Key]]] = {
+      (path, recurse) match {
+        case ("/dtabs/mydtab", true) if blockingIndex != Some("42") =>
+          Future.value(Indexed[Seq[Key]](keys, Some("42")))
+        case ("/dtabs/mydtab", true) if blockingIndex == Some("42") =>
+          Future.never
+        case _ => ???
+      }
+    }
+
+    override def list(
+      path: String,
+      datacenter: Option[String],
+      blockingIndex: Option[String],
+      separator: Option[String],
+      retry: Boolean
+    ): Future[Indexed[Seq[String]]] = ???
+
+    override def put(
+      path: String,
+      value: String,
+      datacenter: Option[String],
+      cas: Option[String],
+      retry: Boolean
+    ): Future[Boolean] = ???
+
+    override def delete(
+      path: String,
+      datacenter: Option[String],
+      cas: Option[String],
+      recurse: Boolean = false,
+      retry: Boolean
+    ): Future[Boolean] = ???
+  }
+
+  test("observe in recursive mode merges Dtabs alphabetically") {
+    val api = new KvApiStub(Seq(
+      Key("dtabs/mydtab/b", "/5th=>/line"),
+      Key("dtabs/mydtab/a", "/2nd=>/line"),
+      Key("dtabs/mydtab/a/b", "/4th=>/line"),
+      Key("dtabs/mydtab/a/a", "/3rd=>/line"),
+      Key("dtabs/mydtab", "/1st=>/line"),
+      Key("dtabs/mydtab/x", "invalid value"),
+      Key(Some("dtabs/mydtab/empty"), None)
+    ))
+
+    val store = new ConsulDtabStore(api, Path.read("/dtabs"), recursive = true)
+    val act = store.observe("mydtab/")
+
+    val dtab = await(act.toFuture)
+    assert(dtab.isDefined)
+
+    val dtabValue = dtab.get
+    assert(dtabValue.version == Buf.Utf8("42"))
+    assert(dtabValue.dtab == Dtab.read(
+      """
+        |/1st=>/line;
+        |/2nd=>/line;
+        |/3rd=>/line;
+        |/4th=>/line;
+        |/5th=>/line;
+      """.stripMargin
+    ))
+  }
+
+  test("observe matches keys by segments between slashes (/)") {
+    val api = new KvApiStub(Seq(
+      Key("dtabs/mydtab", "/1st=>/line"),
+      Key("dtabs/mydtab/ext", "/2nd=>/line"),
+      Key("dtabs/mydtab2", "/fiz=>/baz")
+    ))
+
+    val store = new ConsulDtabStore(api, Path.read("/dtabs"), recursive = true)
+    val act = store.observe("mydtab/")
+
+    val dtab = await(act.toFuture)
+    assert(dtab.isDefined)
+
+    val dtabValue = dtab.get
+    assert(dtabValue.version == Buf.Utf8("42"))
+    assert(dtabValue.dtab == Dtab.read(
+      """
+        |/1st=>/line;
+        |/2nd=>/line;
+      """.stripMargin
+    ))
+  }
+
+}


### PR DESCRIPTION
This change gives us "composite" dtabs support with Consul.
Given the namespace `ConsulDtabStore` will fetch all the keys
below the namespace recursively and combine then in alphabetical
order of keys while dropping empty ones.
It watches for changes the whole tree of keys.