### PR TITLE
Sort namespaces before showing them to user

### DIFF
--- a/namerd/iface/control-http/src/main/scala/io/buoyant/namerd/iface/HttpControlService.scala
+++ b/namerd/iface/control-http/src/main/scala/io/buoyant/namerd/iface/HttpControlService.scala
@@ -217,7 +217,7 @@ class HttpControlService(storage: DtabStore, delegate: Ns => NameInterpreter, na
 
   private[this] def isStreaming(req: Request): Boolean = req.getBooleanParam("watch")
 
-  private[this] def renderList(list: Set[Ns]): Buf = Json.write(list).concat(newline)
+  private[this] def renderList(list: Iterable[Ns]): Buf = Json.write(list).concat(newline)
 
   private[this] def handleList(req: Request): Future[Response] =
     if (isStreaming(req)) {
@@ -226,7 +226,7 @@ class HttpControlService(storage: DtabStore, delegate: Ns => NameInterpreter, na
       storage.list().toFuture.map { namespaces =>
         val rsp = Response()
         rsp.contentType = MediaType.Json
-        rsp.content = renderList(namespaces)
+        rsp.content = renderList(namespaces.toSeq.sorted)
         rsp
       }
     }

--- a/namerd/iface/control-http/src/test/scala/io/buoyant/namerd/iface/HttpControlServiceTest.scala
+++ b/namerd/iface/control-http/src/test/scala/io/buoyant/namerd/iface/HttpControlServiceTest.scala
@@ -55,7 +55,7 @@ class HttpControlServiceTest extends FunSuite with Awaits {
     val rsp = Await.result(service(req), 1.second)
     assert(rsp.status == Status.Ok)
     assert(rsp.contentType == Some(MediaType.Json))
-    val expected = HttpControlService.Json.write(defaultDtabs.keys).concat(HttpControlService.newline)
+    val expected = HttpControlService.Json.write(defaultDtabs.keys.toSeq.sorted).concat(HttpControlService.newline)
     assert(rsp.content == expected)
   }
 
@@ -112,7 +112,7 @@ class HttpControlServiceTest extends FunSuite with Awaits {
     val rsp = Await.result(service(req), 1.second)
     assert(rsp.status == Status.Ok)
     assert(rsp.contentType == Some(MediaType.Json))
-    val expected = HttpControlService.Json.write(defaultDtabs.keys).concat(HttpControlService.newline)
+    val expected = HttpControlService.Json.write(defaultDtabs.keys.toSeq.sorted).concat(HttpControlService.newline)
     assert(rsp.content == expected)
   }
 

--- a/namerd/main/src/main/scala/io/buoyant/namerd/DtabListHandler.scala
+++ b/namerd/main/src/main/scala/io/buoyant/namerd/DtabListHandler.scala
@@ -12,11 +12,11 @@ class DtabListHandler(
     store.list().toFuture.map { list =>
       val response = Response()
       response.contentType = MediaType.Html + ";charset=UTF-8"
-      response.contentString = render(list)
+      response.contentString = render(list.toSeq.sorted)
       response
     }
 
-  def render(list: Set[String]) = {
+  def render(list: Iterable[String]) = {
     val listHtml = list.map { ns =>
       s"""
         <a class="list-group-item" href="dtab/$ns">$ns</a>


### PR DESCRIPTION
Wouldn't hurt but removes items jumping in UI - that's super annoying when working a lot with Namerd Admin UI.