### PR TITLE
Introduce telemetry subsystem

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -2,10 +2,13 @@
 
 * Add `resolve` endpoint to Namerd HTTP API
 * Add `authority` metadata field to re-write HTTP host/:authority on demand
-* Add `setHost` parameter for Consul CatalogNamer to set `authority` metadata 
+* Consul improvements:
+  * Add `setHost` parameter for Consul CatalogNamer to set `authority` metadata 
+  * Add auth `token` parameter to Consul Namer & Dtab Store
+  * Add `datacenter` parameter to Consul Dtab Store
 * Add file-system based name interpreter.
-* Add auth `token` parameter to Consul Namer & Dtab Store
-* Add `datacenter` parameter to Consul Dtab Store
+* Introduce the _telemetry_ plugin subsystem to support arbitrary stats
+  exporters and to eventually supplant the `tracers` subsystem.
 
 ## 0.7.3
 

--- a/linkerd/core/src/main/scala/io/buoyant/linkerd/Linker.scala
+++ b/linkerd/core/src/main/scala/io/buoyant/linkerd/Linker.scala
@@ -85,7 +85,7 @@ object Linker {
       // At least one router must be specified
       if (routers.isEmpty) throw NoRoutersSpecified
 
-      val telemeters = telemetry.map(_.map(_.mk()))
+      val telemeters = telemetry.map(_.map(_.mk(Stack.Params.empty)))
 
       // Telemeters may provide StatsReceivers.  Note that if all
       // telemeters provide implementations that do not use the

--- a/linkerd/core/src/test/scala/io/buoyant/linkerd/LinkerTest.scala
+++ b/linkerd/core/src/test/scala/io/buoyant/linkerd/LinkerTest.scala
@@ -204,11 +204,11 @@ class LinkerTest extends FunSuite with Exceptions {
          |- kind: test
          |  debugTrace: true
          |telemetry:
-         |- kind: io.l5d.testelemeter
+         |- kind: io.l5d.testTelemeter
          |  metrics: true
-         |- kind: io.l5d.testelemeter
+         |- kind: io.l5d.testTelemeter
          |  tracing: true
-         |- kind: io.l5d.testelemeter
+         |- kind: io.l5d.testTelemeter
          |  metrics: true
          |  tracing: true
          |namers:

--- a/linkerd/core/src/test/scala/io/buoyant/linkerd/LinkerTest.scala
+++ b/linkerd/core/src/test/scala/io/buoyant/linkerd/LinkerTest.scala
@@ -2,10 +2,12 @@ package io.buoyant.linkerd
 
 import com.twitter.finagle.buoyant.DstBindingFactory
 import com.twitter.finagle.param
-import com.twitter.finagle.tracing.DefaultTracer
+import com.twitter.finagle.stats.InMemoryStatsReceiver
+import com.twitter.finagle.tracing._
 import io.buoyant.config.{ConflictingLabels, ConflictingPorts, ConflictingSubtypes}
 import io.buoyant.namer.Param.Namers
 import io.buoyant.namer.{NamerInitializer, ConflictingNamerInitializer, TestNamerInitializer, TestNamer}
+import io.buoyant.telemetry._
 import io.buoyant.test.Exceptions
 import java.net.{InetAddress, InetSocketAddress}
 import org.scalatest.FunSuite
@@ -17,8 +19,9 @@ class LinkerTest extends FunSuite with Exceptions {
   def initializer(
     protos: Seq[ProtocolInitializer] = Seq(TestProtocol.Plain, TestProtocol.Fancy),
     namers: Seq[NamerInitializer] = Seq(TestNamerInitializer),
-    tracers: Seq[TracerInitializer] = Seq(TestTracerInitializer)
-  ) = Linker.Initializers(protocol = protos, namer = namers, tracer = tracers)
+    tracers: Seq[TracerInitializer] = Seq(TestTracerInitializer),
+    telemeters: Seq[TelemeterInitializer] = Seq(new TestTelemeterInitializer)
+  ) = Linker.Initializers(protocol = protos, namer = namers, tracer = tracers, telemetry = telemeters)
 
   def parse(yaml: String) = initializer().load(yaml)
 
@@ -195,11 +198,19 @@ class LinkerTest extends FunSuite with Exceptions {
     assert(fDebugTrace())
   }
 
-  test("with namers & tracers") {
+  test("with namers & tracers & telemetry") {
     val yaml =
       """|tracers:
          |- kind: test
          |  debugTrace: true
+         |telemetry:
+         |- kind: io.l5d.testelemeter
+         |  metrics: true
+         |- kind: io.l5d.testelemeter
+         |  tracing: true
+         |- kind: io.l5d.testelemeter
+         |  metrics: true
+         |  tracing: true
          |namers:
          |- kind: test
          |routers:
@@ -216,9 +227,27 @@ class LinkerTest extends FunSuite with Exceptions {
       case Seq((_, namer: TestNamer)) =>
       case namers => fail(s"unexpected namers: $namers")
     }
+    assert(linker.telemeters.size == 3)
+
+    val ttracers = linker.telemeters.map(_.tracer).collect { case t: BufferingTracer => t }
+    assert(ttracers.size == 2)
+    val treceivers = linker.telemeters.map(_.stats).collect { case s: InMemoryStatsReceiver => s }
+    assert(treceivers.size == 2)
+
+    val param.Stats(stats) = linker.routers.head.params[param.Stats]
+    stats.counter("rad").incr()
+    treceivers.foreach { r =>
+      assert(r.counters(Seq("rt", "rad")) == 1)
+    }
+
     val param.Tracer(tracer) = linker.routers.head.params[param.Tracer]
-    assert(tracer.isInstanceOf[TestTracer])
-    assert(linker.tracer.isInstanceOf[TestTracer])
+    Trace.letTracer(tracer) {
+      Trace.recordBinary("ugh", "hi")
+    }
+    ttracers.foreach { t =>
+      assert(t.size == 1)
+    }
+
     assert(fDebugTrace())
   }
 

--- a/linkerd/main/src/main/scala/io/buoyant/Linkerd.scala
+++ b/linkerd/main/src/main/scala/io/buoyant/Linkerd.scala
@@ -34,6 +34,10 @@ object Linkerd extends App {
         // TODO initialize:
         // - namers
         // - tracers
+
+        val telemeters = linker.telemeters.map(_.run())
+        telemeters.foreach(closeOnExit(_))
+
         val routers = linker.routers.flatMap { router =>
           val running = router.initialize()
           closeOnExit(running)
@@ -44,7 +48,7 @@ object Linkerd extends App {
             listening
           }
         }
-        Await.all(routers: _*)
+        Await.all(routers ++ telemeters: _*)
 
       case _ => exitOnError("usage: linkerd path/to/config")
     }

--- a/project/LinkerdBuild.scala
+++ b/project/LinkerdBuild.scala
@@ -117,6 +117,11 @@ object LinkerdBuild extends Base {
     .withTwitterLib(Deps.finagle("stats"))
     .withTests()
 
+  val telemetryCore = projectDir("telemetry/core")
+    .dependsOn(configCore)
+    .withTwitterLib(Deps.finagle("core"))
+    .withTests()
+
   val ConfigFileRE = """^(.*)\.yaml$""".r
 
   val execScriptJvmOptions =
@@ -337,10 +342,11 @@ object LinkerdBuild extends Base {
 
     val core = projectDir("linkerd/core")
       .dependsOn(
-        Router.core,
         configCore,
         LinkerdBuild.admin,
-        Namer.core % "compile->compile;test->test"
+        telemetryCore,
+        Namer.core % "compile->compile;test->test",
+        Router.core
       )
       .withLib(Deps.jacksonCore)
       .withTests()

--- a/project/LinkerdBuild.scala
+++ b/project/LinkerdBuild.scala
@@ -344,7 +344,7 @@ object LinkerdBuild extends Base {
       .dependsOn(
         configCore,
         LinkerdBuild.admin,
-        telemetryCore,
+        telemetryCore % "compile->compile;test->test",
         Namer.core % "compile->compile;test->test",
         Router.core
       )

--- a/telemetry/core/src/main/scala/io/buoyant/telemetry/Telemeter.scala
+++ b/telemetry/core/src/main/scala/io/buoyant/telemetry/Telemeter.scala
@@ -11,5 +11,5 @@ import com.twitter.util.{Awaitable, Closable}
 trait Telemeter {
   def stats: StatsReceiver = NullStatsReceiver
   def tracer: Tracer = NullTracer
-  def run(): Closable with Awaitable[_]
+  def run(): Closable with Awaitable[Unit]
 }

--- a/telemetry/core/src/main/scala/io/buoyant/telemetry/Telemeter.scala
+++ b/telemetry/core/src/main/scala/io/buoyant/telemetry/Telemeter.scala
@@ -1,0 +1,15 @@
+package io.buoyant.telemetry
+
+import com.twitter.finagle.stats.{StatsReceiver, NullStatsReceiver}
+import com.twitter.finagle.tracing.{Tracer, NullTracer}
+import com.twitter.util.{Awaitable, Closable}
+
+/**
+ * A telemeter may receive stats and trace annotations, i.e. to send
+ * to a collector or export.
+ */
+trait Telemeter {
+  def stats: StatsReceiver = NullStatsReceiver
+  def tracer: Tracer = NullTracer
+  def run(): Closable with Awaitable[_]
+}

--- a/telemetry/core/src/main/scala/io/buoyant/telemetry/TelemeterInitializer.scala
+++ b/telemetry/core/src/main/scala/io/buoyant/telemetry/TelemeterInitializer.scala
@@ -1,0 +1,21 @@
+package io.buoyant.telemetry
+
+import com.fasterxml.jackson.annotation.{JsonIgnore, JsonTypeInfo}
+import io.buoyant.config.ConfigInitializer
+
+/**
+ * Telemeter plugins describe how to
+ */
+trait TelemeterInitializer extends ConfigInitializer {
+  type Config <: TelemeterConfig
+  def configClass: Class[Config]
+}
+
+@JsonTypeInfo(
+  use = JsonTypeInfo.Id.NAME,
+  include = JsonTypeInfo.As.PROPERTY,
+  property = "kind"
+)
+trait TelemeterConfig {
+  @JsonIgnore def mk(): Telemeter
+}

--- a/telemetry/core/src/main/scala/io/buoyant/telemetry/TelemeterInitializer.scala
+++ b/telemetry/core/src/main/scala/io/buoyant/telemetry/TelemeterInitializer.scala
@@ -1,10 +1,11 @@
 package io.buoyant.telemetry
 
 import com.fasterxml.jackson.annotation.{JsonIgnore, JsonTypeInfo}
+import com.twitter.finagle.Stack
 import io.buoyant.config.ConfigInitializer
 
 /**
- * Telemeter plugins describe how to
+ * Telemeter plugins describe how to load TelemeterConfig items.
  */
 trait TelemeterInitializer extends ConfigInitializer {
   type Config <: TelemeterConfig
@@ -17,5 +18,5 @@ trait TelemeterInitializer extends ConfigInitializer {
   property = "kind"
 )
 trait TelemeterConfig {
-  @JsonIgnore def mk(): Telemeter
+  @JsonIgnore def mk(params: Stack.Params): Telemeter
 }

--- a/telemetry/core/src/test/resources/META-INF/services/io.buoyant.telemetry.TelemeterInitializer
+++ b/telemetry/core/src/test/resources/META-INF/services/io.buoyant.telemetry.TelemeterInitializer
@@ -1,0 +1,1 @@
+io.buoyant.telemetry.TestTelemeterInitializer

--- a/telemetry/core/src/test/scala/io/buoyant/telemetry/TelemeterInitializerTest.scala
+++ b/telemetry/core/src/test/scala/io/buoyant/telemetry/TelemeterInitializerTest.scala
@@ -1,5 +1,6 @@
 package io.buoyant.telemetry
 
+import com.twitter.finagle.Stack
 import com.twitter.finagle.stats.{InMemoryStatsReceiver, NullStatsReceiver}
 import com.twitter.finagle.tracing.{BufferingTracer, NullTracer}
 import com.twitter.finagle.util.LoadService
@@ -17,19 +18,19 @@ class TelemeterInitializerTest extends FunSuite {
     val config = Parser.objectMapper(yaml, Seq(LoadService[TelemeterInitializer]))
       .readValue[TelemeterConfig](yaml)
 
-    val telemeter = config.mk()
+    val telemeter = config.mk(Stack.Params.empty)
     val closer = telemeter.run()
   }
 }
 
 class TestTelemeterInitializer extends TelemeterInitializer {
   type Config = TestTelemeterConfig
-  override def configId = "io.l5d.testelemeter"
+  override def configId = "io.l5d.testTelemeter"
   def configClass = classOf[TestTelemeterConfig]
 }
 
 case class TestTelemeterConfig(metrics: Boolean, tracing: Boolean) extends TelemeterConfig {
-  def mk(): TestTelemeter = new TestTelemeter(metrics, tracing)
+  def mk(params: Stack.Params): TestTelemeter = new TestTelemeter(metrics, tracing)
 }
 
 case class TestTelemeter(metrics: Boolean, tracing: Boolean) extends Telemeter {

--- a/telemetry/core/src/test/scala/io/buoyant/telemetry/TelemeterInitializerTest.scala
+++ b/telemetry/core/src/test/scala/io/buoyant/telemetry/TelemeterInitializerTest.scala
@@ -1,0 +1,42 @@
+package io.buoyant.telemetry
+
+import com.twitter.finagle.util.LoadService
+import com.twitter.util._
+import io.buoyant.config.Parser
+import org.scalatest._
+
+class TelemeterInitializerTest extends FunSuite {
+
+  test("telemetry is totally radical") {
+    val yaml =
+      """|kind: io.l5d.testelemeter
+         |radical: true
+         |""".stripMargin
+
+    val config = Parser.objectMapper(yaml, Seq(LoadService[TelemeterInitializer]))
+      .readValue[TelemeterConfig](yaml)
+
+    val telemeter = config.mk()
+    val closer = telemeter.run()
+  }
+}
+
+class TestTelemeterInitializer extends TelemeterInitializer {
+  type Config = TestTelemeterConfig
+  override def configId = "io.l5d.testelemeter"
+  def configClass = classOf[TestTelemeterConfig]
+}
+
+case class TestTelemeterConfig(radical: Boolean) extends TelemeterConfig {
+  def mk(): TestTelemeter = new TestTelemeter(radical)
+}
+
+case class TestTelemeter(radical: Boolean) extends Telemeter {
+  @volatile var closed = false
+  def run(): Closable with Awaitable[Unit] = new Closable with CloseAwaitably {
+    def close(d: Time) = closeAwaitably {
+      closed = true
+      Future.Unit
+    }
+  }
+}


### PR DESCRIPTION
The telemetry subsystem provides a uniform mechanism for configuring stats
receivers and tracers (i.e. that emit data to a collection system).

Later on, our Prometheus, Zipkin, etc integrations may be moved into this new
telemetry API.