### PR TITLE
Accept '_' in hostnames in RewritingNamers

### DIFF
--- a/router/http/src/main/scala/io/buoyant/http/namer.scala
+++ b/router/http/src/main/scala/io/buoyant/http/namer.scala
@@ -7,7 +7,7 @@ import com.twitter.util.{Activity, Future, Try}
 private object Match {
   // do very coarse host matching so that we can support dns names,
   // ipv4, and ipv6 without going crazy.
-  val host = """^[A-Za-z0-9.:-]+$""".r
+  val host = """^[A-Za-z0-9.:_-]+$""".r
   val method = "[A-Z]+".r
 
   def subdomain(domain: String, hostname: String): Option[String] = {

--- a/router/http/src/test/scala/io/buoyant/http/NamerTest.scala
+++ b/router/http/src/test/scala/io/buoyant/http/NamerTest.scala
@@ -1,8 +1,7 @@
 package io.buoyant.http
 
-import com.twitter.finagle.{Status => SvcStatus, _}
 import com.twitter.finagle.http.{Http => _, _}
-import com.twitter.util._
+import com.twitter.finagle.{Status => SvcStatus, _}
 import io.buoyant.test.Awaits
 import org.scalatest.FunSuite
 
@@ -59,6 +58,16 @@ class NamerTest extends FunSuite with Awaits {
   test("subdomainOfPfx") {
     val path = Path.read("/$/io.buoyant.http.subdomainOfPfx/a.b/foo/bar.a.b/bah")
     assert(lookup(path) == NameTree.Leaf(Name.Path(Path.Utf8("foo", "bar", "bah"))))
+  }
+
+  test("subdomainOfPfx with underscore") {
+    val path = Path.read("/$/io.buoyant.http.subdomainOfPfx/a.b/foo/bar_suffix.a.b/bah")
+    assert(lookup(path) == NameTree.Leaf(Name.Path(Path.Utf8("foo", "bar_suffix", "bah"))))
+  }
+
+  test("subdomainOfPfx with dash") {
+    val path = Path.read("/$/io.buoyant.http.subdomainOfPfx/a.b/foo/bar-suffix.a.b/bah")
+    assert(lookup(path) == NameTree.Leaf(Name.Path(Path.Utf8("foo", "bar-suffix", "bah"))))
   }
 
   test("domainToPath") {


### PR DESCRIPTION
Although it looks like that underscore is not supposed to
appear in hostnames in reality it does in some cases. Assuming that
practicality beats purity.