### PR TITLE
Allow protocol-specific parameters to be inherited on servers

### DIFF
--- a/linkerd/protocol/http/src/main/scala/com/twitter/finagle/buoyant/linkerd/HttpEngine.scala
+++ b/linkerd/protocol/http/src/main/scala/com/twitter/finagle/buoyant/linkerd/HttpEngine.scala
@@ -11,21 +11,18 @@ import com.twitter.finagle.netty4.http.exp.Netty4Impl
   property = "kind"
 )
 @JsonSubTypes(Array(
-  new JsonSubTypes.Type(value = classOf[HttpEngine.Netty3], name = "netty3"),
-  new JsonSubTypes.Type(value = classOf[HttpEngine.Netty4], name = "netty4")
+  new JsonSubTypes.Type(value = classOf[Netty3HttpEngine], name = "netty3"),
+  new JsonSubTypes.Type(value = classOf[Netty4HttpEngine], name = "netty4")
 ))
-abstract trait HttpEngine {
-
+abstract class HttpEngine {
   @JsonIgnore
   def mk(params: Stack.Params): Stack.Params
 }
 
-object HttpEngine {
-  class Netty3 extends HttpEngine {
-    def mk(params: Stack.Params) = params + Http.param.Netty3Impl
-  }
+class Netty3HttpEngine extends HttpEngine {
+  def mk(params: Stack.Params) = params + Http.param.Netty3Impl
+}
 
-  class Netty4 extends HttpEngine {
-    def mk(params: Stack.Params) = params + Netty4Impl
-  }
+class Netty4HttpEngine extends HttpEngine {
+  def mk(params: Stack.Params) = params + Netty4Impl
 }

--- a/linkerd/protocol/http/src/main/scala/io/buoyant/linkerd/protocol/HttpConfig.scala
+++ b/linkerd/protocol/http/src/main/scala/io/buoyant/linkerd/protocol/HttpConfig.scala
@@ -38,10 +38,9 @@ class HttpInitializer extends ProtocolInitializer.Simple {
   }
 
   /**
-   * Apply the router's codec coonfiguration applies to the server.
+   * Apply the router's codec configuration parameters to a server.
    */
-  override protected def configureServer(router: Router, server: Server): Server = {
-    println(s"configuring server with ${router.params}")
+  override protected def configureServer(router: Router, server: Server): Server =
     super.configureServer(router, server)
       .configured(router.params[hparam.MaxChunkSize])
       .configured(router.params[hparam.MaxHeaderSize])
@@ -50,7 +49,6 @@ class HttpInitializer extends ProtocolInitializer.Simple {
       .configured(router.params[hparam.MaxResponseSize])
       .configured(router.params[hparam.Streaming])
       .configured(router.params[hparam.CompressionLevel])
-  }
 
   protected val defaultServer = {
     val stk = Http.server.stack

--- a/linkerd/protocol/http/src/main/scala/io/buoyant/linkerd/protocol/HttpConfig.scala
+++ b/linkerd/protocol/http/src/main/scala/io/buoyant/linkerd/protocol/HttpConfig.scala
@@ -37,6 +37,21 @@ class HttpInitializer extends ProtocolInitializer.Simple {
       .configured(RoutingFactory.DstPrefix(Path.Utf8(name)))
   }
 
+  /**
+   * Apply the router's codec coonfiguration applies to the server.
+   */
+  override protected def configureServer(router: Router, server: Server): Server = {
+    println(s"configuring server with ${router.params}")
+    super.configureServer(router, server)
+      .configured(router.params[hparam.MaxChunkSize])
+      .configured(router.params[hparam.MaxHeaderSize])
+      .configured(router.params[hparam.MaxInitialLineSize])
+      .configured(router.params[hparam.MaxRequestSize])
+      .configured(router.params[hparam.MaxResponseSize])
+      .configured(router.params[hparam.Streaming])
+      .configured(router.params[hparam.CompressionLevel])
+  }
+
   protected val defaultServer = {
     val stk = Http.server.stack
       .replace(HttpTraceInitializer.role, HttpTraceInitializer.serverModule)


### PR DESCRIPTION
Currently, only a few non-protocol-specific parameters are shared from a router
to its servers.  This makes it impossible to set router-levelcodec parameters
(e.g. MaxChunkSize).

Add a `configureServer` method to ProtocolInitializer so that each protocol may
provide configuration-sharing logic as needed.  By default, we share HTTP codec
parameters from routers to servers.

<hr />
Manually tested locally: uploading a 38M file fails with a 413 unless `maxRequestKB` is set appropriately.