### PR TITLE
Add maxResponseKB to http client configuration

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -3,6 +3,7 @@
 * Add support for tags in the `io.l5d.consul` namer
 * linkerd should use last known good data if it get errors from namerd
 * Fix exceptions when k8s namer encounters unexpected end of stream #551
+* Expose HTTP codec parameters as configuration options.
 
 ## 0.7.1
 

--- a/linkerd/docs/protocol-http.md
+++ b/linkerd/docs/protocol-http.md
@@ -8,6 +8,21 @@ Router configuration options include:
 access log is written.
 * *identifier* -- [Http-specific identifier](#protocol-http-identifiers) (default:
 io.l5d.methodAndHost)
+* *maxChunkKB* -- The maximum size of an HTTP chunk (default: 8KB)
+* *maxHeadersKB* -- The maximum size of all headers in an HTTP message (default: 8KB)
+* *maxInitialLineKB* -- The maximum size of an initial HTTP
+  message line (default: 4KB)
+* *maxRequestKB* -- The maximum size of a non-chunked HTTP request
+  payload (default: 5MB)
+* *maxResponseKB* -- The maximum size of a non-chunked HTTP response
+  payload (default: 5MB)
+* *compressionLevel* -- The compression level to use (on 0-9)
+  (default: -1, automatically compresses textual content types with
+  compression level 6)
+
+_Note_: These memory constraints are selected to allow reliable
+concurrent usage of linkerd. Changing these parameters may
+significantly alter linkerd's performance characteristics.
 
 The default _dstPrefix_ is `/http`
 The default server _port_ is 4140

--- a/linkerd/examples/acceptance-test.yaml
+++ b/linkerd/examples/acceptance-test.yaml
@@ -160,6 +160,12 @@ routers:
     /host       => /#/io.l5d.fs;
     /http/1.1/* => /host;
   timeoutMs: 1000
+  maxChunkKB: 16
+  maxHeadersKB: 16
+  maxInitialLineKB: 16
+  maxRequestKB: 102400 # 100MB
+  maxResponseKB: 102400 # 100MB
+  compressionLevel: 9
   client:
     tls:
       kind: io.l5d.boundPath

--- a/linkerd/examples/http.yaml
+++ b/linkerd/examples/http.yaml
@@ -19,6 +19,7 @@ routers:
     engine:
       kind: netty3
   client:
+    # maxResponseKB: 40960 # 40MB
     engine:
       kind: netty3
 

--- a/linkerd/protocol/http/src/main/scala/io/buoyant/linkerd/protocol/HttpConfig.scala
+++ b/linkerd/protocol/http/src/main/scala/io/buoyant/linkerd/protocol/HttpConfig.scala
@@ -2,8 +2,9 @@ package io.buoyant.linkerd
 package protocol
 
 import com.fasterxml.jackson.annotation.JsonIgnore
+import com.twitter.conversions.storage._
 import com.twitter.finagle.{Path, Stack}
-import com.twitter.finagle.Http.param.HttpImpl
+import com.twitter.finagle.Http.{param => hparam}
 import com.twitter.finagle.buoyant.linkerd.{DelayedRelease, Headers, HttpTraceInitializer, HttpEngine}
 import com.twitter.finagle.client.StackClient
 import com.twitter.finagle.service.Retries
@@ -72,7 +73,14 @@ case class HttpServerConfig(
 
 case class HttpConfig(
   httpAccessLog: Option[String],
-  identifier: Option[HttpIdentifierConfig]
+  identifier: Option[HttpIdentifierConfig],
+  maxChunkKB: Option[Int],
+  maxHeadersKB: Option[Int],
+  maxInitialLineKB: Option[Int],
+  maxRequestKB: Option[Int],
+  maxResponseKB: Option[Int],
+  streamingEnabled: Option[Boolean],
+  compressionLevel: Option[Int]
 ) extends RouterConfig {
 
   var client: Option[HttpClientConfig] = None
@@ -89,4 +97,12 @@ case class HttpConfig(
   override def routerParams: Stack.Params = super.routerParams
     .maybeWith(httpAccessLog.map(AccessLogger.param.File(_)))
     .maybeWith(identifier.map(id => Http.param.HttpIdentifier(id.newIdentifier)))
+    .maybeWith(maxChunkKB.map(kb => hparam.MaxChunkSize(kb.kilobytes)))
+    .maybeWith(maxHeadersKB.map(kb => hparam.MaxHeaderSize(kb.kilobytes)))
+    .maybeWith(maxInitialLineKB.map(kb => hparam.MaxInitialLineSize(kb.kilobytes)))
+    .maybeWith(maxRequestKB.map(kb => hparam.MaxRequestSize(kb.kilobytes)))
+    .maybeWith(maxResponseKB.map(kb => hparam.MaxResponseSize(kb.kilobytes)))
+    .maybeWith(streamingEnabled.map(hparam.Streaming(_)))
+    .maybeWith(compressionLevel.map(hparam.CompressionLevel(_)))
+
 }


### PR DESCRIPTION
By default, Finagle and Netty set a 10MB limit for an unchunked response. This
is done to protect against having to buffer arbitrarily large payloads, which
can lead to performance degradation.

This change introduces a new configuration option for HTTP clients, allowing
this limit to be increased on a per-router basis.