### PR TITLE
Improve dtab playground error message

### DIFF
--- a/admin/src/main/resources/io/buoyant/admin/js/delegator.js
+++ b/admin/src/main/resources/io/buoyant/admin/js/delegator.js
@@ -40,7 +40,7 @@ var Delegator = (function() {
         "/delegator.json?" + $.param({ path: path, dtab: dtabViewer.dtabStr(), namespace: namespace }),
         renderAll.bind(this));
       request.fail(function( jqXHR ) {
-        $(".error-modal").html(templates.errorModal(jqXHR.statusText));
+        $(".error-modal").html(templates.errorModal(jqXHR.responseText));
         $('.error-modal').modal();
       });
     });

--- a/linkerd/admin/src/test/scala/io/buoyant/linkerd/admin/names/DelegateApiHandlerTest.scala
+++ b/linkerd/admin/src/test/scala/io/buoyant/linkerd/admin/names/DelegateApiHandlerTest.scala
@@ -81,6 +81,7 @@ class DelegateApiHandlerTest extends FunSuite with Awaits {
     req.uri = s"/delegate?path=invalid-param&namespace=label"
     val rsp = await(web(req))
     assert(rsp.status == Status.BadRequest)
+    assert(rsp.contentString == "Invalid path: '/' expected but 'i' found at '[i]nvalid-param'")
   }
 
   test("invalid dtab results in 400") {
@@ -89,5 +90,6 @@ class DelegateApiHandlerTest extends FunSuite with Awaits {
     req.uri = s"/delegate?path=/boo/humbug&dtab=invalid-param"
     val rsp = await(web(req))
     assert(rsp.status == Status.BadRequest)
+    assert(rsp.contentString == "Invalid dtab: '/' expected but 'i' found at '[i]nvalid-param'")
   }
 }


### PR DESCRIPTION
If the Path or Dtab is invalid, display a better error message than "Bad Request"

