### PR TITLE
Resolve endpoint for namerd HTTP control interface

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,5 +1,6 @@
 ## x.x.x
 
+* Add `resolve` endpoint to Namerd HTTP API 
 * Add file-system based name interpreter.
 * Add auth `token` parameter to Consul Namer & Dtab Store
 

--- a/admin/src/main/scala/io/buoyant/admin/names/DelegateApiHandler.scala
+++ b/admin/src/main/scala/io/buoyant/admin/names/DelegateApiHandler.scala
@@ -36,10 +36,10 @@ object DelegateApiHandler {
     Future.value(resp)
   }
 
-  case class Address(ip: String, port: Int)
+  case class Address(ip: String, port: Int, meta: Map[String, Any])
   object Address {
     def mk(addr: FAddress): Option[Address] = addr match {
-      case FAddress.Inet(isa, _) => Some(Address(isa.getAddress.getHostAddress, isa.getPort))
+      case FAddress.Inet(isa, meta) => Some(Address(isa.getAddress.getHostAddress, isa.getPort, meta))
       case _ => None
     }
   }

--- a/linkerd/admin/src/test/scala/io/buoyant/linkerd/admin/names/DelegateApiHandlerTest.scala
+++ b/linkerd/admin/src/test/scala/io/buoyant/linkerd/admin/names/DelegateApiHandlerTest.scala
@@ -4,7 +4,7 @@ import com.twitter.finagle.Name.Bound
 import com.twitter.finagle.http._
 import com.twitter.finagle.naming.NameInterpreter
 import com.twitter.finagle.{Status => _, _}
-import com.twitter.util.{Var, Activity}
+import com.twitter.util.Activity
 import io.buoyant.admin.names.DelegateApiHandler
 import io.buoyant.linkerd._
 import io.buoyant.namer.{ErrorNamerInitializer, TestNamerInitializer}
@@ -50,7 +50,7 @@ class DelegateApiHandlerTest extends FunSuite with Awaits {
           |"dentry":{"prefix":"/foo","dst":"/bah | /beh | /$/fail"},"delegate":{
             |"type":"leaf","path":"/$/inet/127.1/8080","dentry":{"prefix":"/bah/humbug",
               |"dst":"/$/inet/127.1/8080"},
-            |"bound":{"addr":{"type":"bound","addrs":[{"ip":"127.0.0.1","port":8080}],"meta":{}},
+            |"bound":{"addr":{"type":"bound","addrs":[{"ip":"127.0.0.1","port":8080,"meta":{}}],"meta":{}},
               |"id":"/$/inet/127.1/8080","path":"/"}}},
           |{"type":"delegate","path":"/beh/humbug",
             |"dentry":{"prefix":"/foo","dst":"/bah | /beh | /$/fail"},"delegate":{

--- a/namerd/README.md
+++ b/namerd/README.md
@@ -83,3 +83,9 @@ Evaluate a path against an arbitrary dtab:
 ```
 $ curl -v "$NAMERD_URL/api/1/delegate?dtab=/foo=>/bar&path=/foo"
 ```
+
+Resolve a logic or concrete name against a known dtab namespace:
+
+```
+$ curl -v $NAMERD_URL/api/1/resolve/baz?path=/foo
+```

--- a/namerd/iface/control-http/src/test/scala/io/buoyant/namerd/iface/HttpControlServiceTest.scala
+++ b/namerd/iface/control-http/src/test/scala/io/buoyant/namerd/iface/HttpControlServiceTest.scala
@@ -290,11 +290,12 @@ class HttpControlServiceTest extends FunSuite with Awaits {
 
     val resp = await(service(Request("/api/1/bind/default?path=/foo")))
     assert(resp.status == Status.Ok)
-    assert(resp.contentString.replaceAllLiterally("\n", "") == """
-                                                                 |{"type":"leaf",
-                                                                 |"bound":{"addr":{"type":"bound","addrs":[{"ip":"127.0.0.1","port":1}],"meta":{}},
-                                                                 |"id":"/#/io.l5d.namer/foo","path":"/"}}
-                                                                 |""".stripMargin.replaceAllLiterally("\n", ""))
+    assert(resp.contentString.replaceAllLiterally("\n", "") ==
+      """
+        |{"type":"leaf",
+        |"bound":{"addr":{"type":"bound","addrs":[{"ip":"127.0.0.1","port":1,"meta":{}}],"meta":{}},
+        |"id":"/#/io.l5d.namer/foo","path":"/"}}
+        |""".stripMargin.replaceAllLiterally("\n", ""))
   }
 
   test("bind with an extra dtab") {
@@ -314,11 +315,12 @@ class HttpControlServiceTest extends FunSuite with Awaits {
 
     val resp = await(service(Request("/api/1/bind/default?path=/foo&dtab=/foo=>/bar")))
     assert(resp.status == Status.Ok)
-    assert(resp.contentString.replaceAllLiterally("\n", "") == """
-                                                                 |{"type":"leaf",
-                                                                 |"bound":{"addr":{"type":"bound","addrs":[{"ip":"127.0.0.1","port":1}],"meta":{}},
-                                                                 |"id":"/#/io.l5d.namer/bar","path":"/"}}
-                                                                 |""".stripMargin.replaceAllLiterally("\n", ""))
+    assert(resp.contentString.replaceAllLiterally("\n", "") ==
+      """
+        |{"type":"leaf",
+        |"bound":{"addr":{"type":"bound","addrs":[{"ip":"127.0.0.1","port":1,"meta":{}}],"meta":{}},
+        |"id":"/#/io.l5d.namer/bar","path":"/"}}
+        |""".stripMargin.replaceAllLiterally("\n", ""))
   }
 
   test("bind watch") {
@@ -336,7 +338,7 @@ class HttpControlServiceTest extends FunSuite with Awaits {
       resp.reader,
       """
         |{"type":"leaf",
-        |"bound":{"addr":{"type":"bound","addrs":[{"ip":"127.0.0.1","port":1}],"meta":{}},
+        |"bound":{"addr":{"type":"bound","addrs":[{"ip":"127.0.0.1","port":1,"meta":{}}],"meta":{}},
         |"id":"/#/io.l5d.namer/foo","path":"/"}}""".stripMargin.replaceAllLiterally("\n", "")
     )
 
@@ -353,7 +355,7 @@ class HttpControlServiceTest extends FunSuite with Awaits {
       resp.reader,
       """
         |{"type":"leaf",
-        |"bound":{"addr":{"type":"bound","addrs":[{"ip":"127.0.0.1","port":1}],"meta":{}},
+        |"bound":{"addr":{"type":"bound","addrs":[{"ip":"127.0.0.1","port":1,"meta":{}}],"meta":{}},
         |"id":"/#/io.l5d.namer/bar","path":"/"}}""".stripMargin.replaceAllLiterally("\n", "")
     )
 
@@ -403,7 +405,7 @@ class HttpControlServiceTest extends FunSuite with Awaits {
     assert(resp.contentString.replaceAllLiterally("\n", "") ==
       """
         |{"type":"bound",
-        |"addrs":[{"ip":"127.0.0.1","port":1}],"meta":{}}
+        |"addrs":[{"ip":"127.0.0.1","port":1,"meta":{}}],"meta":{}}
         |""".stripMargin.replaceAllLiterally("\n", ""))
   }
 
@@ -423,7 +425,7 @@ class HttpControlServiceTest extends FunSuite with Awaits {
       resp.reader,
       """
         |{"type":"bound",
-        |"addrs":[{"ip":"127.0.0.1","port":1}],"meta":{}}
+        |"addrs":[{"ip":"127.0.0.1","port":1,"meta":{}}],"meta":{}}
         |""".stripMargin.replaceAllLiterally("\n", "")
     )
 
@@ -432,7 +434,7 @@ class HttpControlServiceTest extends FunSuite with Awaits {
       resp.reader,
       """
         |{"type":"bound",
-        |"addrs":[{"ip":"127.0.0.1","port":1},{"ip":"127.0.0.1","port":2}],"meta":{}}
+        |"addrs":[{"ip":"127.0.0.1","port":1,"meta":{}},{"ip":"127.0.0.1","port":2,"meta":{}}],"meta":{}}
         |""".stripMargin.replaceAllLiterally("\n", "")
     )
 
@@ -450,7 +452,7 @@ class HttpControlServiceTest extends FunSuite with Awaits {
       resp.reader,
       """
         |{"type":"bound",
-        |"addrs":[{"ip":"127.0.0.1","port":3}],"meta":{}}
+        |"addrs":[{"ip":"127.0.0.1","port":3,"meta":{}}],"meta":{}}
         |""".stripMargin.replaceAllLiterally("\n", "")
     )
 
@@ -571,7 +573,7 @@ class HttpControlServiceTest extends FunSuite with Awaits {
         |{
         |  "type":"bound",
         |  "addrs":[
-        |    {"ip":"127.0.0.1","port":1}
+        |    {"ip":"127.0.0.1","port":1,"meta":{"isa-meta":"isa-data"}}
         |  ],
         |  "meta":{
         |    "bound-meta":"bound-data"
@@ -624,7 +626,7 @@ class HttpControlServiceTest extends FunSuite with Awaits {
         |{
         |  "type":"bound",
         |  "addrs":[
-        |    {"ip":"127.0.0.1","port":1}
+        |    {"ip":"127.0.0.1","port":1,"meta":{"isa-meta-1":"isa-data-1"}}
         |  ],
         |  "meta":{
         |    "bound-meta":"bound-data"
@@ -641,8 +643,8 @@ class HttpControlServiceTest extends FunSuite with Awaits {
         |{
         |  "type":"bound",
         |  "addrs":[
-        |    {"ip":"127.0.0.1","port":1},
-        |    {"ip":"127.0.0.1","port":2}
+        |    {"ip":"127.0.0.1","port":1,"meta":{"isa-meta-1":"isa-data-1"}},
+        |    {"ip":"127.0.0.1","port":2,"meta":{"isa-meta-2":"isa-data-2"}}
         |  ],
         |  "meta":{
         |    "bound-meta":"bound-data"


### PR DESCRIPTION
Usage example:

```
$ curl -s "$NAMERD_URL/api/1/resolve/default?path=/http/1.1/GET/users"
{"addrs":[{"addr":"192.168.10.23:8080","metadata":{}}],"metadata":{"authority": "users.service.dc1.consul.acme.co"}}%
```

Under the hood, combines `bind` and `addr` and uses `DelegateApiHandler.Codec` to serialize result into JSON.