### PR TITLE
Move doc examples' placement

### DIFF
--- a/linkerd/docs/announcer.md
+++ b/linkerd/docs/announcer.md
@@ -1,7 +1,5 @@
 # Announcers
 
-*(for the [announcers](config.md#announcers) key)*
-
 An announcer registers servers in service discovery.  Each server may specify
 a list of concrete names to announce as in the [announce](config.md#announce)
 server key.  Each announcer has a prefix and will only announce names that

--- a/linkerd/docs/client_tls.md
+++ b/linkerd/docs/client_tls.md
@@ -1,31 +1,38 @@
 # Client TLS
 
-*(for the [tls](config.md#client_tls) key)*
+>Client TLS is defined in the client section of routers:
+
+```yaml
+routers:
+- protocol: http
+  client:
+    tls: ...
+```
 
 A client TLS object describes how linkerd should use TLS when sending requests
 to destination services.  A client TLS config block must contain a `kind`
 parameter which indicates which client TLS plugin to use as well as any
 parameters specific to the plugin.
 
-### Example
+## No Validation
 
 ```yaml
-routers:
-- ...
-  client:
-    tls:
-      kind: io.l5d.static
-      commonName: foo
-      caCertPath: /foo/caCert.pem
+tls:
+  kind: io.l5d.noValidation
 ```
-
-## No Validation
 
 `io.l5d.noValidation`
 
-Skip hostname validation.  This is unsafe.
+<aside class="warning">This skips hostname validation and is unsafe.</aside>
 
 ## Static
+
+```yaml
+tls:
+  kind: io.l5d.static
+  commonName: foo
+  caCertPath: /foo/caCert.pem
+```
 
 `io.l5d.static`
 
@@ -38,6 +45,16 @@ options:
 * *caCertPath* -- Optional.  Use the given CA cert for common name validation.
 
 ## Bound Path
+
+```yaml
+tls:
+  kind: io.l5d.boundPath
+  caCertPath: /foo/cacert.pem
+  names:
+  - prefix: "/#/io.l5d.fs/{host}"
+    commonNamePattern: "{host}.buoyant.io"
+  strict: false
+```
 
 `io.l5d.boundPath`
 
@@ -56,13 +73,4 @@ supports the following options:
 * *strict* -- Optional. When true, paths that fail to match any prefixes throw
     an exception. Defaults to true.
 
-For example,
 
-```yaml
-kind: io.l5d.boundPath
-caCertPath: /foo/cacert.pem
-names:
-- prefix: "/#/io.l5d.fs/{host}"
-  commonNamePattern: "{host}.buoyant.io"
- strict: false
-```

--- a/linkerd/docs/config.md
+++ b/linkerd/docs/config.md
@@ -1,25 +1,16 @@
-# Configuration
+# Introduction
 
-linkerd's configuration is controlled via config file, which must be provided
-as a command-line argument. It may be a local file path or `-` to
-indicate that the configuration should be read from the standard input.
-For convenience, the release package includes a default `linkerd.yaml` file in
-the `config/` directory.
+>The most minimal linkerd configuration looks something like the following, which forwards all requests on `localhost:8080` to `localhost:8888`
 
-## File Format
+```yaml
+routers:
+- protocol: http
+  baseDtab: /http => /$/inet/127.1/8888
+  servers:
+  - port: 8080
+```
 
-The configuration may be specified as a JSON or YAML object, as described
-below.  Four top level keys are supported:
-
-* [admin](#admin)
-* [routers](#routers)
-* [namers](#namers)
-* [tracers](#tracers)
-
-There are no requirements on field ordering, though it's generally
-good style to start a router with the _protocol_.
-
-## Example
+> Here's a more complex linkerd config example
 
 ```yaml
 admin:
@@ -77,19 +68,32 @@ routers:
     /thrift => /#/io.l5d.fs/thrift;
 ```
 
-The most minimal configuration looks something like the following,
-which forwards all requests on `localhost:8080` to `localhost:8888`.
+linkerd's configuration is controlled via config file, which must be provided
+as a command-line argument. It may be a local file path or `-` to
+indicate that the configuration should be read from the standard input.
+For convenience, the release package includes a default `linkerd.yaml` file in
+the `config/` directory.
 
-```yaml
-routers:
-- protocol: http
-  baseDtab: /http => /$/inet/127.1/8888
-  servers:
-  - port: 8080
-```
+### File Format
+
+The configuration may be specified as a JSON or YAML object, as described
+below.  Four top level keys are supported:
+
+* [admin](#admin)
+* [routers](#routers)
+* [namers](#namers)
+* [tracers](#tracers)
+
+There are no requirements on field ordering, though it's generally
+good style to start a router with the _protocol_.
 
 <a name="admin"></a>
 ## Administrative interface
+
+```yaml
+admin:
+  port: 9990
+```
 
 linkerd supports an administrative interface, both as a web ui and a collection
 of json endpoints. The exposed admin port is configurable via a top-level
@@ -98,11 +102,6 @@ of json endpoints. The exposed admin port is configurable via a top-level
 * *admin* -- Config section for the admin interface, contains keys:
   * *port* -- Port for the admin interface (default is `9990`)
 
-For example:
-```yaml
-admin:
-  port: 9990
-```
 
 <a name="routers"></a>
 ## Routers

--- a/linkerd/docs/interpreter.md
+++ b/linkerd/docs/interpreter.md
@@ -1,11 +1,6 @@
 # Interpreter
 
-*(for the [interpreter](config.md#interpreter) key)*
-
-An interpreter determines how names are resolved.  An interpreter config block
-must contain a `kind` parameter which indicates which interpreter plugin to use.
-
-### Example
+> Example Interpreter Configuration
 
 ```yaml
 routers:
@@ -14,6 +9,9 @@ routers:
     kind: io.l5d.namerd
     dst: /$/inet/1.2.3.4/4180
 ```
+
+An interpreter determines how names are resolved.  An interpreter config block
+must contain a `kind` parameter which indicates which interpreter plugin to use.
 
 ## Default
 

--- a/linkerd/docs/load_balancer.md
+++ b/linkerd/docs/load_balancer.md
@@ -1,19 +1,5 @@
 # Load Balancer
 
-*(for the [loadBalancer](config.md#load_balancer) key)*
-
-Specifies a load balancer to use.  It must be an object containing keys:
-
-  * *kind* -- One of the supported load balancers.
-  * *enableProbation* -- Optional.  Controls whether endpoints are eagerly evicted from
-    service discovery. (default: true)
-    See Finagle's [LoadBalancerFactory.EnableProbation](https://github.com/twitter/finagle/blob/develop/finagle-core/src/main/scala/com/twitter/finagle/loadbalancer/LoadBalancerFactory.scala#L28)
-  * Any options specific to the load balancer.
-
-If unspecified, p2c is used.
-
-### Example
-
 ```yaml
 routers:
 - ...
@@ -24,7 +10,15 @@ routers:
       decayTimeMs: 15000
 ```
 
-Current load balancers include:
+Specifies a load balancer to use.  It must be an object containing keys:
+
+  * *kind* -- One of the supported load balancers.
+  * *enableProbation* -- Optional.  Controls whether endpoints are eagerly evicted from
+    service discovery. (default: true)
+    See Finagle's [LoadBalancerFactory.EnableProbation](https://github.com/twitter/finagle/blob/develop/finagle-core/src/main/scala/com/twitter/finagle/loadbalancer/LoadBalancerFactory.scala#L28)
+  * Any options specific to the load balancer.
+
+If unspecified, p2c is used. Current load balancers include:
 
 [p2c]: https://twitter.github.io/finagle/guide/Clients.html#power-of-two-choices-p2c-least-loaded
 [ewma]: https://twitter.github.io/finagle/guide/Clients.html#power-of-two-choices-p2c-peak-ewma

--- a/linkerd/docs/protocol-http.md
+++ b/linkerd/docs/protocol-http.md
@@ -21,15 +21,11 @@ io.l5d.methodAndHost)
   (default: -1, automatically compresses textual content types with
   compression level 6)
 
-_Note_: These memory constraints are selected to allow reliable
+<aside class="warning">
+These memory constraints are selected to allow reliable
 concurrent usage of linkerd. Changing these parameters may
 significantly alter linkerd's performance characteristics.
-
-<a name="protocol-http-defaults"></a>
-## Example
-As an example, here's an HTTP router config that routes all `POST`
-requests to 8091 and all other requests to 8081, using the default
-identifier of `io.l5d.methodAndHost`, listening on port 5000:
+</aside>
 
 ```yaml
 routers:
@@ -43,9 +39,15 @@ routers:
     port: 5000
 ```
 
-(Note that the dtab is written in terms of names produced by the
+As an example, here's an HTTP router config that routes all `POST`
+requests to 8091 and all other requests to 8081, using the default
+identifier of `io.l5d.methodAndHost`, listening on port 5000:
+
+<aside class="notice">
+The dtab is written in terms of names produced by the
 `methodAndHost` identifier. Using a different identifier would require a
-different set of dtab rules. See the next section for more on identifiers.)
+different set of dtab rules. See the next section for more on identifiers.
+</aside>
 
 <a name="protocol-http-identifiers"></a>
 ## HTTP/1.1 Identifiers
@@ -112,10 +114,6 @@ The path identifier generates logical names of the form:
   / dstPrefix / [*segments* number of segments from the URL path]
 ```
 
-Note that `dstPrefix`, if unset in the identifier configuration block,
-defaults to "http". For example, here's a router configured with the path
-identifier:
-
 ```yaml
 routers:
 - protocol: http
@@ -126,6 +124,10 @@ routers:
   servers:
     port: 5000
 ```
+
+Note that `dstPrefix`, if unset in the identifier configuration block,
+defaults to "http". For example, here's a router configured with the path
+identifier
 
 With this configuration, a request to `:5000/true/love/waits.php` will be
 mapped to `/http/true/love` and will be routed based on this name by the
@@ -140,9 +142,6 @@ alternate HTTP implementation to be used. Currently there are two
 supported HTTP implementations: _netty3_ (default) and _netty4_ (will
 become default in an upcoming release).
 
-For example, the following configures an HTTP router that uses the new
-netty4 implementation on both the client and server:
-
 ```yaml
 - protocol: http
   ...
@@ -156,6 +155,8 @@ netty4 implementation on both the client and server:
       kind: netty4
 ```
 
+For example, the following configures an HTTP router that uses the new
+netty4 implementation on both the client and server:
 
 ## HTTP Headers
 

--- a/linkerd/docs/protocol-mux.md
+++ b/linkerd/docs/protocol-mux.md
@@ -1,14 +1,10 @@
 # Mux Protocol (experimental)
 
-*(for the [routers](config.md#routers) key)*
-
 linkerd experimentally supports the [mux
 protocol](http://twitter.github.io/finagle/guide/Protocols.html#mux).
 
 The default _dstPrefix_ is `/mux`.
 The default server _port_ is 4141.
-
-As an example: Here's a mux router configuration that routes requests to port 9001
 
 ```yaml
 
@@ -19,3 +15,4 @@ routers:
   baseDtab: |
     /overNineThousand => /$/inet/127.0.1/9001;
 ```
+As an example: Here's a mux router configuration that routes requests to port 9001

--- a/linkerd/docs/protocol-thrift.md
+++ b/linkerd/docs/protocol-thrift.md
@@ -1,7 +1,5 @@
 # Thrift Protocol
 
-*(for the [routers](config.md#routers) key)*
-
 Since the Thrift protocol does not encode a destination name in the message
 itself, routing must be done per port. This implies one port per Thrift
 service. For out-of-the-box configuration, this means that the contents of
@@ -38,9 +36,6 @@ Thrift also supports additional *client* parameters:
 * *attemptTTwitterUpgrade* -- controls whether thrift protocol upgrade should be
    attempted.  (default: true)
 
-As an example: Here's a thrift router configuration that routes thrift--via
-buffered transport using the TCompactProtocol --from port 4004 to port 5005
-
 ```yaml
 routers:
 - protocol: thrift
@@ -56,3 +51,7 @@ routers:
     thriftFramed: false
     thriftProtocol: compact
 ```
+
+As an example: Here's a thrift router configuration that routes thrift--via
+buffered transport using the TCompactProtocol --from port 4004 to port 5005
+

--- a/linkerd/docs/response_classifier.md
+++ b/linkerd/docs/response_classifier.md
@@ -1,14 +1,5 @@
 # HTTP Response Classifiers
-
-*(for the [responseClassifier](config.md#response_classifier) key)*
-
-Response classifiers determine which HTTP responses are considered to
-be failures (for the purposes of success rate calculation) and which
-of these responses may be [retried](retries.md). A response classifier
-config block must contain a `kind` parameter which indicates which classifier
-plugin to use.  By default, the _io.l5d.nonRetryable5XX_ classifier is used.
-
-### Example
+> Example Response Classifier
 
 ```yaml
 routers:
@@ -17,6 +8,12 @@ routers:
     responseClassifier:
       kind: io.l5d.retryableRead5XX
 ```
+
+Response classifiers determine which HTTP responses are considered to
+be failures (for the purposes of success rate calculation) and which
+of these responses may be [retried](retries.md). A response classifier
+config block must contain a `kind` parameter which indicates which classifier
+plugin to use.  By default, the _io.l5d.nonRetryable5XX_ classifier is used.
 
 ## Non-Retryable 5XX
 

--- a/linkerd/docs/retries.md
+++ b/linkerd/docs/retries.md
@@ -1,6 +1,19 @@
 # Retries
 
-*(for the [retries](config.md#retries) key)*
+```yaml
+routers:
+- ...
+  client:
+    retries:
+      budget:
+        minRetriesPerSec: 5
+        percentCanRetry: 0.5
+        ttlSecs: 15
+      backoff:
+        kind: jittered
+        minMs: 10
+        maxMs: 10000
+```
 
 linkerd can automatically retry requests on certain failures (for example,
 connection errors).  A retries config block is an object with the following
@@ -35,20 +48,3 @@ The _jittered_ backoff policy uses a
 backoff algorithm and requires two configuration parameters:
 * _minMs_ -- The minimum number of milliseconds to wait before each retry.
 * _maxMs_ -- The maximum number of milliseconds to wait before each retry.
-
-### Example
-
-```yaml
-routers:
-- ...
-  client:
-    retries:
-      budget:
-        minRetriesPerSec: 5
-        percentCanRetry: 0.5
-        ttlSecs: 15
-      backoff:
-        kind: jittered
-        minMs: 10
-        maxMs: 10000
-```

--- a/linkerd/docs/tracer.md
+++ b/linkerd/docs/tracer.md
@@ -1,7 +1,5 @@
 # Tracers
 
-*(for the [tracers](config.md#tracers) key)*
-
 Requests that are routed by linkerd are also traceable using Finagle's built-in
 tracing instrumentation.  A tracer config object has the following parameters:
 
@@ -15,15 +13,7 @@ Current tracers include:
 
 ## Zipkin
 
-`io.l5d.zipkin`
-
-Finagle's [zipkin-tracer](https://github.com/twitter/finagle/tree/develop/finagle-zipkin).
-
-* *host* -- Optional. Host to send trace data to. (default: localhost)
-* *port* -- Optional. Port to send trace data to. (default: 9410)
-* *sampleRate* -- Optional. How much data to collect. (default: 0.001)
-
-For example:
+> Example zipkin config
 
 ```yaml
 tracers:
@@ -33,3 +23,11 @@ tracers:
   sampleRate: 0.02
   debugTrace: true
 ```
+
+`io.l5d.zipkin`
+
+Finagle's [zipkin-tracer](https://github.com/twitter/finagle/tree/develop/finagle-zipkin).
+
+* *host* -- Optional. Host to send trace data to. (default: localhost)
+* *port* -- Optional. Port to send trace data to. (default: 9410)
+* *sampleRate* -- Optional. How much data to collect. (default: 0.001)


### PR DESCRIPTION
Problem:
https://linkerd.io/doc/0.7.4/linkerd/config has lots of good documentation
but is somewhat difficult to navigate.

Solution:
Use a new three column layout (nav, doc, & example) to display linkerd
documentation.

Why this change:
The new layout looks better when example code is placed before the
paragraph that describes it.

(this is the kind of diff git/github doesn't do especially well with, apologies)