### PR TITLE
Update config.md examples and navigation

### DIFF
--- a/linkerd/docs/response_classifier.md
+++ b/linkerd/docs/response_classifier.md
@@ -4,9 +4,8 @@
 ```yaml
 routers:
 - ...
-  client:
-    responseClassifier:
-      kind: io.l5d.retryableRead5XX
+  responseClassifier:
+    kind: io.l5d.retryableRead5XX
 ```
 
 Response classifiers determine which HTTP responses are considered to


### PR DESCRIPTION
Problem:
Many links in buoyant.io/linkerd are broken, since in this site
layout all markdown files are combined into a single html file.

Solution:
Move the links to use anchors. Unfortunately they will no longer
link to each other in the docs folder. But maybe that is ok.

I also added an example to every section. I haven't used every
feature listed, so it'd be great if folks could find any errors
I may have made.

Also updates the response classifier example to be on the router
block instead of the client block.