### PR TITLE
Chunked requests must not be considered retryable

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,3 +1,8 @@
+## 0.x.x
+
+* HTTP response classifiers must not consider a request to be
+  retryable when it has a chunked request body.
+
 ## 0.7.4
 
 * Dashboard: add toggling to the router clients to better handle large numbers of clients

--- a/linkerd/docs/response_classifier.md
+++ b/linkerd/docs/response_classifier.md
@@ -32,9 +32,13 @@ requests are considered to be retryable.
 All 5XX responses are considered to be failures. However, `GET`,
 `HEAD`, `OPTIONS`, and `TRACE` requests may be retried automatically.
 
+Requests with chunked bodies are NEVER considered to be retryable.
+
 ## Retryable Idempotent 5XX
 
 `io.l5d.retryableIdempotent5XX`
 
-Like _io.l5d.retryableRead5XX_, but `PUT` and `DELETE` requests may also be
-retried.
+Like _io.l5d.retryableRead5XX_, but `PUT` and `DELETE` requests may
+also be retried.
+
+Requests with chunked bodies are NEVER considered to be retryable.

--- a/linkerd/protocol/http/src/main/scala/io/buoyant/linkerd/protocol/HttpConfig.scala
+++ b/linkerd/protocol/http/src/main/scala/io/buoyant/linkerd/protocol/HttpConfig.scala
@@ -105,6 +105,10 @@ case class HttpConfig(
     ResponseClassifiers.NonRetryableServerFailures orElse super.baseResponseClassifier
 
   @JsonIgnore
+  override def responseClassifier =
+    ResponseClassifiers.NonRetryableChunked(super.responseClassifier)
+
+  @JsonIgnore
   override val protocol: ProtocolInitializer = HttpInitializer
 
   @JsonIgnore


### PR DESCRIPTION
When an HTTP router is configured with the Idempotent repsonse classifier, it
may consider a request with a body (e.g. PUTs) as retryable.  However, chunked
bodies may not be replayed, since the stream is not preserved by linkerd.

To fix this, we only treat a request as retryable when it does not have a
chunked body.

Fixes #599