### PR TITLE
Add filesystem based name interpreter

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,3 +1,7 @@
+## x.x.x
+
+* Add file-system based name interpreter.
+
 ## 0.7.3
 
 * Allow protocol-specific parameters to be inherited on servers #561.

--- a/config/src/main/resources/META-INF/services/io.buoyant.config.ConfigDeserializer
+++ b/config/src/main/resources/META-INF/services/io.buoyant.config.ConfigDeserializer
@@ -1,5 +1,6 @@
 io.buoyant.config.types.DirectoryDeserializer
 io.buoyant.config.types.DtabDeserializer
+io.buoyant.config.types.FileDeserializer
 io.buoyant.config.types.InetAddressDeserializer
 io.buoyant.config.types.PathDeserializer
 io.buoyant.config.types.PortDeserializer

--- a/config/src/main/resources/META-INF/services/io.buoyant.config.ConfigSerializer
+++ b/config/src/main/resources/META-INF/services/io.buoyant.config.ConfigSerializer
@@ -1,5 +1,6 @@
 io.buoyant.config.types.DirectorySerializer
 io.buoyant.config.types.DtabSerializer
+io.buoyant.config.types.FileSerializer
 io.buoyant.config.types.InetAddressSerializer
 io.buoyant.config.types.PathSerializer
 io.buoyant.config.types.PortSerializer

--- a/config/src/main/scala/io/buoyant/config/types/FileDeserializer.scala
+++ b/config/src/main/scala/io/buoyant/config/types/FileDeserializer.scala
@@ -1,0 +1,25 @@
+package io.buoyant.config.types
+
+import com.fasterxml.jackson.core.{JsonGenerator, JsonParser}
+import com.fasterxml.jackson.databind.{SerializerProvider, DeserializationContext}
+import io.buoyant.config.{ConfigSerializer, ConfigDeserializer}
+import java.nio.file.Paths
+
+case class File(path: java.nio.file.Path) {
+  require(path.toFile.isFile, s"$path is not a file")
+}
+
+class FileDeserializer extends ConfigDeserializer[File] {
+  override def deserialize(jp: JsonParser, ctxt: DeserializationContext): File =
+    catchMappingException(ctxt) {
+      File(Paths.get(_parseString(jp, ctxt)))
+    }
+}
+
+class FileSerializer extends ConfigSerializer[File] {
+  override def serialize(
+    value: File,
+    jgen: JsonGenerator,
+    provider: SerializerProvider
+  ): Unit = jgen.writeString(value.path.toString)
+}

--- a/interpreter/fs/src/main/resources/META-INF/services/io.buoyant.namer.InterpreterInitializer
+++ b/interpreter/fs/src/main/resources/META-INF/services/io.buoyant.namer.InterpreterInitializer
@@ -1,0 +1,1 @@
+io.buoyant.interpreter.fs.FsInterpreterInitializer

--- a/interpreter/fs/src/main/scala/io/buoyant/interpreter/fs/FsInterpreterConfig.scala
+++ b/interpreter/fs/src/main/scala/io/buoyant/interpreter/fs/FsInterpreterConfig.scala
@@ -1,0 +1,35 @@
+package io.buoyant.interpreter.fs
+
+import com.fasterxml.jackson.annotation.JsonIgnore
+import com.twitter.finagle.Dtab
+import com.twitter.finagle.Stack.Params
+import com.twitter.finagle.naming.NameInterpreter
+import com.twitter.io.Buf
+import com.twitter.util.Activity
+import io.buoyant.config.types.File
+import io.buoyant.namer.{Param, ConfiguredDtabNamer, InterpreterConfig}
+import io.buoyant.namer.fs.Watcher
+
+case class FsInterpreterConfig(dtabFile: File) extends InterpreterConfig {
+
+  @JsonIgnore
+  private[this] val path = dtabFile.path
+
+  @JsonIgnore
+  private[this] def dtab: Activity[Dtab] =
+    Watcher(path.getParent).children.flatMap { children =>
+      children.get(path.getFileName.toString) match {
+        case Some(file: Watcher.File.Reg) => file.data
+        case _ => Activity.pending
+      }
+    }.map {
+      case Buf.Utf8(dtab) =>
+        Dtab.read(dtab)
+    }
+
+  @JsonIgnore
+  override def newInterpreter(params: Params): NameInterpreter = {
+    val Param.Namers(namers) = params[Param.Namers]
+    ConfiguredDtabNamer(dtab, namers)
+  }
+}

--- a/interpreter/fs/src/main/scala/io/buoyant/interpreter/fs/FsInterpreterInitializer.scala
+++ b/interpreter/fs/src/main/scala/io/buoyant/interpreter/fs/FsInterpreterInitializer.scala
@@ -1,0 +1,10 @@
+package io.buoyant.interpreter.fs
+
+import io.buoyant.namer.InterpreterInitializer
+
+class FsInterpreterInitializer extends InterpreterInitializer {
+  override def configClass: Class[_] = classOf[FsInterpreterConfig]
+  override def configId: String = "io.l5d.fs"
+}
+
+object FsInterpreterInitializer extends FsInterpreterInitializer

--- a/interpreter/fs/src/test/scala/io/buoyant/interpreter/fs/FsInterpreterTest.scala
+++ b/interpreter/fs/src/test/scala/io/buoyant/interpreter/fs/FsInterpreterTest.scala
@@ -1,0 +1,31 @@
+package io.buoyant.interpreter.fs
+
+import com.twitter.finagle.util.LoadService
+import io.buoyant.config.Parser
+import io.buoyant.namer.{InterpreterConfig, InterpreterInitializer}
+import java.io.File
+import org.scalatest.FunSuite
+
+class FsInterpreterTest extends FunSuite {
+
+  test("interpreter registration") {
+    assert(LoadService[InterpreterInitializer]().exists(_.isInstanceOf[FsInterpreterInitializer]))
+  }
+
+  test("parse config") {
+    val dtabFile = File.createTempFile("example", ".dtab")
+    try {
+      val yaml =
+        s"""|kind: io.l5d.fs
+            |dtabFile: ${dtabFile.getPath}
+            |""".stripMargin
+
+      val mapper = Parser.objectMapper(yaml, Iterable(Seq(FsInterpreterInitializer)))
+      val fs = mapper.readValue[InterpreterConfig](yaml).asInstanceOf[FsInterpreterConfig]
+      assert(fs.dtabFile.path.toString == dtabFile.getPath)
+    } finally {
+      val _ = dtabFile.delete()
+    }
+  }
+}
+

--- a/linkerd/docs/interpreter.md
+++ b/linkerd/docs/interpreter.md
@@ -41,7 +41,7 @@ interpreter accepts the following parameters:
 
 `io.l5d.fs`
 
-The default interpreter resolves names via the configured
+The file-system interpreter resolves names via the configured
 [`namers`](config.md#namers), just like the default interpreter, but also uses
 a dtab read from a file on the local file-system.  The specified file is watched
 for changes so that the dtab may be edited live.  This interpreter accepts the

--- a/linkerd/docs/interpreter.md
+++ b/linkerd/docs/interpreter.md
@@ -36,3 +36,15 @@ interpreter accepts the following parameters:
  namerd.  (default: (5 seconds, 10 minutes))
   * *baseSeconds* -- The base number of seconds to wait before retrying.
   * *maxSeconds* -- The maximum number of seconds to wait before retrying.
+
+## File-System
+
+`io.l5d.fs`
+
+The default interpreter resolves names via the configured
+[`namers`](config.md#namers), just like the default interpreter, but also uses
+a dtab read from a file on the local file-system.  The specified file is watched
+for changes so that the dtab may be edited live.  This interpreter accepts the
+following parameters:
+
+* *dtabFile* -- Required.  The file-system path to a file containing a dtab.

--- a/linkerd/examples/acceptance-test.yaml
+++ b/linkerd/examples/acceptance-test.yaml
@@ -39,6 +39,7 @@ namers:
 routers:
 - protocol: http
   label: int
+  dstPrefix: /http
   interpreter:
     kind: io.l5d.fs
     dtabFile: linkerd/examples/example.dtab

--- a/linkerd/examples/acceptance-test.yaml
+++ b/linkerd/examples/acceptance-test.yaml
@@ -39,9 +39,9 @@ namers:
 routers:
 - protocol: http
   label: int
-  baseDtab: |
-    /http/1.1 => /$/inet/127.1/9999;
-  dstPrefix: /http
+  interpreter:
+    kind: io.l5d.fs
+    dtabFile: linkerd/examples/example.dtab
   failFast: false
   timeoutMs: 1000
   httpAccessLog: logs/access.log

--- a/linkerd/examples/example.dtab
+++ b/linkerd/examples/example.dtab
@@ -1,0 +1,2 @@
+/host => /#/io.l5d.fs;
+/http/1.1/* => /host

--- a/linkerd/examples/example.dtab
+++ b/linkerd/examples/example.dtab
@@ -1,2 +1,1 @@
-/host => /#/io.l5d.fs;
-/http/1.1/* => /host
+/http/1.1 => /$/inet/127.1/9999;

--- a/namer/core/src/main/scala/io/buoyant/namer/ConfiguredDtabNamer.scala
+++ b/namer/core/src/main/scala/io/buoyant/namer/ConfiguredDtabNamer.scala
@@ -1,10 +1,9 @@
-package io.buoyant.namerd
+package io.buoyant.namer
 
 import com.twitter.finagle.Name.Bound
 import com.twitter.finagle._
 import com.twitter.finagle.naming.NameInterpreter
 import com.twitter.util.Activity
-import io.buoyant.namer.{ConfiguredNamersInterpreter, DelegateTree, Delegator}
 
 case class ConfiguredDtabNamer(
   configuredDtab: Activity[Dtab],

--- a/namer/fs/src/main/scala/io/buoyant/namer/fs/Watcher.scala
+++ b/namer/fs/src/main/scala/io/buoyant/namer/fs/Watcher.scala
@@ -8,7 +8,7 @@ import java.nio.file.{Path => NioPath, _}
 import java.nio.file.StandardWatchEventKinds._
 import scala.collection.JavaConverters._
 
-private[fs] object Watcher {
+object Watcher {
 
   private[this] val log = Logger.get(getClass.getName)
 

--- a/namerd/core/src/main/scala/io/buoyant/namerd/InterpreterInterfaceConfig.scala
+++ b/namerd/core/src/main/scala/io/buoyant/namerd/InterpreterInterfaceConfig.scala
@@ -5,6 +5,7 @@ import com.twitter.finagle.naming.NameInterpreter
 import com.twitter.finagle.stats.StatsReceiver
 import com.twitter.finagle.{Dtab, Namer, Path}
 import io.buoyant.config.ConfigInitializer
+import io.buoyant.namer.ConfiguredDtabNamer
 
 trait InterpreterInterfaceConfig extends InterfaceConfig {
   @JsonIgnore

--- a/namerd/core/src/test/scala/io/buoyant/namerd/ConfiguredDtabNamerTest.scala
+++ b/namerd/core/src/test/scala/io/buoyant/namerd/ConfiguredDtabNamerTest.scala
@@ -2,6 +2,7 @@ package io.buoyant.namerd
 
 import com.twitter.finagle._
 import com.twitter.util.{Activity, Await, Var}
+import io.buoyant.namer.ConfiguredDtabNamer
 import java.net.InetSocketAddress
 import org.scalatest.FunSuite
 

--- a/namerd/iface/interpreter-thrift/src/test/scala/io/buoyant/namerd/iface/ThriftNamerEndToEndTest.scala
+++ b/namerd/iface/interpreter-thrift/src/test/scala/io/buoyant/namerd/iface/ThriftNamerEndToEndTest.scala
@@ -5,8 +5,8 @@ import com.twitter.finagle.naming.NameInterpreter
 import com.twitter.finagle.stats.NullStatsReceiver
 import com.twitter.finagle._
 import com.twitter.util._
-import io.buoyant.namer.DelegateTree
-import io.buoyant.namerd.{ConfiguredDtabNamer, RichActivity}
+import io.buoyant.namer.{ConfiguredDtabNamer, DelegateTree}
+import io.buoyant.namerd.RichActivity
 import io.buoyant.test.Awaits
 import java.util.concurrent.atomic.AtomicLong
 import org.scalatest.FunSuite

--- a/project/LinkerdBuild.scala
+++ b/project/LinkerdBuild.scala
@@ -324,9 +324,13 @@ object LinkerdBuild extends Base {
       .withTests()
       .dependsOn(Namer.core, Namerd.Iface.interpreterThrift)
 
+    val fs = projectDir("interpreter/fs")
+      .withTests()
+      .dependsOn(Namer.core, Namer.fs)
+
     val all = projectDir("interpreter")
       .settings(aggregateSettings)
-      .aggregate(namerd)
+      .aggregate(namerd, fs)
   }
 
   object Linkerd {
@@ -452,7 +456,7 @@ object LinkerdBuild extends Base {
       // Bundle is includes all of the supported features:
       .configDependsOn(Bundle)(
         Namer.consul, Namer.k8s, Namer.marathon, Namer.serversets, Namer.zkLeader,
-        Interpreter.namerd,
+        Interpreter.namerd, Interpreter.fs,
         Protocol.mux, Protocol.thrift,
         Tracer.zipkin,
         tls)
@@ -529,6 +533,7 @@ object LinkerdBuild extends Base {
 
   val interpreter = Interpreter.all
   val interpreterNamerd = Interpreter.namerd
+  val interpreterFs = Interpreter.fs
 
   val linkerd = Linkerd.all
   val linkerdBenchmark = Linkerd.Protocol.benchmark


### PR DESCRIPTION
The file-system interpreter (io.l5d.fs) resolves names via the configured namers, just like the default interpreter, but also uses a dtab read from a file on the local file-system.  The specified file is watched for changes so that the dtab may be edited live.