### PR TITLE
An option to set auth token for Consul backends

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,6 +1,7 @@
 ## x.x.x
 
 * Add file-system based name interpreter.
+* Add auth `token` parameter to Consul Namer & Dtab Store
 
 ## 0.7.3
 

--- a/consul/src/main/scala/io/buoyant/consul/SetAuthTokenFilter.scala
+++ b/consul/src/main/scala/io/buoyant/consul/SetAuthTokenFilter.scala
@@ -1,0 +1,12 @@
+package io.buoyant.consul
+
+import com.twitter.finagle.http.{Request, Response}
+import com.twitter.finagle.{Service, SimpleFilter}
+
+class SetAuthTokenFilter(token: String) extends SimpleFilter[Request, Response] {
+
+  def apply(req: Request, svc: Service[Request, Response]) = {
+    req.headerMap.set("X-Consul-Token", token)
+    svc(req)
+  }
+}

--- a/linkerd/docs/namer.md
+++ b/linkerd/docs/namer.md
@@ -131,6 +131,7 @@ The Consul namer is configured with kind `io.l5d.consul`, and these parameters:
 * *host* --  the Consul host. (default: localhost)
 * *port* --  the Consul port. (default: 8500)
 * *includeTag* -- whether to read a Consul tag from the path.  (default: false)
+* *token* -- Optional. The auth token to use when making API calls.
 
 For example:
 ```yaml

--- a/namer/consul/src/test/scala/io/buoyant/namer/consul/ConsulTest.scala
+++ b/namer/consul/src/test/scala/io/buoyant/namer/consul/ConsulTest.scala
@@ -23,6 +23,7 @@ class ConsulTest extends FunSuite {
                     |kind: io.l5d.consul
                     |experimental: true
                     |host: consul.site.biz
+                    |token: some-token
                     |port: 8600
       """.stripMargin
 
@@ -30,6 +31,7 @@ class ConsulTest extends FunSuite {
     val consul = mapper.readValue[NamerConfig](yaml).asInstanceOf[ConsulConfig]
     assert(consul.host == Some("consul.site.biz"))
     assert(consul.port == Some(Port(8600)))
+    assert(consul.token == Some("some-token"))
     assert(!consul.disabled)
   }
 

--- a/namerd/docs/storage.md
+++ b/namerd/docs/storage.md
@@ -84,4 +84,5 @@ Stores the dtab in Consul KV storage.  Supports the following options
 
 * *host* -- Optional. The location of the etcd API.  (default: localhost)
 * *port* -- Optional. The port used to connect to the consul API.  (default: 8500)
-* *pathPrefix* -- Optional.  The key path under which dtabs should be stored.  (default: "/namerd/dtabs")
+* *pathPrefix* -- Optional. The key path under which dtabs should be stored.  (default: "/namerd/dtabs")
+* *token* -- Optional. The auth token to use when making API calls.

--- a/namerd/storage/consul/src/test/scala/io/buoyant/namerd/storage/consul/ConsulConfigTest.scala
+++ b/namerd/storage/consul/src/test/scala/io/buoyant/namerd/storage/consul/ConsulConfigTest.scala
@@ -17,13 +17,15 @@ class ConsulConfigTest extends FunSuite with OptionValues {
          |experimental: true
          |pathPrefix: /foo/bar
          |host: consul.local
+         |token: some-token
          |port: 80
       """.stripMargin
     val mapper = Parser.objectMapper(yaml, Iterable(Seq(ConsulDtabStoreInitializer)))
-    val etcd = mapper.readValue[DtabStoreConfig](yaml).asInstanceOf[ConsulConfig]
-    assert(etcd.host.value == "consul.local")
-    assert(etcd.port.value == Port(80))
-    assert(etcd.pathPrefix == Some(Path.read("/foo/bar")))
+    val consul = mapper.readValue[DtabStoreConfig](yaml).asInstanceOf[ConsulConfig]
+    assert(consul.host.value == "consul.local")
+    assert(consul.port.value == Port(80))
+    assert(consul.pathPrefix == Some(Path.read("/foo/bar")))
+    assert(consul.token == Some("some-token"))
   }
 
 }


### PR DESCRIPTION
Both for ConsulNamer and ConsulDtabStore an optional token parameter can
be provided to set `X-Consul-Token` auth header for every request