### PR TITLE
Fix dtab viewer slowness

### DIFF
--- a/admin/src/main/resources/io/buoyant/admin/js/dtab_viewer.js
+++ b/admin/src/main/resources/io/buoyant/admin/js/dtab_viewer.js
@@ -21,6 +21,18 @@ function DtabViewer(initialDtab, dentryTemplate) {
     this.render();
     this._toggleEdit();
   }.bind(this));
+
+  //make the input bigger when you hit enter
+  $("#dtab-input").on('paste input', function () {
+    if ($(this).outerHeight() > this.scrollHeight){
+      $(this).height(1);
+    }
+    while ($(this).outerHeight() < this.scrollHeight + parseFloat($(this).css("borderTopWidth")) + parseFloat($(this).css("borderBottomWidth"))){
+      $(this).height($(this).height() + 1);
+    }
+
+    $("#save-dtab-btn.disabled").removeClass("disabled");
+  });
 }
 
 DtabViewer.prototype._toggleEdit = function() {
@@ -39,18 +51,6 @@ DtabViewer.prototype._toggleEdit = function() {
 DtabViewer.prototype.render = function() {
   this._renderDtabHtml();
   this._renderDtabInput();
-
-  //make the input bigger when you hit enter
-  $("#dtab-input").on('paste input', function () {
-    if ($(this).outerHeight() > this.scrollHeight){
-      $(this).height(1);
-    }
-    while ($(this).outerHeight() < this.scrollHeight + parseFloat($(this).css("borderTopWidth")) + parseFloat($(this).css("borderBottomWidth"))){
-      $(this).height($(this).height() + 1);
-    }
-
-    $("#save-dtab-btn.disabled").removeClass("disabled");
-  });
 
   //dentry click handlers
   $(".dentry-prefix").click(this._activateDentries.bind(this, "data-dentry-prefix"));


### PR DESCRIPTION
Fixes item 1 of #523 

# Problem

Each time the dtab save button is clicked, a call to render registers a new input listener on the dtab-input box.  Over time as you edit and save the dtab, the number of listeners increases and the dtab-input gets slower and slower.

# Solution

Register the input listener once instead of on each call to render.

# Result

dtab-input doesn't get slower over time.