### PR TITLE
modify the delegate api to provide bound addresses

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,5 +1,7 @@
 ## x.x.x
 
+* Modify namerd's `/delegate` http endpoint to return bound names #569.
+
 ## 0.7.2
 
 * Add support for tags in the `io.l5d.consul` namer.

--- a/admin/src/main/scala/io/buoyant/admin/names/DelegateApiHandler.scala
+++ b/admin/src/main/scala/io/buoyant/admin/names/DelegateApiHandler.scala
@@ -191,7 +191,8 @@ object DelegateApiHandler {
 }
 
 class DelegateApiHandler(
-  interpreters: String => NameInterpreter
+  interpreters: String => NameInterpreter,
+  namers: Seq[(Path, Namer)] = Nil
 ) extends Service[Request, Response] {
 
   import DelegateApiHandler._
@@ -207,7 +208,7 @@ class DelegateApiHandler(
               err(Status.NotImplemented, s"Name Interpreter for $ns cannot show delegations")
           }
         case None =>
-          getDelegateRsp(req.getParam("dtab"), req.getParam("path"), ConfiguredNamersInterpreter(Nil))
+          getDelegateRsp(req.getParam("dtab"), req.getParam("path"), ConfiguredNamersInterpreter(namers))
       }
     case _ => err(Status.MethodNotAllowed)
   }

--- a/namerd/iface/control-http/src/main/scala/io/buoyant/namerd/iface/HttpControlService.scala
+++ b/namerd/iface/control-http/src/main/scala/io/buoyant/namerd/iface/HttpControlService.scala
@@ -147,7 +147,7 @@ class HttpControlService(storage: DtabStore, delegate: Ns => NameInterpreter, na
   private[this] def getDtab(ns: String): Future[Option[VersionedDtab]] =
     storage.observe(ns).toFuture
 
-  private[this] val delegateApiHander = new DelegateApiHandler(delegate)
+  private[this] val delegateApiHander = new DelegateApiHandler(delegate, namers.toSeq)
 
   def apply(req: Request): Future[Response] = Future(req match {
     case DtabUri(_, None) =>


### PR DESCRIPTION
problem: the http /delegate endpoint would not provide bound addresses
unless a namespace parameter was provided.

solution: modify the behavior of /delegate to use available namers when
a namespace is not provided.

note: this does not change the behavior of the /delegate/[namespace]/
api, though it may be prudent in the future to harmonize or converge
these code paths.