### PR TITLE
Remove doubly nested inner classes

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -2,6 +2,7 @@
 
 * Add support for tags in the `io.l5d.consul` namer
 * linkerd should use last known good data if it get errors from namerd
+* Fix exceptions when k8s namer encounters unexpected end of stream #551
 
 ## 0.7.1
 

--- a/k8s/src/main/scala/io/buoyant/k8s/EndpointsNamer.scala
+++ b/k8s/src/main/scala/io/buoyant/k8s/EndpointsNamer.scala
@@ -6,7 +6,7 @@ import com.twitter.finagle.service.Backoff
 import com.twitter.finagle.tracing.Trace
 import com.twitter.finagle.util.DefaultTimer
 import com.twitter.util._
-import io.buoyant.k8s.v1.{EndpointsWatch, NsApi}
+import io.buoyant.k8s.v1._
 import io.buoyant.namer.EnumeratingNamer
 import scala.collection.mutable
 
@@ -301,10 +301,10 @@ private object EndpointsNamer {
     }
 
     def update(watch: EndpointsWatch): Unit = watch match {
-      case EndpointsWatch.Error(e) => log.error("k8s watch error: %s", e)
-      case EndpointsWatch.Added(endpoints) => add(endpoints)
-      case EndpointsWatch.Modified(endpoints) => modify(endpoints)
-      case EndpointsWatch.Deleted(endpoints) => delete(endpoints)
+      case Error(e) => log.error("k8s watch error: %s", e)
+      case Added(endpoints) => add(endpoints)
+      case Modified(endpoints) => modify(endpoints)
+      case Deleted(endpoints) => delete(endpoints)
     }
 
     private[this] def getName(endpoints: v1.Endpoints) =

--- a/k8s/src/main/scala/io/buoyant/k8s/v1.scala
+++ b/k8s/src/main/scala/io/buoyant/k8s/v1.scala
@@ -15,33 +15,31 @@ package object v1 {
 
   @JsonTypeInfo(use = JsonTypeInfo.Id.NAME, include = JsonTypeInfo.As.PROPERTY, property = "type")
   @JsonSubTypes(Array(
-    new JsonSubTypes.Type(value = classOf[EndpointsWatch.Added], name = "ADDED"),
-    new JsonSubTypes.Type(value = classOf[EndpointsWatch.Modified], name = "MODIFIED"),
-    new JsonSubTypes.Type(value = classOf[EndpointsWatch.Deleted], name = "DELETED"),
-    new JsonSubTypes.Type(value = classOf[EndpointsWatch.Error], name = "ERROR")
+    new JsonSubTypes.Type(value = classOf[Added], name = "ADDED"),
+    new JsonSubTypes.Type(value = classOf[Modified], name = "MODIFIED"),
+    new JsonSubTypes.Type(value = classOf[Deleted], name = "DELETED"),
+    new JsonSubTypes.Type(value = classOf[Error], name = "ERROR")
   ))
   sealed trait EndpointsWatch extends Watch[Endpoints]
-  object EndpointsWatch {
-    case class Added(
-      `object`: Endpoints
-    ) extends EndpointsWatch with Watch.Added[Endpoints]
+  case class Added(
+    `object`: Endpoints
+  ) extends EndpointsWatch with Watch.Added[Endpoints]
 
-    case class Modified(
-      `object`: Endpoints
-    ) extends EndpointsWatch with Watch.Modified[Endpoints]
+  case class Modified(
+    `object`: Endpoints
+  ) extends EndpointsWatch with Watch.Modified[Endpoints]
 
-    case class Deleted(
-      `object`: Endpoints
-    ) extends EndpointsWatch with Watch.Deleted[Endpoints]
+  case class Deleted(
+    `object`: Endpoints
+  ) extends EndpointsWatch with Watch.Deleted[Endpoints]
 
-    case class Error(
-      @JsonProperty(value = "object") status: Status
-    ) extends EndpointsWatch with Watch.Error[Endpoints]
-  }
+  case class Error(
+    @JsonProperty(value = "object") status: Status
+  ) extends EndpointsWatch with Watch.Error[Endpoints]
 
   implicit object EndpointsDescriptor extends ObjectDescriptor[Endpoints, EndpointsWatch] {
     def listName = "endpoints"
-    def toWatch(e: Endpoints) = EndpointsWatch.Modified(e)
+    def toWatch(e: Endpoints) = Modified(e)
   }
 
   case class Api(client: Client) extends Version[Object] {

--- a/k8s/src/test/scala/io/buoyant/k8s/v1/ApiTest.scala
+++ b/k8s/src/test/scala/io/buoyant/k8s/v1/ApiTest.scala
@@ -110,12 +110,12 @@ class ApiTest extends FunSuite with Awaits with Exceptions {
     val w = rsp.writer
     await(w.write(modified2 concat added0))
     await(stream.uncons) match {
-      case Some((EndpointsWatch.Modified(eps), getStream)) =>
+      case Some((Modified(eps), getStream)) =>
         assert(eps.subsets.flatMap(_.notReadyAddresses).flatten.map(_.ip) ==
           Seq("10.248.2.8", "10.248.7.10", "10.248.8.8"))
 
         await(getStream().uncons) match {
-          case Some((EndpointsWatch.Added(eps), getStream)) =>
+          case Some((Added(eps), getStream)) =>
             assert(eps.subsets.flatMap(_.addresses).flatten.map(_.ip) ==
               Seq("104.154.78.240"))
 
@@ -124,7 +124,7 @@ class ApiTest extends FunSuite with Awaits with Exceptions {
             await(w.write(modified1))
             assert(next.isDefined)
             await(next) match {
-              case Some((EndpointsWatch.Modified(eps), getStream)) =>
+              case Some((Modified(eps), getStream)) =>
                 assert(eps.subsets.flatMap(_.addresses).flatten.map(_.ip) ==
                   Seq("10.248.3.3"))
 
@@ -133,7 +133,7 @@ class ApiTest extends FunSuite with Awaits with Exceptions {
                 await(w.write(modified0))
                 assert(next.isDefined)
                 await(next) match {
-                  case Some((EndpointsWatch.Modified(eps), getStream)) =>
+                  case Some((Modified(eps), getStream)) =>
                     assert(eps.subsets.flatMap(_.addresses).flatten.map(_.ip) ==
                       Seq("10.248.2.8", "10.248.7.10", "10.248.8.8"))
                     val next = getStream().uncons
@@ -194,14 +194,14 @@ class ApiTest extends FunSuite with Awaits with Exceptions {
 
     val (stream, closable) = api.endpoints.watch(resourceVersion = Some(ver))
     await(stream.uncons) match {
-      case Some((EndpointsWatch.Error(status), stream)) =>
+      case Some((Error(status), stream)) =>
         assert(status.status == Some("Failure"))
         await(stream().uncons) match {
-          case Some((EndpointsWatch.Modified(mod), stream)) =>
+          case Some((Modified(mod), stream)) =>
             assert(mod.metadata.get.resourceVersion.get == "17147786")
             assert(mod.subsets.head.addresses == Some(Seq(EndpointAddress("10.248.9.109", Some(ObjectReference(Some("Pod"), Some("greg-test"), Some("accounts-h5zht"), Some("0b598c6e-9f9b-11e5-94e8-42010af00045"), None, Some("17147785"), None))))))
             await(stream().uncons) match {
-              case Some((EndpointsWatch.Modified(mod), stream)) =>
+              case Some((Modified(mod), stream)) =>
                 assert(mod.metadata.get.resourceVersion.get == "17147808")
                 assert(mod.subsets.head.addresses == Some(List(EndpointAddress("10.248.4.134", Some(ObjectReference(Some("Pod"), Some("greg-test"), Some("auth-54q3e"), Some("0d5d0a2d-9f9b-11e5-94e8-42010af00045"), None, Some("17147807"), None))))))
                 val next = stream().uncons
@@ -298,11 +298,11 @@ class ApiTest extends FunSuite with Awaits with Exceptions {
 
     val (stream, closable) = api.endpoints.watch(resourceVersion = Some(ver))
     await(stream.uncons) match {
-      case Some((EndpointsWatch.Modified(mod), stream)) =>
+      case Some((Modified(mod), stream)) =>
         assert(mod.metadata.get.resourceVersion.get == "17147786")
         assert(mod.subsets.head.addresses == Some(Seq(EndpointAddress("10.248.9.109", Some(ObjectReference(Some("Pod"), Some("greg-test"), Some("accounts-h5zht"), Some("0b598c6e-9f9b-11e5-94e8-42010af00045"), None, Some("17147785"), None))))))
         await(stream().uncons) match {
-          case Some((EndpointsWatch.Modified(mod), stream)) =>
+          case Some((Modified(mod), stream)) =>
             assert(mod.metadata.get.resourceVersion.get == "17147808")
             assert(mod.subsets.head.addresses == Some(List(EndpointAddress("10.248.4.134", Some(ObjectReference(Some("Pod"), Some("greg-test"), Some("auth-54q3e"), Some("0d5d0a2d-9f9b-11e5-94e8-42010af00045"), None, Some("17147807"), None))))))
             val next = stream().uncons


### PR DESCRIPTION
Fixes #551 

Avoid https://issues.scala-lang.org/browse/SI-2034 by not using doubly-nested inner classes.