### PR TITLE
Log which telemeters are in use at startup

### DIFF
--- a/linkerd/core/src/main/scala/io/buoyant/linkerd/Linker.scala
+++ b/linkerd/core/src/main/scala/io/buoyant/linkerd/Linker.scala
@@ -118,7 +118,7 @@ object Linker {
       }
       val tracer: Tracer = (configuredTracers, telemeterTracers) match {
         case (None, None) =>
-          log.info(s"Using default stats tracer")
+          log.info(s"Using default tracer")
           DefaultTracer
         case (tracers0, tracers1) =>
           val tracers = (tracers0 ++ tracers1).flatten.toSeq

--- a/telemetry/core/src/main/scala/io/buoyant/telemetry/Telemeter.scala
+++ b/telemetry/core/src/main/scala/io/buoyant/telemetry/Telemeter.scala
@@ -1,7 +1,7 @@
 package io.buoyant.telemetry
 
-import com.twitter.finagle.stats.{StatsReceiver, NullStatsReceiver}
-import com.twitter.finagle.tracing.{Tracer, NullTracer}
+import com.twitter.finagle.stats.StatsReceiver
+import com.twitter.finagle.tracing.Tracer
 import com.twitter.util.{Awaitable, Closable}
 
 /**
@@ -9,7 +9,7 @@ import com.twitter.util.{Awaitable, Closable}
  * to a collector or export.
  */
 trait Telemeter {
-  def stats: StatsReceiver = NullStatsReceiver
-  def tracer: Tracer = NullTracer
+  def stats: StatsReceiver
+  def tracer: Tracer
   def run(): Closable with Awaitable[Unit]
 }


### PR DESCRIPTION
Furthermore, do not provide default stats and trace receivers.  When providing defaults, it's easy to think you're overriding _statsReceiver_, for instance, when you should be overriding _stats_.  By removing default values, implementations must explicitly satisfy the receivers in order for the module to compile.