### PR TITLE
namerd http control api should return json

### DIFF
--- a/admin/src/main/scala/io/buoyant/admin/names/DelegateApiHandler.scala
+++ b/admin/src/main/scala/io/buoyant/admin/names/DelegateApiHandler.scala
@@ -4,6 +4,7 @@ package admin.names
 import com.fasterxml.jackson.annotation._
 import com.fasterxml.jackson.core.{io => _, _}
 import com.fasterxml.jackson.databind._
+import com.fasterxml.jackson.databind.annotation.JsonSerialize.Inclusion
 import com.fasterxml.jackson.databind.module.SimpleModule
 import com.fasterxml.jackson.module.scala.DefaultScalaModule
 import com.fasterxml.jackson.module.scala.experimental.ScalaObjectMapper
@@ -169,6 +170,7 @@ object DelegateApiHandler {
     private[this] val mapper = new ObjectMapper with ScalaObjectMapper
     mapper.registerModule(DefaultScalaModule)
     mapper.configure(DeserializationFeature.FAIL_ON_UNKNOWN_PROPERTIES, false)
+    mapper.setSerializationInclusion(JsonInclude.Include.NON_NULL)
     mapper.registerModule(mkModule())
 
     def writeStr[T](t: T): String = mapper.writeValueAsString(t)

--- a/linkerd/admin/src/test/scala/io/buoyant/linkerd/admin/names/DelegateApiHandlerTest.scala
+++ b/linkerd/admin/src/test/scala/io/buoyant/linkerd/admin/names/DelegateApiHandlerTest.scala
@@ -43,7 +43,7 @@ class DelegateApiHandlerTest extends FunSuite with Awaits {
     val rsp = await(web(req))
     assert(rsp.status == Status.Ok)
     assert(rsp.contentString == """{
-      |"type":"delegate","path":"/boo/humbug","dentry":null,"delegate":{
+      |"type":"delegate","path":"/boo/humbug","delegate":{
         |"type":"alt","path":"/foo/humbug","dentry":{"prefix":"/boo","dst":"/foo"},"alt":[
           |{"type":"neg","path":"/bar/humbug","dentry":{"prefix":"/foo","dst":"/bar"}},
           |{"type":"delegate","path":"/bah/humbug",


### PR DESCRIPTION
# Problems

* bind and addr endpoints on the namerd http api don't return data in a machine readable format
* delegate endpoint on the namerd api double-includes the dtab, resulting in redundant alts in the delegation

# Solutions

* render bind and addr output as json
* don't double-include dtabs in delegate

# Results

```
17:10:05 ~$ curl 'localhost:4180/api/1/delegate/pandoracorn?path=/http/1.1/GET/default'
{"type":"delegate","path":"/http/1.1/GET/default","delegate":{"type":"leaf","path":"/#/io.l5d.fs/default","dentry":{"prefix":"/http/1.1/GET","dst":"/#/io.l5d.fs"},"bound":{"addr":{"type":"bound","addrs":[{"ip":"127.0.0.1","port":9990},{"ip":"127.0.0.2","port":9990},{"ip":"127.0.0.3","port":9990}],"meta":{}},"id":"/#/io.l5d.fs/default","path":"/"}}}⏎                                                                                                                                                      17:10:11 ~$ curl 'localhost:4180/api/1/bind/pandoracorn?path=/http/1.1/GET/default'
{"type":"leaf","bound":{"addr":{"type":"bound","addrs":[{"ip":"127.0.0.1","port":9990},{"ip":"127.0.0.2","port":9990},{"ip":"127.0.0.3","port":9990}],"meta":{}},"id":"/#/io.l5d.fs/default","path":"/"}}
17:10:17 ~$ curl 'localhost:4180/api/1/addr/pandoracorn?path=/%23/io.l5d.fs/default'
{"type":"bound","addrs":[{"ip":"127.0.0.1","port":9990},{"ip":"127.0.0.2","port":9990},{"ip":"127.0.0.3","port":9990}],"meta":{}}
```