### PR TITLE
Don't clear addr on k8s service deletion

### DIFF
--- a/k8s/src/main/scala/io/buoyant/k8s/EndpointsNamer.scala
+++ b/k8s/src/main/scala/io/buoyant/k8s/EndpointsNamer.scala
@@ -198,18 +198,6 @@ private object EndpointsNamer {
 
     val ports = Activity(state)
 
-    def clear(): Unit = synchronized {
-      state.sample() match {
-        case Activity.Ok(snap) =>
-          for (port <- snap.values) {
-            port() = Addr.Neg
-          }
-          state() = Activity.Pending
-
-        case _ =>
-      }
-    }
-
     def delete(name: String): Unit = synchronized {
       state.sample() match {
         case Activity.Ok(snap) =>
@@ -274,17 +262,6 @@ private object EndpointsNamer {
 
     val services: Activity[Map[String, SvcCache]] = Activity(state)
 
-    def clear(): Unit = synchronized {
-      state.sample() match {
-        case Activity.Ok(snap) =>
-          for (svc <- snap.values) {
-            svc.clear()
-          }
-        case _ =>
-      }
-      state() = Activity.Pending
-    }
-
     /**
      * Initialize a namespaces of services.  The activity is updated
      * once with the entire state of the namespace (i.e. not
@@ -347,7 +324,6 @@ private object EndpointsNamer {
         state.sample() match {
           case Activity.Ok(snap) =>
             for (svc <- snap.get(name)) {
-              svc.clear()
               state() = Activity.Ok(snap - name)
             }
 


### PR DESCRIPTION
As described in #566, the k8s namer may become "stuck" so that load balancers receive no updates after a k8s service is deleted.

Removing linkerd's state-clearing code appears to resolve the problem.