### PR TITLE
Add multiGet to Consul KvApi

### DIFF
--- a/consul/src/main/scala/io/buoyant/consul/v1/KvApi.scala
+++ b/consul/src/main/scala/io/buoyant/consul/v1/KvApi.scala
@@ -1,5 +1,7 @@
 package io.buoyant.consul.v1
 
+import java.util.Base64
+
 import com.twitter.conversions.time._
 import com.twitter.finagle.http
 import com.twitter.finagle.service.Backoff
@@ -61,6 +63,30 @@ class KvApi(
   }
 
   /**
+   * Get key(s)
+   *
+   * https://www.consul.io/docs/agent/http/kv.html#single
+   *
+   * @param path path to the key, must start with /
+   */
+  def multiGet(
+    path: String,
+    datacenter: Option[String] = None,
+    blockingIndex: Option[String] = None,
+    recurse: Option[Boolean] = None,
+    retry: Boolean = false
+  ): Future[Indexed[Seq[Key]]] = {
+    val req = mkreq(
+      http.Method.Get,
+      s"$kvPrefix$path",
+      "index" -> blockingIndex,
+      "dc" -> datacenter,
+      "recurse" -> recurse.map(_.toString)
+    )
+    executeJson[Seq[Key]](req, retry)
+  }
+
+  /**
    * Store the key value
    *
    * https://www.consul.io/docs/agent/http/kv.html#single
@@ -95,15 +121,27 @@ class KvApi(
     path: String,
     datacenter: Option[String] = None,
     cas: Option[String] = None,
+    recurse: Option[Boolean] = None,
     retry: Boolean = false
   ): Future[Boolean] = {
     val req = mkreq(
       http.Method.Delete,
       s"$kvPrefix$path",
       "cas" -> cas,
+      "recurse" -> recurse.map(_.toString),
       "dc" -> datacenter
     )
     executeJson[Boolean](req, retry).map(_.value)
   }
+}
 
+object Key {
+  def mk(key: String, value: String): Key = Key(Some(key), Some(Base64.getEncoder.encodeToString(value.getBytes)))
+}
+
+case class Key(
+  Key: Option[String],
+  Value: Option[String]
+) {
+  lazy val decoded: Option[String] = Value.map { raw => new String(Base64.getDecoder.decode(raw)) }
 }


### PR DESCRIPTION
The main difference is that `mulltiGet` always returns a list (even when single element is requested) and can be used to fetch keys recursively.

This PR also adds optional `recurse` parameter to `delete`.