### PR TITLE
Dashboard: add toggling to the router clients 

### DIFF
--- a/admin/src/main/resources/io/buoyant/admin/css/dashboard.css
+++ b/admin/src/main/resources/io/buoyant/admin/css/dashboard.css
@@ -236,6 +236,11 @@ nav ul.navbar-nav {
   padding: 8px 0;
 }
 
+.client-toggle {
+  font-size: 14px;
+  cursor: pointer;
+}
+
 .router-latencies-container {
   padding-top: 18px;
 }

--- a/admin/src/main/resources/io/buoyant/admin/js/metrics_collector.js
+++ b/admin/src/main/resources/io/buoyant/admin/js/metrics_collector.js
@@ -32,8 +32,8 @@ var MetricsCollector = (function() {
     listeners.push({handler: handler, metrics: metrics});
   }
 
-  function deregisterListener(listener) {
-    _.remove(listeners, function(l) { return l.handler === listener; });
+  function deregisterListener(handler) {
+    _.remove(listeners, function(l) { return l.handler === handler; });
   }
 
   return function(initialMetrics) {

--- a/admin/src/main/resources/io/buoyant/admin/js/router_client.js
+++ b/admin/src/main/resources/io/buoyant/admin/js/router_client.js
@@ -83,17 +83,42 @@ var RouterClient = (function() {
     return summary;
   }
 
-  return function (metricsCollector, routers, client, $metricsEl, routerName, clientTemplate, metricPartial, $chartEl, colors) {
+  return function (metricsCollector, routers, client, $metricsEl, routerName, clientTemplate, metricPartial, $chartEl, colors, $toggleLinks, shouldExpandInitially) {
     template = clientTemplate;
     Handlebars.registerPartial('metricPartial', metricPartial);
     var clientColor = colors.color;
     var latencyLegend = createLatencyLegend(colors.colorFamily);
     var metricDefinitions = getMetricDefinitions(routerName, client.label);
 
-    renderMetrics($metricsEl, client, [], [], clientColor);
-    var chart = SuccessRateGraph($chartEl, colors.color);
+    var $expandLink = $toggleLinks.find(".client-expand");
+    var $collapseLink = $toggleLinks.find(".client-collapse");
 
-    var metricsHandler = function(data) {
+    renderMetrics($metricsEl, client, [], [], clientColor);
+    var chart = SuccessRateGraph($chartEl.find($(".client-success-rate")), colors.color);
+
+    // collapse client section by default (deal with large # of clients)
+    if(shouldExpandInitially) {
+      toggleClientDisplay(true);
+    } else {
+      toggleClientDisplay(false);
+    }
+
+    $expandLink.click(function() { toggleClientDisplay(true); });
+    $collapseLink.click(function() { toggleClientDisplay(false); });
+
+    function toggleClientDisplay(expand) {
+      if (expand) {
+        metricsCollector.registerListener(metricsHandler, getDesiredMetrics);
+      } else {
+        metricsCollector.deregisterListener(metricsHandler);
+      }
+      $metricsEl.toggle(expand);
+      $chartEl.toggle(expand);
+      $collapseLink.toggle(expand);
+      $expandLink.toggle(!expand);
+    }
+
+    function metricsHandler(data) {
       var filteredData = _.filter(data.specific, function (d) { return d.name.indexOf(routerName) !== -1 });
       var summaryData = getSummaryData(filteredData, metricDefinitions);
       var latencies = getLatencyData(client, latencyKeys, latencyLegend); // this legend is no longer used in any charts: consider removing
@@ -102,13 +127,11 @@ var RouterClient = (function() {
       renderMetrics($metricsEl, client, summaryData, latencies, clientColor);
     }
 
-    var getDesiredMetrics = function(metrics) {
+    function getDesiredMetrics(metrics) {
       return  _.flatMap(metricDefinitions, function(d) {
         return Query.filter(d.query, metrics);
       });
     }
-
-    metricsCollector.registerListener(metricsHandler, getDesiredMetrics);
 
     return {
       updateColors: function(clientToColor) {

--- a/admin/src/main/resources/io/buoyant/admin/js/router_clients.js
+++ b/admin/src/main/resources/io/buoyant/admin/js/router_clients.js
@@ -1,6 +1,8 @@
 /* globals CombinedClientGraph, RouterClient */
 /* exported RouterClients */
 var RouterClients = (function() {
+  var EXPAND_CLIENT_THRESHOLD = 6;
+
   function assignColorsToClients(colors, clients) {
     var colorIdx = 0;
 
@@ -10,19 +12,29 @@ var RouterClients = (function() {
     }, {});
   }
 
+  function shouldExpandClients(numClients) {
+    // if there are many clients, collapse them by default to improve page perfomance
+    return numClients < EXPAND_CLIENT_THRESHOLD;
+  }
+
   return function (metricsCollector, routers, $clientEl, routerName, clientTemplate, metricPartial, clientContainerTemplate, colors) {
     var clientToColor = assignColorsToClients(colors, routers.clients(routerName));
     var combinedClientGraph = CombinedClientGraph(metricsCollector, routerName, $clientEl.find(".router-graph"), clientToColor);
     var clients = routers.clients(routerName);
 
-    var routerClients = _.map(clients, initializeClient);
+    var expandClients = shouldExpandClients(clients.length);
+
+    var routerClients = _.map(clients, function(client) {
+      return initializeClient(client, expandClients);
+    });
+
     if (routerClients.length == 0) {
       $clientEl.hide();
     }
 
     routers.onAddedClients(addClients);
 
-    function initializeClient(client) {
+    function initializeClient(client, shouldExpand) {
       $clientEl.show();
       var colorsForClient = clientToColor[client.label];
       var $container = $(clientContainerTemplate({
@@ -31,8 +43,9 @@ var RouterClients = (function() {
       })).appendTo($clientEl);
       var $metrics = $container.find(".metrics-container");
       var $chart = $container.find(".chart-container");
+      var $toggle = $container.find(".client-toggle");
 
-      return RouterClient(metricsCollector, routers, client, $metrics, routerName, clientTemplate, metricPartial, $chart, colorsForClient);
+      return RouterClient(metricsCollector, routers, client, $metrics, routerName, clientTemplate, metricPartial, $chart, colorsForClient, $toggle, shouldExpand);
     }
 
     function addClients(addedClients) {
@@ -46,11 +59,13 @@ var RouterClients = (function() {
         routerClient.updateColors(clientToColor);
       });
 
+      var expandClients = shouldExpandClients(addedClients.length + routerClients.length);
+
       // add new clients
       _.chain(addedClients)
         .filter(function(client) { return client.router === routerName })
         .each(function(clientForRouter) {
-          routerClients.push(initializeClient(clientForRouter));
+          routerClients.push(initializeClient(clientForRouter, expandClients));
         })
         .value();
     }

--- a/admin/src/main/resources/io/buoyant/admin/template/router_client_container.template
+++ b/admin/src/main/resources/io/buoyant/admin/template/router_client_container.template
@@ -1,10 +1,14 @@
 <div class="client-container clearfix">
   <div class="router-header-large"style="border-bottom: 2px solid {{clientColor}};">
     /{{client}}
+    <div class="client-toggle pull-right">
+      <a class="client-expand" target="blank">expand</a>
+      <a class="client-collapse" target="blank">collapse</a>
+    </div>
   </div>
   <div class="metrics-container col-md-6"></div>
-  <div class="col-md-6">
+  <div class="chart-container col-md-6">
     <div class="router-graph-header">Client success rate</div>
-    <div class="chart-container "></div>
+    <div class="client-success-rate"></div>
   </div>
 </div>


### PR DESCRIPTION
Problem:
With large numbers of clients, there are many listeners registered to the metrics collector (each client registers with the metrics collector when initialized). After each stats fetch, the metrics collector goes through its list of handlers and calls `listener.handler`. That's a lot of work.

Solution:
* Add toggling to the router clients. When a section is toggled, register/deregister the listener with the metrics collector. This lets us have some control over how much work is being done.
* All clients under a router now collapse if there are more than 6 clients.
* Collapsed clients remove themselves from the list of metricsListeners on metricsCollector,
which should result in much less work being done for a large number of clients.

Fixes #572

![screen shot 2016-08-12 at 3 48 23 pm](https://cloud.githubusercontent.com/assets/549258/17639982/5fb65f44-60ad-11e6-8479-9f6f65af77e5.png)

![screen shot 2016-08-12 at 3 29 50 pm](https://cloud.githubusercontent.com/assets/549258/17639991/72909ecc-60ad-11e6-80ad-3c348d713faf.png)

