### PR TITLE
Add tag to authority in Consul namer

### DIFF
--- a/namer/consul/src/main/scala/io/buoyant/namer/consul/CatalogNamer.scala
+++ b/namer/consul/src/main/scala/io/buoyant/namer/consul/CatalogNamer.scala
@@ -139,7 +139,11 @@ class CatalogNamer(
         if (setHost)
           domainFuture().map { domainOption =>
             val domain = domainOption.getOrElse("consul")
-            Addr.Metadata(Metadata.authority -> s"${key.name}.service.$datacenter.$domain")
+            val authority = key.tag match {
+              case Some(tag) => s"$tag.${key.name}.service.$datacenter.$domain"
+              case None => s"${key.name}.service.$datacenter.$domain"
+            }
+            Addr.Metadata(Metadata.authority -> authority)
           }
         else
           Future.value(Addr.Metadata.empty)


### PR DESCRIPTION
When `includeTag` mode is makes sense to include tag in `authority` meta field as it would match Consul's behavior.