### PR TITLE
Allow 'empty tags' in ConsulNamer with includeTag=true

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,6 +1,7 @@
 ## x.x.x
 
 * Add file-system based name interpreter.
+* Allow `_` to be used as an 'no tags' placeholder in CatalogNamer
 * Add auth `token` parameter to Consul Namer & Dtab Store
 
 ## 0.7.3

--- a/consul/src/main/scala/io/buoyant/consul/CatalogNamer.scala
+++ b/consul/src/main/scala/io/buoyant/consul/CatalogNamer.scala
@@ -142,13 +142,6 @@ class CatalogNamer(
     }
   }
 
-  case class SvcKey(name: String, tag: Option[String]) {
-    override def toString = tag match {
-      case Some(t) => s"$name:$t"
-      case None => name
-    }
-  }
-
   /**
    * Contains all cached serviceMap responses and the mapping of names
    * to SvcCaches for a particular datacenter.
@@ -257,5 +250,12 @@ class CatalogNamer(
 object CatalogNamer {
   type VarUp[T] = Var[T] with Updatable[T]
   type ActUp[T] = VarUp[Activity.State[T]]
+
+  case class SvcKey(name: String, tag: Option[String]) {
+    override def toString = tag match {
+      case Some(t) if t != "_" => s"$name:$t"
+      case _ => name
+    }
+  }
 }
 

--- a/consul/src/test/scala/io/buoyant/consul/v1/CatalogNamerTest.scala
+++ b/consul/src/test/scala/io/buoyant/consul/v1/CatalogNamerTest.scala
@@ -4,6 +4,7 @@ import com.twitter.finagle._
 import com.twitter.io.Buf
 import com.twitter.util.{Activity, Future, Promise}
 import io.buoyant.consul.CatalogNamer
+import io.buoyant.consul.CatalogNamer.SvcKey
 import io.buoyant.test.Awaits
 import org.scalatest.FunSuite
 
@@ -272,5 +273,10 @@ class CatalogNamerTest extends FunSuite with Awaits {
       assert(addrs.size == 1)
       assert(addrs.head.toString.contains("192.168.1.35:8080"))
     }
+  }
+
+  test("SvcKey treats _ as an empty tag") {
+    val key = SvcKey("my-service", Some("_"))
+    assert(key.toString == "my-service")
   }
 }

--- a/linkerd/admin/src/test/scala/io/buoyant/linkerd/admin/names/DelegateApiHandlerTest.scala
+++ b/linkerd/admin/src/test/scala/io/buoyant/linkerd/admin/names/DelegateApiHandlerTest.scala
@@ -1,10 +1,11 @@
 package io.buoyant.linkerd.admin.names
 
+import com.twitter.conversions.time._
 import com.twitter.finagle.Name.Bound
 import com.twitter.finagle.http._
 import com.twitter.finagle.naming.NameInterpreter
 import com.twitter.finagle.{Status => _, _}
-import com.twitter.util.{Var, Activity}
+import com.twitter.util.Activity
 import io.buoyant.admin.names.DelegateApiHandler
 import io.buoyant.linkerd._
 import io.buoyant.namer.{ErrorNamerInitializer, TestNamerInitializer}
@@ -40,7 +41,7 @@ class DelegateApiHandlerTest extends FunSuite with Awaits {
     val web = new DelegateApiHandler(_ => linker.routers.head.interpreter)
     val req = Request()
     req.uri = s"/delegate?namespace=plain&path=/boo/humbug&dtab=${URLEncoder.encode(dtab.show, "UTF-8")}"
-    val rsp = await(web(req))
+    val rsp = await(500.millis)(web(req))
     assert(rsp.status == Status.Ok)
     assert(rsp.contentString == """{
       |"type":"delegate","path":"/boo/humbug","delegate":{

--- a/linkerd/docs/namer.md
+++ b/linkerd/docs/namer.md
@@ -148,7 +148,10 @@ The default _prefix_ is `io.l5d.consul`.
 Once configured, to use the Consul namer, you must reference it in
 the dtab. The Consul namer takes two path components: `datacenter` and
 `serviceName`.  If `includeTag` is true, then it takes three path components:
-`datacenter`, `tag`, and `serviceName`.  For example:
+`datacenter`, `tag`, and `serviceName` (while value of `_` can be used to
+opt-out of tag filtering). 
+
+For example:
 
 ```
 baseDtab: |

--- a/namerd/iface/control-http/src/test/scala/io/buoyant/namerd/iface/HttpControlServiceTest.scala
+++ b/namerd/iface/control-http/src/test/scala/io/buoyant/namerd/iface/HttpControlServiceTest.scala
@@ -7,9 +7,9 @@ import com.twitter.finagle.naming.NameInterpreter
 import com.twitter.finagle.{Status => _, _}
 import com.twitter.io.{Buf, Reader}
 import com.twitter.util._
-import io.buoyant.namer.ConfiguredNamersInterpreter
-import io.buoyant.namerd.storage.InMemoryDtabStore
+import io.buoyant.namer.ConfiguredDtabNamer
 import io.buoyant.namerd._
+import io.buoyant.namerd.storage.InMemoryDtabStore
 import io.buoyant.test.Awaits
 import org.scalatest.FunSuite
 


### PR DESCRIPTION
When `includeTag` mode is enabled there is no way to request service
without filtering by tags. This change makes behavior of
`/dc1/_/my-service` with `includeTag=true` equal to `/dc1/my-service` with `includeTag=false`.
