### PR TITLE
Consul API refactoring

### DIFF
--- a/consul/src/main/scala/io/buoyant/consul/SetAuthTokenFilter.scala
+++ b/consul/src/main/scala/io/buoyant/consul/SetAuthTokenFilter.scala
@@ -1,0 +1,12 @@
+package io.buoyant.consul
+
+import com.twitter.finagle.http.{Request, Response}
+import com.twitter.finagle.{Service, SimpleFilter}
+
+class SetAuthTokenFilter(token: String) extends SimpleFilter[Request, Response] {
+
+  def apply(req: Request, svc: Service[Request, Response]) = {
+    req.headerMap.set("X-Consul-Token", token)
+    svc(req)
+  }
+}

--- a/consul/src/main/scala/io/buoyant/consul/v1/BaseApi.scala
+++ b/consul/src/main/scala/io/buoyant/consul/v1/BaseApi.scala
@@ -61,17 +61,11 @@ trait BaseApi extends Closable {
     Try(mapper.readValue[T](bytes, begin, end - begin))
   }
 
-  private[v1] def executeJson[T: Manifest](req: http.Request, retry: Boolean): Future[Indexed[T]] = {
+  private[v1] def execute[T: Manifest](req: http.Request, retry: Boolean): Future[Indexed[T]] = {
     for {
       rsp <- Trace.letClear(getClient(retry)(req))
       value <- Future.const(parseJson[T](rsp.content))
     } yield Indexed[T](value, rsp.headerMap.get(Headers.Index))
-  }
-
-  private[v1] def executeRaw(req: http.Request, retry: Boolean): Future[Indexed[String]] = {
-    Trace.letClear(getClient(retry)(req)).map { rsp =>
-      Indexed[String](rsp.contentString, rsp.headerMap.get(Headers.Index))
-    }
   }
 }
 

--- a/consul/src/main/scala/io/buoyant/consul/v1/CatalogApi.scala
+++ b/consul/src/main/scala/io/buoyant/consul/v1/CatalogApi.scala
@@ -22,7 +22,7 @@ class CatalogApi(
   // https://www.consul.io/docs/agent/http/catalog.html#catalog_datacenters
   def datacenters(retry: Boolean = false): Future[Seq[String]] = {
     val req = mkreq(http.Method.Get, s"$catalogPrefix/datacenters")
-    executeJson[Seq[String]](req, retry).map(_.value)
+    execute[Seq[String]](req, retry).map(_.value)
   }
 
   // https://www.consul.io/docs/agent/http/catalog.html#catalog_services
@@ -37,7 +37,7 @@ class CatalogApi(
       "index" -> blockingIndex,
       "dc" -> datacenter
     )
-    executeJson[Map[String, Seq[String]]](req, retry)
+    execute[Map[String, Seq[String]]](req, retry)
   }
 
   // https://www.consul.io/docs/agent/http/catalog.html#catalog_service
@@ -55,7 +55,7 @@ class CatalogApi(
       "dc" -> datacenter,
       "tag" -> tag
     )
-    executeJson[Seq[ServiceNode]](req, retry)
+    execute[Seq[ServiceNode]](req, retry)
   }
 }
 

--- a/consul/src/main/scala/io/buoyant/consul/v1/package.scala
+++ b/consul/src/main/scala/io/buoyant/consul/v1/package.scala
@@ -1,6 +1,6 @@
 package io.buoyant.consul
 
-import com.twitter.finagle.{SimpleFilter, Service, http}
+import com.twitter.finagle.{Service, SimpleFilter, http}
 import com.twitter.util.Future
 
 package object v1 {
@@ -16,7 +16,7 @@ package object v1 {
 
   private[v1] val apiErrorFilter = new SimpleFilter[http.Request, http.Response] {
 
-    def apply(request: http.Request, service: Client): Future[http.Response] = {
+    def apply(request: http.Request, service: Client): Future[http.Response] =
       service(request).flatMap { response: http.Response =>
         response.status match {
           case http.Status.Ok => Future.value(response)
@@ -25,7 +25,5 @@ package object v1 {
           case _ => Future.exception(UnexpectedResponse(response))
         }
       }
-    }
   }
-
 }

--- a/linkerd/admin/src/test/scala/io/buoyant/linkerd/admin/names/DelegateApiHandlerTest.scala
+++ b/linkerd/admin/src/test/scala/io/buoyant/linkerd/admin/names/DelegateApiHandlerTest.scala
@@ -1,10 +1,11 @@
 package io.buoyant.linkerd.admin.names
 
+import com.twitter.conversions.time._
 import com.twitter.finagle.Name.Bound
 import com.twitter.finagle.http._
 import com.twitter.finagle.naming.NameInterpreter
 import com.twitter.finagle.{Status => _, _}
-import com.twitter.util.{Var, Activity}
+import com.twitter.util.Activity
 import io.buoyant.admin.names.DelegateApiHandler
 import io.buoyant.linkerd._
 import io.buoyant.namer.{ErrorNamerInitializer, TestNamerInitializer}
@@ -40,7 +41,7 @@ class DelegateApiHandlerTest extends FunSuite with Awaits {
     val web = new DelegateApiHandler(_ => linker.routers.head.interpreter)
     val req = Request()
     req.uri = s"/delegate?namespace=plain&path=/boo/humbug&dtab=${URLEncoder.encode(dtab.show, "UTF-8")}"
-    val rsp = await(web(req))
+    val rsp = await(500.millis)(web(req))
     assert(rsp.status == Status.Ok)
     assert(rsp.contentString == """{
       |"type":"delegate","path":"/boo/humbug","dentry":null,"delegate":{

--- a/linkerd/docs/namer.md
+++ b/linkerd/docs/namer.md
@@ -131,6 +131,7 @@ The Consul namer is configured with kind `io.l5d.consul`, and these parameters:
 * *host* --  the Consul host. (default: localhost)
 * *port* --  the Consul port. (default: 8500)
 * *includeTag* -- whether to read a Consul tag from the path.  (default: false)
+* *token* -- Optional. The auth token to use when making API calls.
 
 For example:
 ```yaml

--- a/namer/consul/src/main/scala/io/buoyant/namer/consul/ConsulInitializer.scala
+++ b/namer/consul/src/main/scala/io/buoyant/namer/consul/ConsulInitializer.scala
@@ -4,7 +4,7 @@ import com.fasterxml.jackson.annotation.JsonIgnore
 import com.twitter.finagle.param.Label
 import com.twitter.finagle.tracing.NullTracer
 import com.twitter.finagle.{Http, Path, Stack}
-import io.buoyant.consul.{CatalogNamer, SetHostFilter, v1}
+import io.buoyant.consul.{SetAuthTokenFilter, CatalogNamer, SetHostFilter, v1}
 import io.buoyant.config.types.Port
 import io.buoyant.namer.{NamerConfig, NamerInitializer}
 
@@ -30,7 +30,8 @@ object ConsulInitializer extends ConsulInitializer
 case class ConsulConfig(
   host: Option[String],
   port: Option[Port],
-  includeTag: Option[Boolean]
+  includeTag: Option[Boolean],
+  token: Option[String] = None
 ) extends NamerConfig {
 
   @JsonIgnore
@@ -50,11 +51,16 @@ case class ConsulConfig(
    */
   @JsonIgnore
   def newNamer(params: Stack.Params): CatalogNamer = {
+    val filters = if (token.isDefined)
+      new SetHostFilter(getHost, getPort) andThen new SetAuthTokenFilter(token.get)
+    else
+      new SetHostFilter(getHost, getPort)
+
     val service = Http.client
       .withParams(Http.client.params ++ params)
       .configured(Label("namer" + prefix))
       .withTracer(NullTracer)
-      .filtered(new SetHostFilter(getHost, getPort))
+      .filtered(filters)
       .newService(s"/$$/inet/$getHost/$getPort")
 
     new CatalogNamer(prefix, v1.CatalogApi(service), includeTag.getOrElse(false))

--- a/namer/consul/src/main/scala/io/buoyant/namer/consul/ConsulInitializer.scala
+++ b/namer/consul/src/main/scala/io/buoyant/namer/consul/ConsulInitializer.scala
@@ -18,6 +18,7 @@ import io.buoyant.namer.{NamerConfig, NamerInitializer}
  *   host: consul.site.biz
  *   port: 8600
  *   includeTag: true
+ *   token: some-consul-acl-token
  * </pre>
  */
 class ConsulInitializer extends NamerInitializer {

--- a/namer/consul/src/test/scala/io/buoyant/namer/consul/ConsulTest.scala
+++ b/namer/consul/src/test/scala/io/buoyant/namer/consul/ConsulTest.scala
@@ -23,6 +23,7 @@ class ConsulTest extends FunSuite {
                     |kind: io.l5d.consul
                     |experimental: true
                     |host: consul.site.biz
+                    |token: some-token
                     |port: 8600
       """.stripMargin
 
@@ -30,6 +31,7 @@ class ConsulTest extends FunSuite {
     val consul = mapper.readValue[NamerConfig](yaml).asInstanceOf[ConsulConfig]
     assert(consul.host == Some("consul.site.biz"))
     assert(consul.port == Some(Port(8600)))
+    assert(consul.token == Some("some-token"))
     assert(!consul.disabled)
   }
 

--- a/namerd/docs/storage.md
+++ b/namerd/docs/storage.md
@@ -85,4 +85,5 @@ Stores the dtab in Consul KV storage.  Supports the following options
 * *host* -- Optional. The location of the etcd API.  (default: localhost)
 * *port* -- Optional. The port used to connect to the consul API.  (default: 8500)
 * *pathPrefix* -- Optional. The key path under which dtabs should be stored.  (default: "/namerd/dtabs")
-* *token* -- Optional. The auth token to use when making API calls.
+* *token* -- Optional. The auth token to use when making API calls. (default: not set)
+* *datacenter* -- Optional. The datacenter to forward requests to. (default: not set, use agent's datacenter)

--- a/namerd/docs/storage.md
+++ b/namerd/docs/storage.md
@@ -84,4 +84,5 @@ Stores the dtab in Consul KV storage.  Supports the following options
 
 * *host* -- Optional. The location of the etcd API.  (default: localhost)
 * *port* -- Optional. The port used to connect to the consul API.  (default: 8500)
-* *pathPrefix* -- Optional.  The key path under which dtabs should be stored.  (default: "/namerd/dtabs")
+* *pathPrefix* -- Optional. The key path under which dtabs should be stored.  (default: "/namerd/dtabs")
+* *token* -- Optional. The auth token to use when making API calls.

--- a/namerd/iface/control-http/src/main/scala/io/buoyant/namerd/iface/HttpControlService.scala
+++ b/namerd/iface/control-http/src/main/scala/io/buoyant/namerd/iface/HttpControlService.scala
@@ -217,7 +217,7 @@ class HttpControlService(storage: DtabStore, delegate: Ns => NameInterpreter, na
 
   private[this] def isStreaming(req: Request): Boolean = req.getBooleanParam("watch")
 
-  private[this] def renderList(list: Set[Ns]): Buf = Json.write(list).concat(newline)
+  private[this] def renderList(list: Iterable[Ns]): Buf = Json.write(list).concat(newline)
 
   private[this] def handleList(req: Request): Future[Response] =
     if (isStreaming(req)) {
@@ -226,7 +226,7 @@ class HttpControlService(storage: DtabStore, delegate: Ns => NameInterpreter, na
       storage.list().toFuture.map { namespaces =>
         val rsp = Response()
         rsp.contentType = MediaType.Json
-        rsp.content = renderList(namespaces)
+        rsp.content = renderList(namespaces.toSeq.sorted)
         rsp
       }
     }

--- a/namerd/iface/control-http/src/test/scala/io/buoyant/namerd/iface/HttpControlServiceTest.scala
+++ b/namerd/iface/control-http/src/test/scala/io/buoyant/namerd/iface/HttpControlServiceTest.scala
@@ -55,7 +55,7 @@ class HttpControlServiceTest extends FunSuite with Awaits {
     val rsp = Await.result(service(req), 1.second)
     assert(rsp.status == Status.Ok)
     assert(rsp.contentType == Some(MediaType.Json))
-    val expected = HttpControlService.Json.write(defaultDtabs.keys).concat(HttpControlService.newline)
+    val expected = HttpControlService.Json.write(defaultDtabs.keys.toSeq.sorted).concat(HttpControlService.newline)
     assert(rsp.content == expected)
   }
 
@@ -112,7 +112,7 @@ class HttpControlServiceTest extends FunSuite with Awaits {
     val rsp = Await.result(service(req), 1.second)
     assert(rsp.status == Status.Ok)
     assert(rsp.contentType == Some(MediaType.Json))
-    val expected = HttpControlService.Json.write(defaultDtabs.keys).concat(HttpControlService.newline)
+    val expected = HttpControlService.Json.write(defaultDtabs.keys.toSeq.sorted).concat(HttpControlService.newline)
     assert(rsp.content == expected)
   }
 

--- a/namerd/main/src/main/scala/io/buoyant/namerd/DtabListHandler.scala
+++ b/namerd/main/src/main/scala/io/buoyant/namerd/DtabListHandler.scala
@@ -12,11 +12,11 @@ class DtabListHandler(
     store.list().toFuture.map { list =>
       val response = Response()
       response.contentType = MediaType.Html + ";charset=UTF-8"
-      response.contentString = render(list)
+      response.contentString = render(list.toSeq.sorted)
       response
     }
 
-  def render(list: Set[String]) = {
+  def render(list: Iterable[String]) = {
     val listHtml = list.map { ns =>
       s"""
         <a class="list-group-item" href="dtab/$ns">$ns</a>

--- a/namerd/storage/consul/src/main/scala/io/buoyant/namerd/storage/consul/ConsulDtabStore.scala
+++ b/namerd/storage/consul/src/main/scala/io/buoyant/namerd/storage/consul/ConsulDtabStore.scala
@@ -1,7 +1,7 @@
 package io.buoyant.namerd
 package storage.consul
 
-import com.twitter.finagle.{Dtab, Path}
+import com.twitter.finagle.{Dtab, Failure, Path}
 import com.twitter.io.Buf
 import com.twitter.util._
 import io.buoyant.consul.v1._
@@ -9,98 +9,77 @@ import io.buoyant.namerd.DtabStore.{DtabNamespaceAlreadyExistsException, DtabNam
 
 class ConsulDtabStore(api: KvApi, root: Path) extends DtabStore {
 
-  override def list(): Activity[Set[Ns]] = {
-    def namespace(key: String): Ns = key.stripPrefix("/").stripSuffix("/").substring(root.show.length)
+  def path(ns: Ns) = s"${root.show}/$ns"
 
-    val run = Var.async[Activity.State[Set[Ns]]](Activity.Pending) { updates =>
-      @volatile var running = true
+  def getNs(ns: Ns, index: Option[String] = None) =
+    api.get(path(ns), blockingIndex = index, recurse = path(ns).endsWith("/"))
 
+  def putNs(ns: Ns, value: String, cas: Option[String] = None) = api.put(path(ns), value, cas = cas)
+
+  def watch[T](ns: Ns)(empty: T)(f: Indexed[Seq[Key]] => T) = {
+    val run = Var.async[Activity.State[T]](Activity.Pending) { updates =>
       def cycle(index: Option[String]): Future[Unit] =
-        if (running)
-          api.list(s"${root.show}/", blockingIndex = index).transform {
-            case Return(result) =>
-              val namespaces = result.value.map(namespace).toSet
-              updates() = Activity.Ok(namespaces)
-              cycle(result.index)
-            case Throw(e: NotFound) =>
-              updates() = Activity.Ok(Set.empty[Ns])
-              cycle(e.rsp.headerMap.get(Headers.Index))
-            case Throw(e) =>
-              updates() = Activity.Failed(e)
-              cycle(None)
-          }
-        else
-          Future.Unit
+        getNs(ns, index = index).transform {
+          case Return(result) =>
+            updates() = Activity.Ok(f(result))
+            cycle(result.index)
+          case Throw(e: NotFound) =>
+            updates() = Activity.Ok(empty)
+            cycle(e.rsp.headerMap.get(Headers.Index))
+          case Throw(e: Failure) if e.isFlagged(Failure.Interrupted) => Future.Unit
+          case Throw(e) =>
+            updates() = Activity.Failed(e)
+            cycle(None)
+        }
       val pending = cycle(None)
 
-      Closable.make { _ =>
-        running = false
-        pending.raise(new FutureCancelledException)
-        Future.Unit
-      }
+      Closable.make(_ => Future.value(pending.raise(new FutureCancelledException)))
     }
 
     Activity(run)
   }
 
+  override def list(): Activity[Set[Ns]] = watch[Set[Ns]]("")(Set.empty[Ns]) { keys =>
+    keys.value.map(_.Key.get.substring(root.show.length)).toSet // strip pathPrefix from keys
+  }
+
   def create(ns: Ns, dtab: Dtab): Future[Unit] =
-    api.put(s"${root.show}/$ns", dtab.show, cas = Some("0")).flatMap { result =>
+    putNs(ns, dtab.show, cas = Some("0")).flatMap { result =>
       if (result) Future.Done else Future.exception(new DtabNamespaceAlreadyExistsException(ns))
     }
 
-  def delete(ns: Ns): Future[Unit] = {
-    val key = s"${root.show}/$ns"
-    api.get(key).transform {
-      case Return(_) => api.delete(key).unit
-      case Throw(e: NotFound) => Future.exception(new DtabNamespaceDoesNotExistException(ns))
-      case Throw(e) => Future.exception(e)
-    }
+  def delete(ns: Ns): Future[Unit] = getNs(ns).transform {
+    case Return(_) => api.delete(path(ns)).unit
+    case Throw(e: NotFound) => Future.exception(new DtabNamespaceDoesNotExistException(ns))
+    case Throw(e) => Future.exception(e)
   }
 
   def update(ns: Ns, dtab: Dtab, version: Version): Future[Unit] = {
     val Buf.Utf8(vstr) = version
     Try(vstr.toLong) match {
       case Return(_) =>
-        api.put(s"${root.show}/$ns", dtab.show, cas = Some(vstr)).flatMap { result =>
+        putNs(ns, dtab.show, cas = Some(vstr)).flatMap { result =>
           if (result) Future.Done else Future.exception(new DtabVersionMismatchException)
         }
       case _ => Future.exception(new DtabVersionMismatchException)
     }
   }
 
-  def put(ns: Ns, dtab: Dtab): Future[Unit] =
-    api.put(s"${root.show}/$ns", dtab.show).unit
+  def put(ns: Ns, dtab: Dtab): Future[Unit] = putNs(ns, dtab.show).unit
 
-  def observe(ns: Ns): Activity[Option[VersionedDtab]] = {
-    val key = s"${root.show}/$ns"
-    val run = Var.async[Activity.State[Option[VersionedDtab]]](Activity.Pending) { updates =>
-      @volatile var running = true
-
-      def cycle(index: Option[String]): Future[Unit] =
-        if (running)
-          api.get(key, blockingIndex = index).transform {
-            case Return(result) =>
-              val version = Buf.Utf8(result.index.get)
-              val dtab = Dtab.read(result.value)
-              updates() = Activity.Ok(Some(VersionedDtab(dtab, version)))
-              cycle(result.index)
-            case Throw(e: NotFound) =>
-              updates() = Activity.Ok(None)
-              cycle(e.rsp.headerMap.get(Headers.Index))
-            case Throw(e) =>
-              updates() = Activity.Failed(e)
-              cycle(None)
-          }
-        else
-          Future.Unit
-      val pending = cycle(None)
-
-      Closable.make { _ =>
-        running = false
-        pending.raise(new FutureCancelledException)
-        Future.Unit
+  def readDtabFromKey(key: Key): Dtab = key.decoded match {
+    case Some(value) =>
+      Try { Dtab.read(value) } match {
+        case Return(dtab) => dtab
+        case _ => Dtab.empty // key with wrong dtab syntax -> empty dtab
       }
-    }
-    Activity(run)
+    case _ => Dtab.empty // empty key -> empty dtab
+  }
+
+  def observe(ns: Ns): Activity[Option[VersionedDtab]] = watch[Option[VersionedDtab]](ns)(None) { keys =>
+    // API returns list even when a single key requested - just handle output in a generic way
+    val dtab = keys.value.map(readDtabFromKey).reduceLeft(_ ++ _)
+    val version = Buf.Utf8(keys.index.get)
+    Some(VersionedDtab(dtab, version))
   }
 }

--- a/namerd/storage/consul/src/main/scala/io/buoyant/namerd/storage/consul/ConsulDtabStoreInitializer.scala
+++ b/namerd/storage/consul/src/main/scala/io/buoyant/namerd/storage/consul/ConsulDtabStoreInitializer.scala
@@ -12,7 +12,8 @@ case class ConsulConfig(
   host: Option[String],
   port: Option[Port],
   pathPrefix: Option[Path],
-  token: Option[String] = None
+  token: Option[String] = None,
+  datacenter: Option[String] = None
 ) extends DtabStoreConfig {
   import ConsulConfig._
 
@@ -34,7 +35,7 @@ case class ConsulConfig(
       .withTracer(NullTracer)
       .filtered(filters)
       .newService(s"/$$/inet/$serviceHost/$servicePort")
-    new ConsulDtabStore(KvApiV1(service), prefix)
+    new ConsulDtabStore(KvApiV1(service), prefix, datacenter = datacenter)
   }
 }
 

--- a/namerd/storage/consul/src/main/scala/io/buoyant/namerd/storage/consul/ConsulDtabStoreInitializer.scala
+++ b/namerd/storage/consul/src/main/scala/io/buoyant/namerd/storage/consul/ConsulDtabStoreInitializer.scala
@@ -5,7 +5,7 @@ import com.twitter.finagle.tracing.NullTracer
 import com.twitter.finagle.{Http, Path}
 import io.buoyant.config.types.Port
 import io.buoyant.consul.SetHostFilter
-import io.buoyant.consul.v1.KvApi
+import io.buoyant.consul.v1.KvApiV1
 import io.buoyant.namerd.{DtabStore, DtabStoreConfig, DtabStoreInitializer}
 
 case class ConsulConfig(
@@ -22,15 +22,13 @@ case class ConsulConfig(
   override def mkDtabStore: DtabStore = {
     val serviceHost = host.getOrElse(DefaultHost)
     val servicePort = port.getOrElse(DefaultPort).port
+    val prefix = pathPrefix.getOrElse(Path.read("/namerd/dtabs"))
 
     val service = Http.client
       .withTracer(NullTracer)
       .filtered(new SetHostFilter(serviceHost, servicePort))
       .newService(s"/$$/inet/$serviceHost/$servicePort")
-    new ConsulDtabStore(
-      KvApi(service),
-      pathPrefix.getOrElse(Path.read("/namerd/dtabs"))
-    )
+    new ConsulDtabStore(KvApiV1(service), prefix)
   }
 }
 

--- a/namerd/storage/consul/src/test/scala/io/buoyant/namerd/storage/consul/ConsulConfigTest.scala
+++ b/namerd/storage/consul/src/test/scala/io/buoyant/namerd/storage/consul/ConsulConfigTest.scala
@@ -17,6 +17,7 @@ class ConsulConfigTest extends FunSuite with OptionValues {
          |experimental: true
          |pathPrefix: /foo/bar
          |host: consul.local
+         |token: some-token
          |port: 80
       """.stripMargin
     val mapper = Parser.objectMapper(yaml, Iterable(Seq(ConsulDtabStoreInitializer)))
@@ -24,6 +25,7 @@ class ConsulConfigTest extends FunSuite with OptionValues {
     assert(consul.host.value == "consul.local")
     assert(consul.port.value == Port(80))
     assert(consul.pathPrefix == Some(Path.read("/foo/bar")))
+    assert(consul.token == Some("some-token"))
   }
 
 }

--- a/namerd/storage/consul/src/test/scala/io/buoyant/namerd/storage/consul/ConsulConfigTest.scala
+++ b/namerd/storage/consul/src/test/scala/io/buoyant/namerd/storage/consul/ConsulConfigTest.scala
@@ -20,10 +20,10 @@ class ConsulConfigTest extends FunSuite with OptionValues {
          |port: 80
       """.stripMargin
     val mapper = Parser.objectMapper(yaml, Iterable(Seq(ConsulDtabStoreInitializer)))
-    val etcd = mapper.readValue[DtabStoreConfig](yaml).asInstanceOf[ConsulConfig]
-    assert(etcd.host.value == "consul.local")
-    assert(etcd.port.value == Port(80))
-    assert(etcd.pathPrefix == Some(Path.read("/foo/bar")))
+    val consul = mapper.readValue[DtabStoreConfig](yaml).asInstanceOf[ConsulConfig]
+    assert(consul.host.value == "consul.local")
+    assert(consul.port.value == Port(80))
+    assert(consul.pathPrefix == Some(Path.read("/foo/bar")))
   }
 
 }

--- a/namerd/storage/consul/src/test/scala/io/buoyant/namerd/storage/consul/ConsulConfigTest.scala
+++ b/namerd/storage/consul/src/test/scala/io/buoyant/namerd/storage/consul/ConsulConfigTest.scala
@@ -18,6 +18,7 @@ class ConsulConfigTest extends FunSuite with OptionValues {
          |pathPrefix: /foo/bar
          |host: consul.local
          |token: some-token
+         |datacenter: us-east-42
          |port: 80
       """.stripMargin
     val mapper = Parser.objectMapper(yaml, Iterable(Seq(ConsulDtabStoreInitializer)))
@@ -26,6 +27,7 @@ class ConsulConfigTest extends FunSuite with OptionValues {
     assert(consul.port.value == Port(80))
     assert(consul.pathPrefix == Some(Path.read("/foo/bar")))
     assert(consul.token == Some("some-token"))
+    assert(consul.datacenter == Some("us-east-42"))
   }
 
 }

--- a/namerd/storage/consul/src/test/scala/io/buoyant/namerd/storage/consul/ConsulDtabStoreTest.scala
+++ b/namerd/storage/consul/src/test/scala/io/buoyant/namerd/storage/consul/ConsulDtabStoreTest.scala
@@ -1,0 +1,124 @@
+package io.buoyant.namerd.storage.consul
+
+import com.twitter.finagle.{Dtab, Path}
+import com.twitter.io.Buf
+import com.twitter.util.Future
+import io.buoyant.consul.v1.{Indexed, Key, KvApi}
+import io.buoyant.test.Awaits
+import org.scalatest.FunSuite
+
+class BaseKvApiStub extends KvApi {
+  def get(
+    path: String,
+    datacenter: Option[String],
+    blockingIndex: Option[String],
+    recurse: Boolean,
+    retry: Boolean
+  ): Future[Indexed[Seq[Key]]] = ???
+
+  def put(
+    path: String,
+    value: String,
+    datacenter: Option[String],
+    cas: Option[String],
+    retry: Boolean
+  ): Future[Boolean] = ???
+
+  def delete(
+    path: String,
+    datacenter: Option[String],
+    cas: Option[String],
+    recurse: Boolean = false,
+    retry: Boolean
+  ): Future[Boolean] = ???
+}
+
+class ConsulDtabStoreTest extends FunSuite with Awaits {
+
+  test("list returns namespaces with pathPrefix stripped") {
+
+    class ListKvApiStub(keys: Seq[Key]) extends BaseKvApiStub {
+      override def get(
+        path: String,
+        datacenter: Option[String],
+        blockingIndex: Option[String],
+        recurse: Boolean,
+        retry: Boolean
+      ): Future[Indexed[Seq[Key]]] = {
+        (path, recurse) match {
+          case ("/dtabs/", true) if blockingIndex != Some("42") => Future.value(Indexed[Seq[Key]](keys, Some("42")))
+          case ("/dtabs/", true) if blockingIndex == Some("42") => Future.never
+          case _ => ???
+        }
+      }
+    }
+
+    val api = new ListKvApiStub(Seq(
+      Key("dtabs/foo", "/foo=>/bar"),
+      Key("dtabs/bar", "/bar=>/baz")
+    ))
+
+    val store = new ConsulDtabStore(api, Path.read("/dtabs"))
+    val listFuture = store.list().values.map(_.toOption).toFuture()
+    val nsSet = await(listFuture).get
+
+    assert(nsSet == Set("foo", "bar"))
+  }
+
+  test("observe returns requested dtab value") {
+
+    class ListKvApiStub(keys: Seq[Key]) extends BaseKvApiStub {
+      override def get(
+        path: String,
+        datacenter: Option[String],
+        blockingIndex: Option[String],
+        recurse: Boolean,
+        retry: Boolean
+      ): Future[Indexed[Seq[Key]]] = {
+        (path, recurse) match {
+          case ("/dtabs/foo", false) if blockingIndex != Some("42") => Future.value(Indexed[Seq[Key]](keys, Some("42")))
+          case ("/dtabs/foo", false) if blockingIndex == Some("42") => Future.never
+          case _ => ???
+        }
+      }
+    }
+
+    val api = new ListKvApiStub(Seq(Key("dtabs/foo", "/foo=>/bar")))
+
+    val store = new ConsulDtabStore(api, Path.read("/dtabs"))
+    val dtabFuture = store.observe("foo").toFuture
+    val versionedDtab = await(dtabFuture).get
+
+    assert(versionedDtab.version == Buf.Utf8("42"))
+    assert(versionedDtab.dtab == Dtab.read("/foo=>/bar"))
+  }
+
+  test("observe reports broken dtabs as empty") {
+
+    class ListKvApiStub(keys: Seq[Key]) extends BaseKvApiStub {
+      override def get(
+        path: String,
+        datacenter: Option[String],
+        blockingIndex: Option[String],
+        recurse: Boolean,
+        retry: Boolean
+      ): Future[Indexed[Seq[Key]]] = {
+        (path, recurse) match {
+          case ("/dtabs/foo", false) if blockingIndex != Some("42") => Future.value(Indexed[Seq[Key]](keys, Some("42")))
+          case ("/dtabs/foo", false) if blockingIndex == Some("42") => Future.never
+          case _ => ???
+        }
+      }
+    }
+
+    val api = new ListKvApiStub(Seq(Key("dtabs/foo", "broken")))
+
+    val store = new ConsulDtabStore(api, Path.read("/dtabs"))
+    val dtabFuture = store.observe("foo").toFuture
+    val versionedDtab = await(dtabFuture).get
+
+    assert(versionedDtab.version == Buf.Utf8("42"))
+    assert(versionedDtab.dtab == Dtab.empty)
+  }
+
+}


### PR DESCRIPTION
This is the followup PR after #555 was declined.

As discussed previously with @olix0r this PR provides few improvements and optimizations for Consul API implementation making it more efficient and extensible.

The main changes are:
* `CatalogNamer` / `ConsulDtabStore` now can be configured with an extra `token` parameter that would set an auth token HTTP header for each request (done with a filter)
* `ConsulDtabStore` now can be configured with an extra `datacenter` parameter that would instruct Consul to forward requests to given datacenter rather than use the datacenter of local agent
* `io.buoyant.consul.v1.KvApi` - got rid of `list` method. This method is actually doesn't exist and just and alternative mode of operation for `get` method. The same result could be achieved by using `get` in recursive mode. Bonus: less code. :)
* `ConsulDtabStore` - remove code duplication (now it's less than 90 LOC), properly handle long-polling cancellation (get rid of tracebacks in logs when requests are canceled),  don't fail on malformed dtabs (report them as empty rather than crash), more tests
* `HttpControlService` / `DtabListHandler` - sort namespaces before showing them to user - no significant impact but just removes 'items jumping' in UI upon refresh which is really annoying when working with Named Admin UI