### PR TITLE
addr and resolve apis should wait until Addrs are non-pending

### DIFF
--- a/namerd/iface/control-http/src/main/scala/io/buoyant/namerd/iface/HttpControlService.scala
+++ b/namerd/iface/control-http/src/main/scala/io/buoyant/namerd/iface/HttpControlService.scala
@@ -383,6 +383,9 @@ class HttpControlService(storage: DtabStore, delegate: Ns => NameInterpreter, na
             case NameTree.Neg => Activity.value(Addr.Neg)
             case NameTree.Alt(_) | NameTree.Union(_) =>
               Activity.exception(new Exception(s"${key._2.show} is not a concrete bound id"))
+          }.flatMap {
+            case Addr.Pending => Activity.pending
+            case addr => Activity.value(addr)
           }
       }
     )

--- a/namerd/iface/control-http/src/test/scala/io/buoyant/namerd/iface/HttpControlServiceTest.scala
+++ b/namerd/iface/control-http/src/test/scala/io/buoyant/namerd/iface/HttpControlServiceTest.scala
@@ -616,14 +616,6 @@ class HttpControlServiceTest extends FunSuite with Awaits {
       resp.reader,
       """
         |{
-        |  "type":"pending"
-        |}""".stripMargin.replaceAll("\\s", "")
-    )
-
-    readAndAssert(
-      resp.reader,
-      """
-        |{
         |  "type":"bound",
         |  "addrs":[
         |    {"ip":"127.0.0.1","port":1,"meta":{"isa-meta-1":"isa-data-1"}}


### PR DESCRIPTION
# Problem

If address resolution takes some time, the `addr` and `resolve` endpoints will return an address in the pending state.

# Solution

Wait until the address is non-pending before returning.

Reported by @Ashald 