### PR TITLE
Improve display of Neg, Empty, Fail in delegator UI

### DIFF
--- a/admin/src/main/resources/io/buoyant/admin/template/delegatenode.template
+++ b/admin/src/main/resources/io/buoyant/admin/template/delegatenode.template
@@ -19,7 +19,7 @@
       </div>
       {{path}}
       {{#with dentry}}
-        <span class='node-dentry'>{{prefix}}=>{{dst}}</span>
+        <span class='node-dentry'>{{prefix}} => {{dst}}</span>
       {{/with}}
     </div>
     <ul class='list-group'>{{{child}}}</ul>
@@ -63,7 +63,7 @@
     {{/with}}
     {{path}}
     {{#with dentry}}
-      <span class='node-dentry'>{{prefix}}=>{{dst}}</span>
+      <span class='node-dentry'>{{prefix}} => {{dst}}</span>
     {{/with}}
   </li>
 {{/if}}

--- a/admin/src/main/scala/io/buoyant/admin/names/DelegateApiHandler.scala
+++ b/admin/src/main/scala/io/buoyant/admin/names/DelegateApiHandler.scala
@@ -92,15 +92,11 @@ object DelegateApiHandler {
   ))
   sealed trait JsonDelegateTree
   object JsonDelegateTree {
-    case class Empty(dentry: Option[Dentry]) extends JsonDelegateTree {
-      val path = "$"
-    }
+    case class Empty(path: Path, dentry: Option[Dentry]) extends JsonDelegateTree
     case class Fail(dentry: Option[Dentry]) extends JsonDelegateTree {
       val path = "!"
     }
-    case class Neg(dentry: Option[Dentry]) extends JsonDelegateTree {
-      val path = "~"
-    }
+    case class Neg(path: Path, dentry: Option[Dentry]) extends JsonDelegateTree
     case class Exception(path: Path, dentry: Option[Dentry], message: String) extends JsonDelegateTree
     case class Delegate(path: Path, dentry: Option[Dentry], delegate: JsonDelegateTree) extends JsonDelegateTree
     case class Leaf(path: Path, dentry: Option[Dentry], bound: Bound) extends JsonDelegateTree
@@ -112,11 +108,11 @@ object DelegateApiHandler {
       case DelegateTree.Exception(p, d, e) =>
         Future.value(JsonDelegateTree.Exception(p, mkDentry(d), e.getMessage))
       case DelegateTree.Empty(p, d) =>
-        Future.value(JsonDelegateTree.Empty(mkDentry(d)))
+        Future.value(JsonDelegateTree.Empty(p, mkDentry(d)))
       case DelegateTree.Fail(p, d) =>
         Future.value(JsonDelegateTree.Fail(mkDentry(d)))
       case DelegateTree.Neg(p, d) =>
-        Future.value(JsonDelegateTree.Neg(mkDentry(d)))
+        Future.value(JsonDelegateTree.Neg(p, mkDentry(d)))
       case DelegateTree.Delegate(p, d, t) =>
         mk(t).map(JsonDelegateTree.Delegate(p, mkDentry(d), _))
       case DelegateTree.Alt(p, d, ts@_*) =>

--- a/admin/src/main/scala/io/buoyant/admin/names/DelegateApiHandler.scala
+++ b/admin/src/main/scala/io/buoyant/admin/names/DelegateApiHandler.scala
@@ -92,9 +92,15 @@ object DelegateApiHandler {
   ))
   sealed trait JsonDelegateTree
   object JsonDelegateTree {
-    case class Empty(path: Path, dentry: Option[Dentry]) extends JsonDelegateTree
-    case class Fail(path: Path, dentry: Option[Dentry]) extends JsonDelegateTree
-    case class Neg(path: Path, dentry: Option[Dentry]) extends JsonDelegateTree
+    case class Empty(dentry: Option[Dentry]) extends JsonDelegateTree {
+      val path = "$"
+    }
+    case class Fail(dentry: Option[Dentry]) extends JsonDelegateTree {
+      val path = "!"
+    }
+    case class Neg(dentry: Option[Dentry]) extends JsonDelegateTree {
+      val path = "~"
+    }
     case class Exception(path: Path, dentry: Option[Dentry], message: String) extends JsonDelegateTree
     case class Delegate(path: Path, dentry: Option[Dentry], delegate: JsonDelegateTree) extends JsonDelegateTree
     case class Leaf(path: Path, dentry: Option[Dentry], bound: Bound) extends JsonDelegateTree
@@ -106,11 +112,11 @@ object DelegateApiHandler {
       case DelegateTree.Exception(p, d, e) =>
         Future.value(JsonDelegateTree.Exception(p, mkDentry(d), e.getMessage))
       case DelegateTree.Empty(p, d) =>
-        Future.value(JsonDelegateTree.Empty(p, mkDentry(d)))
+        Future.value(JsonDelegateTree.Empty(mkDentry(d)))
       case DelegateTree.Fail(p, d) =>
-        Future.value(JsonDelegateTree.Fail(p, mkDentry(d)))
+        Future.value(JsonDelegateTree.Fail(mkDentry(d)))
       case DelegateTree.Neg(p, d) =>
-        Future.value(JsonDelegateTree.Neg(p, mkDentry(d)))
+        Future.value(JsonDelegateTree.Neg(mkDentry(d)))
       case DelegateTree.Delegate(p, d, t) =>
         mk(t).map(JsonDelegateTree.Delegate(p, mkDentry(d), _))
       case DelegateTree.Alt(p, d, ts@_*) =>

--- a/admin/src/main/scala/io/buoyant/admin/names/DelegateApiHandler.scala
+++ b/admin/src/main/scala/io/buoyant/admin/names/DelegateApiHandler.scala
@@ -93,10 +93,8 @@ object DelegateApiHandler {
   sealed trait JsonDelegateTree
   object JsonDelegateTree {
     case class Empty(path: Path, dentry: Option[Dentry]) extends JsonDelegateTree
-    case class Fail(dentry: Option[Dentry]) extends JsonDelegateTree {
-      val path = "!"
-    }
-    case class Neg(path: Path, dentry: Option[Dentry]) extends JsonDelegateTree
+    case class Fail(path: String, dentry: Option[Dentry]) extends JsonDelegateTree
+    case class Neg(path: String, dentry: Option[Dentry]) extends JsonDelegateTree
     case class Exception(path: Path, dentry: Option[Dentry], message: String) extends JsonDelegateTree
     case class Delegate(path: Path, dentry: Option[Dentry], delegate: JsonDelegateTree) extends JsonDelegateTree
     case class Leaf(path: Path, dentry: Option[Dentry], bound: Bound) extends JsonDelegateTree
@@ -104,15 +102,23 @@ object DelegateApiHandler {
     case class Union(path: Path, dentry: Option[Dentry], union: Seq[Weighted]) extends JsonDelegateTree
     case class Weighted(weight: Double, tree: JsonDelegateTree)
 
+    private[this] val fail = Path.read("/$/fail")
+
     def mk(d: DelegateTree[Name.Bound]): Future[JsonDelegateTree] = d match {
       case DelegateTree.Exception(p, d, e) =>
         Future.value(JsonDelegateTree.Exception(p, mkDentry(d), e.getMessage))
       case DelegateTree.Empty(p, d) =>
         Future.value(JsonDelegateTree.Empty(p, mkDentry(d)))
       case DelegateTree.Fail(p, d) =>
-        Future.value(JsonDelegateTree.Fail(mkDentry(d)))
+        val path = if (p == null) null
+        else if (p.startsWith(fail)) p.show
+        else "!"
+        Future.value(JsonDelegateTree.Fail(path, mkDentry(d)))
       case DelegateTree.Neg(p, d) =>
-        Future.value(JsonDelegateTree.Neg(p, mkDentry(d)))
+        val path = if (p == null) null
+        else if (p.isEmpty) "~"
+        else p.show
+        Future.value(JsonDelegateTree.Neg(path, mkDentry(d)))
       case DelegateTree.Delegate(p, d, t) =>
         mk(t).map(JsonDelegateTree.Delegate(p, mkDentry(d), _))
       case DelegateTree.Alt(p, d, ts@_*) =>

--- a/linkerd/admin/src/test/scala/io/buoyant/linkerd/admin/names/DelegateApiHandlerTest.scala
+++ b/linkerd/admin/src/test/scala/io/buoyant/linkerd/admin/names/DelegateApiHandlerTest.scala
@@ -57,7 +57,7 @@ class DelegateApiHandlerTest extends FunSuite with Awaits {
             |"dentry":{"prefix":"/foo","dst":"/bah | /beh | /$/fail"},"delegate":{
               |"type":"exception","path":"/#/error/humbug","dentry":{"prefix":"/beh","dst":"/#/error"},
                 |"message":"error naming /#/error/humbug"}},
-          |{"type":"fail","dentry":{"prefix":"/foo","dst":"/bah | /beh | /$/fail"},"path":"!"}]}}
+          |{"type":"fail","path":"/$/fail/humbug","dentry":{"prefix":"/foo","dst":"/bah | /beh | /$/fail"}}]}}
       |""".stripMargin.replaceAllLiterally("\n", ""))
   }
 
@@ -81,7 +81,7 @@ class DelegateApiHandlerTest extends FunSuite with Awaits {
     assert(rsp.status == Status.Ok)
     assert(rsp.contentString == """{
       |"type":"delegate","path":"/neg","delegate":{
-        |"type":"neg","path":"/neg","dentry":{"prefix":"/neg","dst":"~"}}}
+        |"type":"neg","path":"~","dentry":{"prefix":"/neg","dst":"~"}}}
       |""".stripMargin.replaceAllLiterally("\n", ""))
   }
 

--- a/namer/core/src/main/scala/io/buoyant/namer/DefaultInterpreterInitializer.scala
+++ b/namer/core/src/main/scala/io/buoyant/namer/DefaultInterpreterInitializer.scala
@@ -101,7 +101,10 @@ case class ConfiguredNamersInterpreter(namers: Seq[(Path, Namer)])
 
     val lookup: Activity[DelegateTree[Name]] = result match {
       case DelegateTree.Neg(path, d) =>
-        this.lookup(path).map(fromNameTree(path, d, _))
+        this.lookup(path).map {
+          case NameTree.Neg => result
+          case tree => fromNameTree(path, d, tree)
+        }
       case tree => Activity.value(tree)
     }
 

--- a/namer/core/src/main/scala/io/buoyant/namer/DefaultInterpreterInitializer.scala
+++ b/namer/core/src/main/scala/io/buoyant/namer/DefaultInterpreterInitializer.scala
@@ -95,7 +95,7 @@ case class ConfiguredNamersInterpreter(namers: Seq[(Path, Namer)])
 
     val result: DelegateTree[Name.Path] = matches match {
       case Nil => DelegateTree.Neg(path, dentry)
-      case Seq(tree) => tree
+      case Seq(tree) => Delegate(path, dentry, tree)
       case trees => DelegateTree.Alt(path, dentry, trees: _*)
     }
 
@@ -128,7 +128,7 @@ case class ConfiguredNamersInterpreter(namers: Seq[(Path, Namer)])
         // Resolve this leaf path through the dtab and bind the resulting tree.
         delegateLookup(dtab, dentry, path).flatMap { delegateTree =>
           delegateBind(dtab, depth + 1, delegateTree)
-        }.map(Delegate(path, dentry, _))
+        }
 
       case Delegate(path, dentry, tree) =>
         delegateBind(dtab, depth, tree).map(Delegate(path, dentry, _))

--- a/namer/core/src/main/scala/io/buoyant/namer/DelegateTree.scala
+++ b/namer/core/src/main/scala/io/buoyant/namer/DelegateTree.scala
@@ -50,7 +50,12 @@ object DelegateTree {
   private def simplify[T](tree: DelegateTree[T]): DelegateTree[T] = tree match {
     case Delegate(path, dentry, tree) =>
       val simplified = simplify(tree)
-      if (simplified.path == path) simplified.withDentry(dentry)
+      val collapse = simplified match {
+        case _: DelegateTree.Neg | _: DelegateTree.Fail | _: DelegateTree.Empty =>
+          false
+        case _ => simplified.path == path
+      }
+      if (collapse) simplified.withDentry(dentry)
       else Delegate(path, dentry, simplified)
 
     case Alt(path, dentry) => Neg(path, dentry)

--- a/namer/core/src/main/scala/io/buoyant/namer/DelegateTree.scala
+++ b/namer/core/src/main/scala/io/buoyant/namer/DelegateTree.scala
@@ -100,7 +100,7 @@ object DelegateTree {
     names match {
       case NameTree.Empty => DelegateTree.Empty(path, dentry)
       case NameTree.Fail => DelegateTree.Fail(path, dentry)
-      case NameTree.Neg => DelegateTree.Neg(path, dentry)
+      case NameTree.Neg => DelegateTree.Neg(Path.empty, dentry)
       case NameTree.Leaf(v) => DelegateTree.Leaf(path, dentry, v)
       case NameTree.Alt(names@_*) =>
         val delegates = names.map(fromNameTree[T](path, dentry, _))
@@ -111,5 +111,22 @@ object DelegateTree {
             DelegateTree.Weighted(w, fromNameTree(path, dentry, tree))
         }
         DelegateTree.Union(path, dentry, delegates: _*)
+    }
+
+  def fromNameTree[T](names: NameTree[T]): DelegateTree[T] =
+    names match {
+      case NameTree.Empty => DelegateTree.Empty(null, Dentry.nop)
+      case NameTree.Fail => DelegateTree.Fail(null, Dentry.nop)
+      case NameTree.Neg => DelegateTree.Neg(null, Dentry.nop)
+      case NameTree.Leaf(v) => DelegateTree.Leaf(null, Dentry.nop, v)
+      case NameTree.Alt(names@_*) =>
+        val delegates = names.map(fromNameTree[T](null, Dentry.nop, _))
+        DelegateTree.Alt(null, Dentry.nop, delegates: _*)
+      case NameTree.Union(names@_*) =>
+        val delegates = names.map {
+          case NameTree.Weighted(w, tree) =>
+            DelegateTree.Weighted(w, fromNameTree(null, Dentry.nop, tree))
+        }
+        DelegateTree.Union(null, Dentry.nop, delegates: _*)
     }
 }

--- a/namer/core/src/test/scala/io/buoyant/namer/DelegateTreeTest.scala
+++ b/namer/core/src/test/scala/io/buoyant/namer/DelegateTreeTest.scala
@@ -47,7 +47,8 @@ class DelegateTreeTest extends FunSuite {
 
     val simplified =
       Delegate(Path.read("/a"), Dentry.nop,
-        Neg(Path.read("/b"), Dentry.read("/a => /b")))
+        Delegate(Path.read("/b"), Dentry.read("/a => /b"),
+          Neg(Path.read("/b"), Dentry.read("/b => ~"))))
 
     assert(orig.simplified == simplified)
   }
@@ -75,7 +76,8 @@ class DelegateTreeTest extends FunSuite {
 
     val simplified =
       Delegate(Path.read("/a"), Dentry.nop,
-        Neg(Path.read("/b"), Dentry.read("/a => /b")))
+        Delegate(Path.read("/b"), Dentry.read("/a => /b"),
+          Neg(Path.read("/b"), Dentry.read("/b => ~"))))
 
     assert(orig.simplified == simplified)
   }

--- a/namerd/iface/control-http/src/main/scala/io/buoyant/namerd/iface/HttpControlService.scala
+++ b/namerd/iface/control-http/src/main/scala/io/buoyant/namerd/iface/HttpControlService.scala
@@ -355,7 +355,7 @@ class HttpControlService(storage: DtabStore, delegate: Ns => NameInterpreter, na
 
   private[this] def renderNameTree(tree: NameTree[Name.Bound]): Future[Buf] =
     JsonDelegateTree.mk(
-      DelegateTree.fromNameTree(null, Dentry.nop, tree)
+      DelegateTree.fromNameTree(tree)
     ).map(DelegateApiHandler.Codec.writeBuf).map(_.concat(Buf.Utf8("\n")))
 
   private[this] def handleGetBind(ns: String, path: Path, req: Request): Future[Response] = {


### PR DESCRIPTION
Fixes #604 

# Problem

Neg, empty, or fail DelegationTrees get collapsed into their delegation parent which makes the display confusing.

# Solution

Don't collapse neg, empty, or fail DelegationTrees.  Also use ~, $, and ! as their display names instead of the parent path.

(See #604 for screenshot)