### PR TITLE
linkerd should use last known good data if it get errors from namerd

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,6 +1,7 @@
 ## x.x.x
 
 * Add support for tags in the `io.l5d.consul` namer
+* linkerd should use last known good data if it get errors from namerd
 
 ## 0.7.1
 

--- a/namerd/iface/interpreter-thrift/src/main/scala/io/buoyant/namerd/iface/ThriftNamerClient.scala
+++ b/namerd/iface/interpreter-thrift/src/main/scala/io/buoyant/namerd/iface/ThriftNamerClient.scala
@@ -80,7 +80,6 @@ class ThriftNamerClient(
 
           case Throw(e@thrift.BindFailure(reason, retry, _, _)) =>
             Trace.recordBinary("namerd.client/bind.fail", reason)
-            states() = Activity.Failed(e)
             if (!stopped) {
               pending = Future.sleep(retry.seconds).onSuccess(_ => loop(stamp0))
             }
@@ -178,7 +177,6 @@ class ThriftNamerClient(
 
           case Throw(e@thrift.AddrFailure(msg, retry, _)) =>
             Trace.recordBinary("namerd.client/addr.fail", msg)
-            addr() = Addr.Failed(e)
             if (!stopped) {
               pending = Future.sleep(retry.seconds).onSuccess(_ => loop(stamp0))
             }

--- a/namerd/iface/interpreter-thrift/src/test/scala/io/buoyant/namerd/iface/ThriftNamerEndToEndTest.scala
+++ b/namerd/iface/interpreter-thrift/src/test/scala/io/buoyant/namerd/iface/ThriftNamerEndToEndTest.scala
@@ -151,4 +151,40 @@ class ThriftNamerEndToEndTest extends FunSuite with Eventually with IntegrationP
         )
       ))
   }
+
+  test("use last good bind data") {
+    val id = Path.read("/io.l5d.w00t")
+    val (act, witness) = Activity[NameTree[Name]]()
+    val namer = new Namer {
+      def lookup(path: Path) = act
+    }
+    val namers = Seq(id -> namer)
+    def interpreter(ns: String) = new ConfiguredDtabNamer(
+      Activity.value(Dtab.read("/http => /io.l5d.w00t")),
+      namers
+    )
+    val service = new ThriftNamerInterface(interpreter, namers.toMap, newStamper, retryIn, Capacity.default, NullStatsReceiver)
+    val client = new ThriftNamerClient(service, ns, clientId)
+
+    witness.notify(Return(NameTree.Leaf(Name.Bound(
+      Var(Addr.Bound(Address("localhost", 9000))),
+      Path.read("/io.l5d.w00t/foo"),
+      Path.empty
+    ))))
+
+    val bindAct = client.bind(Dtab.empty, Path.read("/http/foo"))
+    var bound: NameTree[Name.Bound] = null
+    // hold activity open so that it doesn't get restarted and lose state
+    bindAct.values.respond(_ => ())
+    val NameTree.Leaf(bound0) = await(bindAct.toFuture)
+    // hold var open so that it doesn't get restarted and lose state
+    bound0.addr.changes.respond(_ => ())
+    assert(bound0.id == Path.read("/io.l5d.w00t/foo"))
+    assert(bound0.addr.sample == Addr.Bound(Address("localhost", 9000)))
+
+    witness.notify(Throw(new Exception("bind failure")))
+    val NameTree.Leaf(bound1) = await(bindAct.toFuture)
+    assert(bound1.id == Path.read("/io.l5d.w00t/foo"))
+    assert(bound1.addr.sample == Addr.Bound(Address("localhost", 9000)))
+  }
 }


### PR DESCRIPTION
# Problem

If namerd encounters an error during binding, linkerd will go into an error state and fail to bind requests.

# Solution

If linkerd gets error updates from namerd, it should not update its state and keep the last known good data.

This is a partial solution for #518.  It doesn't fix the zk session expired issue, but it does mean that linkerd will continue to function with last known good data in the case of such errors.