### PR TITLE
Make retry filter do not retry on Future.cancel

### DIFF
--- a/consul/src/main/scala/io/buoyant/consul/v1/BaseApi.scala
+++ b/consul/src/main/scala/io/buoyant/consul/v1/BaseApi.scala
@@ -7,7 +7,7 @@ import com.twitter.finagle.param.HighResTimer
 import com.twitter.finagle.service.{RetryBudget, RetryFilter, RetryPolicy}
 import com.twitter.finagle.stats.StatsReceiver
 import com.twitter.finagle.tracing.Trace
-import com.twitter.finagle.{Filter, http}
+import com.twitter.finagle.{Failure, Filter, http}
 import com.twitter.io.Buf
 import com.twitter.util._
 import io.buoyant.consul.log
@@ -27,8 +27,10 @@ trait BaseApi extends Closable {
     RetryPolicy.backoff(backoffs) {
       // We will assume 5xx are retryable, everything else is not for now
       case (_, Return(rep)) => rep.status.code >= 500 && rep.status.code < 600
+      // Don't retry on interruption
+      case (_, Throw(e: Failure)) if e.isFlagged(Failure.Interrupted) => false
       case (_, Throw(NonFatal(ex))) =>
-        log.error(s"retrying consul catalog request on error $ex")
+        log.error(s"retrying consul request on error $ex")
         true
     },
     HighResTimer.Default,


### PR DESCRIPTION
Previously it wasn't possible to cancel request when retry filter is enable as it will consider `FutureCancelledException` as an error that should be re-tried:
```
E 0831 20:24:25.121 THREAD12: retrying consul catalog request on error Failure(The future was cancelled with Future.cancel, flags=0x02)
```