### PR TITLE
Add telemetryCore to all in LinkerdBuild

### DIFF
--- a/project/LinkerdBuild.scala
+++ b/project/LinkerdBuild.scala
@@ -568,6 +568,7 @@ object LinkerdBuild extends Base {
       k8s,
       marathon,
       testUtil,
+      telemetryCore,
       Interpreter.all,
       Linkerd.all,
       Namer.all,

--- a/telemetry/core/src/test/scala/io/buoyant/telemetry/TelemeterInitializerTest.scala
+++ b/telemetry/core/src/test/scala/io/buoyant/telemetry/TelemeterInitializerTest.scala
@@ -12,7 +12,7 @@ class TelemeterInitializerTest extends FunSuite {
 
   test("telemetry is totally radical") {
     val yaml =
-      """|kind: io.l5d.testelemeter
+      """|kind: io.l5d.testTelemeter
          |""".stripMargin
 
     val config = Parser.objectMapper(yaml, Seq(LoadService[TelemeterInitializer]))


### PR DESCRIPTION
Otherwise it's missing when, for example, `./sbt publishLocal` is executed.

Spotted on Friday thanks to @adleong.