### PR TITLE
Handle unexpected k8s watch termination

### DIFF
--- a/k8s/src/main/scala/io/buoyant/k8s/AuthFilter.scala
+++ b/k8s/src/main/scala/io/buoyant/k8s/AuthFilter.scala
@@ -1,7 +1,7 @@
 package io.buoyant.k8s
 
-import com.twitter.finagle.{Service, SimpleFilter}
 import com.twitter.finagle.http.{Request, Response}
+import com.twitter.finagle.{Service, SimpleFilter}
 
 class AuthFilter(token: String) extends SimpleFilter[Request, Response] {
   def apply(req: Request, service: Service[Request, Response]) = {

--- a/k8s/src/main/scala/io/buoyant/k8s/EndpointsNamer.scala
+++ b/k8s/src/main/scala/io/buoyant/k8s/EndpointsNamer.scala
@@ -8,6 +8,7 @@ import com.twitter.finagle.util.DefaultTimer
 import com.twitter.util._
 import io.buoyant.k8s.v1._
 import io.buoyant.namer.EnumeratingNamer
+
 import scala.collection.mutable
 
 class EndpointsNamer(

--- a/k8s/src/main/scala/io/buoyant/k8s/EndpointsNamer.scala
+++ b/k8s/src/main/scala/io/buoyant/k8s/EndpointsNamer.scala
@@ -8,7 +8,6 @@ import com.twitter.finagle.util.DefaultTimer
 import com.twitter.util._
 import io.buoyant.k8s.v1._
 import io.buoyant.namer.EnumeratingNamer
-
 import scala.collection.mutable
 
 class EndpointsNamer(

--- a/k8s/src/main/scala/io/buoyant/k8s/Json.scala
+++ b/k8s/src/main/scala/io/buoyant/k8s/Json.scala
@@ -5,6 +5,7 @@ import com.fasterxml.jackson.databind._
 import com.fasterxml.jackson.module.scala.DefaultScalaModule
 import com.fasterxml.jackson.module.scala.experimental.ScalaObjectMapper
 import com.twitter.concurrent.AsyncStream
+import com.twitter.finagle.ChannelException
 import com.twitter.finagle.util.LoadService
 import com.twitter.io.{Buf, Reader}
 import com.twitter.logging.Logger
@@ -114,7 +115,7 @@ object Json {
             case Throw(e) =>
               log.warning(e, "json read error")
           }.handle {
-            case e: Throwable => None
+            case e: ChannelException => None
           }
           AsyncStream.fromFuture(read).flatMap(AsyncStream.fromOption)
         }

--- a/k8s/src/main/scala/io/buoyant/k8s/Json.scala
+++ b/k8s/src/main/scala/io/buoyant/k8s/Json.scala
@@ -8,8 +8,8 @@ import com.twitter.concurrent.AsyncStream
 import com.twitter.finagle.util.LoadService
 import com.twitter.io.{Buf, Reader}
 import com.twitter.logging.Logger
-import com.twitter.util.{Future, Return, Throw, Try}
-import scala.collection.JavaConverters._
+import com.twitter.util.{Return, Throw, Try}
+
 import scala.collection.mutable
 import scala.reflect.classTag
 
@@ -106,14 +106,15 @@ object Json {
       for {
         chunk <- {
           log.trace("json reading chunk of %d bytes", bufsize)
-          val read = reader.read(bufsize)
-          read.respond {
+          val read = reader.read(bufsize).respond {
             case Return(Some(Buf.Utf8(chunk))) =>
               log.trace("json read chunk: %s", chunk)
             case Return(None) | Throw(_: Reader.ReaderDiscarded) =>
               log.trace("json read eoc")
             case Throw(e) =>
               log.warning(e, "json read error")
+          }.handle {
+            case e: Throwable => None
           }
           AsyncStream.fromFuture(read).flatMap(AsyncStream.fromOption)
         }

--- a/k8s/src/main/scala/io/buoyant/k8s/Json.scala
+++ b/k8s/src/main/scala/io/buoyant/k8s/Json.scala
@@ -9,7 +9,6 @@ import com.twitter.finagle.util.LoadService
 import com.twitter.io.{Buf, Reader}
 import com.twitter.logging.Logger
 import com.twitter.util.{Return, Throw, Try}
-
 import scala.collection.mutable
 import scala.reflect.classTag
 import scala.util.control.NonFatal

--- a/k8s/src/main/scala/io/buoyant/k8s/Json.scala
+++ b/k8s/src/main/scala/io/buoyant/k8s/Json.scala
@@ -5,7 +5,6 @@ import com.fasterxml.jackson.databind._
 import com.fasterxml.jackson.module.scala.DefaultScalaModule
 import com.fasterxml.jackson.module.scala.experimental.ScalaObjectMapper
 import com.twitter.concurrent.AsyncStream
-import com.twitter.finagle.ChannelException
 import com.twitter.finagle.util.LoadService
 import com.twitter.io.{Buf, Reader}
 import com.twitter.logging.Logger
@@ -13,6 +12,7 @@ import com.twitter.util.{Return, Throw, Try}
 
 import scala.collection.mutable
 import scala.reflect.classTag
+import scala.util.control.NonFatal
 
 object Json {
 
@@ -115,7 +115,7 @@ object Json {
             case Throw(e) =>
               log.warning(e, "json read error")
           }.handle {
-            case e: ChannelException => None
+            case NonFatal(e) => None
           }
           AsyncStream.fromFuture(read).flatMap(AsyncStream.fromOption)
         }

--- a/k8s/src/main/scala/io/buoyant/k8s/SetHostFilter.scala
+++ b/k8s/src/main/scala/io/buoyant/k8s/SetHostFilter.scala
@@ -1,9 +1,8 @@
 package io.buoyant.k8s
 
-import java.net.InetSocketAddress
-
 import com.twitter.finagle.http.{Request, Response}
 import com.twitter.finagle.{Service, SimpleFilter}
+import java.net.InetSocketAddress
 
 class SetHostFilter(hostname: String, port: Int) extends SimpleFilter[Request, Response] {
   def this(addr: InetSocketAddress) = this(addr.getHostString, addr.getPort)

--- a/k8s/src/main/scala/io/buoyant/k8s/SetHostFilter.scala
+++ b/k8s/src/main/scala/io/buoyant/k8s/SetHostFilter.scala
@@ -1,8 +1,9 @@
 package io.buoyant.k8s
 
-import com.twitter.finagle.{Service, SimpleFilter}
-import com.twitter.finagle.http.{Request, Response}
 import java.net.InetSocketAddress
+
+import com.twitter.finagle.http.{Request, Response}
+import com.twitter.finagle.{Service, SimpleFilter}
 
 class SetHostFilter(hostname: String, port: Int) extends SimpleFilter[Request, Response] {
   def this(addr: InetSocketAddress) = this(addr.getHostString, addr.getPort)

--- a/k8s/src/main/scala/io/buoyant/k8s/Watchable.scala
+++ b/k8s/src/main/scala/io/buoyant/k8s/Watchable.scala
@@ -1,7 +1,5 @@
 package io.buoyant.k8s
 
-import java.util.concurrent.atomic.AtomicReference
-
 import com.twitter.concurrent.AsyncStream
 import com.twitter.finagle.http
 import com.twitter.finagle.param.HighResTimer
@@ -11,6 +9,7 @@ import com.twitter.finagle.tracing.Trace
 import com.twitter.io.Reader
 import com.twitter.util.TimeConversions._
 import com.twitter.util._
+import java.util.concurrent.atomic.AtomicReference
 
 /**
  * An abstract class that encapsulates the ability to Watch a k8s [[Resource]].

--- a/k8s/src/main/scala/io/buoyant/k8s/v1.scala
+++ b/k8s/src/main/scala/io/buoyant/k8s/v1.scala
@@ -2,7 +2,7 @@ package io.buoyant.k8s
 
 import com.fasterxml.jackson.annotation.{JsonProperty, JsonSubTypes, JsonTypeInfo}
 import com.twitter.finagle.{Service, http}
-import io.buoyant.k8s.{KubeObject => BaseObject, _}
+import io.buoyant.k8s.{KubeObject => BaseObject}
 
 package object v1 {
 

--- a/k8s/src/test/scala/io/buoyant/k8s/EndpointsNamerTest.scala
+++ b/k8s/src/test/scala/io/buoyant/k8s/EndpointsNamerTest.scala
@@ -2,7 +2,7 @@ package io.buoyant.k8s
 
 import com.twitter.conversions.time._
 import com.twitter.finagle.http.{Request, Response}
-import com.twitter.finagle.{Addr, Name, NameTree, Path, Service}
+import com.twitter.finagle._
 import com.twitter.io.Buf
 import com.twitter.util._
 import io.buoyant.test.Awaits
@@ -37,7 +37,7 @@ class EndpointsNamerTest extends FunSuite with Awaits {
         }
 
         doFail onSuccess { _ =>
-          rsp.writer.fail(new Exception("oops"))
+          rsp.writer.fail(new ChannelClosedException)
         }
 
         Future.value(rsp)

--- a/k8s/src/test/scala/io/buoyant/k8s/EndpointsNamerTest.scala
+++ b/k8s/src/test/scala/io/buoyant/k8s/EndpointsNamerTest.scala
@@ -1,8 +1,8 @@
 package io.buoyant.k8s
 
 import com.twitter.conversions.time._
-import com.twitter.finagle.http.{Request, Response}
 import com.twitter.finagle._
+import com.twitter.finagle.http.{Request, Response}
 import com.twitter.io.Buf
 import com.twitter.util._
 import io.buoyant.test.Awaits

--- a/k8s/src/test/scala/io/buoyant/k8s/v1/ApiTest.scala
+++ b/k8s/src/test/scala/io/buoyant/k8s/v1/ApiTest.scala
@@ -206,9 +206,7 @@ class ApiTest extends FunSuite with Awaits with Exceptions {
                 assert(mod.subsets.head.addresses == Some(List(EndpointAddress("10.248.4.134", Some(ObjectReference(Some("Pod"), Some("greg-test"), Some("auth-54q3e"), Some("0d5d0a2d-9f9b-11e5-94e8-42010af00045"), None, Some("17147807"), None))))))
                 val next = stream().uncons
                 await(closable.close())
-                assertThrows[Reader.ReaderDiscarded] {
-                  await(next)
-                }
+                assert(!next.isDefined)
 
               case event =>
                 fail(s"unexpected event: $event")
@@ -244,15 +242,7 @@ class ApiTest extends FunSuite with Awaits with Exceptions {
     await {
       closer.close()
     }
-    assert(uncons.isDefined)
-    assertThrows[Reader.ReaderDiscarded] {
-      await(uncons)
-    }
-    assertThrows[Reader.ReaderDiscarded] {
-      await {
-        rsp.writer.write(added0)
-      }
-    }
+    assert(!uncons.isDefined)
   }
 
   test("watch too old") {
@@ -307,9 +297,7 @@ class ApiTest extends FunSuite with Awaits with Exceptions {
             assert(mod.subsets.head.addresses == Some(List(EndpointAddress("10.248.4.134", Some(ObjectReference(Some("Pod"), Some("greg-test"), Some("auth-54q3e"), Some("0d5d0a2d-9f9b-11e5-94e8-42010af00045"), None, Some("17147807"), None))))))
             val next = stream().uncons
             await(closable.close())
-            assertThrows[Reader.ReaderDiscarded] {
-              await(next)
-            }
+            assert(!next.isDefined)
 
           case event =>
             fail(s"unexpected event: $event")

--- a/k8s/src/test/scala/io/buoyant/k8s/v1/ApiTest.scala
+++ b/k8s/src/test/scala/io/buoyant/k8s/v1/ApiTest.scala
@@ -2,7 +2,7 @@ package io.buoyant.k8s.v1
 
 import com.twitter.finagle.Service
 import com.twitter.finagle.http._
-import com.twitter.io.{Buf, Reader}
+import com.twitter.io.Buf
 import com.twitter.util._
 import io.buoyant.k8s.{ObjectMeta, ObjectReference}
 import io.buoyant.test.{Awaits, Exceptions}


### PR DESCRIPTION
Previously, if a watch response was terminated by a connection close, the reconnection logic became unreachable as the stream of events was never "terminated." This change ensures the stream ends by swallowing exceptions, and ensures the reconnection logic is run. ⚡ 

Fixes BuoyantIO/linkerd#617