### PR TITLE
Use l5d-dst-concrete as request name

### DIFF
--- a/router/http/src/main/scala/io/buoyant/router/Http.scala
+++ b/router/http/src/main/scala/io/buoyant/router/Http.scala
@@ -56,23 +56,11 @@ object Http extends Router[Request, Response] with FinagleServer[Request, Respon
       params: Stack.Params = this.params
     ): Router = copy(pathStack, boundStack, client, params)
 
-    protected def dstIdentifier(
-      baseDtab: () => Dtab,
-      id: RoutingFactory.Identifier[Request]
-    ): RoutingFactory.Identifier[Request] = {
-      case req if req.headerMap.contains("l5d-dst-concrete") =>
-        Future {
-          val path = Path.read(req.headerMap("l5d-dst-concrete"))
-          (Dst.Path(path, baseDtab()), req)
-        }
-      case req => id(req)
-    }
-
     protected def newIdentifier(): RoutingFactory.Identifier[Request] = {
       val RoutingFactory.DstPrefix(pfx) = params[RoutingFactory.DstPrefix]
       val RoutingFactory.BaseDtab(baseDtab) = params[RoutingFactory.BaseDtab]
       val param.HttpIdentifier(id) = params[param.HttpIdentifier]
-      dstIdentifier(baseDtab, id(pfx, baseDtab))
+      id(pfx, baseDtab)
     }
   }
 

--- a/router/http/src/main/scala/io/buoyant/router/http/Identifier.scala
+++ b/router/http/src/main/scala/io/buoyant/router/http/Identifier.scala
@@ -1,0 +1,16 @@
+package io.buoyant.router.http
+
+import com.twitter.finagle.buoyant.Dst
+import com.twitter.finagle.http.Request
+import com.twitter.finagle.{Dtab, Path}
+import com.twitter.util.{Future, Try}
+
+object Identifier {
+  def dstConcrete(req: Request, baseDtab: () => Dtab): Option[Future[(Dst, Request)]] = {
+    req.headerMap.get("l5d-dst-concrete").flatMap { dst =>
+      Try(Path.read(dst)).toOption
+    }.map { dst =>
+      Future.value((Dst.Path(dst, baseDtab()), req))
+    }
+  }
+}

--- a/router/http/src/main/scala/io/buoyant/router/http/MethodAndHostIdentifier.scala
+++ b/router/http/src/main/scala/io/buoyant/router/http/MethodAndHostIdentifier.scala
@@ -24,21 +24,23 @@ case class MethodAndHostIdentifier(
   private[this] def mkPath(path: Path): Dst.Path =
     Dst.Path(prefix ++ path, baseDtab(), Dtab.local)
 
-  def apply(req: http.Request): Future[(Dst, http.Request)] = req.version match {
-    case http.Version.Http10 =>
-      Future.value(
-        (mkPath(Path.Utf8("1.0", req.method.toString) ++ suffix(req)), req)
-      )
-
-    case http.Version.Http11 =>
-      req.host match {
-        case Some(host) if host.nonEmpty =>
+  def apply(req: http.Request): Future[(Dst, http.Request)] =
+    Identifier.dstConcrete(req, baseDtab).getOrElse {
+      req.version match {
+        case http.Version.Http10 =>
           Future.value(
-            (mkPath(Path.Utf8("1.1", req.method.toString, host) ++ suffix(req)), req)
+            (mkPath(Path.Utf8("1.0", req.method.toString) ++ suffix(req)), req)
           )
-        case _ =>
-          Future.exception(new IllegalArgumentException(s"${http.Version.Http11} request missing hostname: $req"))
-      }
-  }
 
+        case http.Version.Http11 =>
+          req.host match {
+            case Some(host) if host.nonEmpty =>
+              Future.value(
+                (mkPath(Path.Utf8("1.1", req.method.toString, host) ++ suffix(req)), req)
+              )
+            case _ =>
+              Future.exception(new IllegalArgumentException(s"${http.Version.Http11} request missing hostname: $req"))
+          }
+      }
+    }
 }

--- a/router/http/src/test/scala/io/buoyant/router/http/MethodAndHostIdentifierTest.scala
+++ b/router/http/src/test/scala/io/buoyant/router/http/MethodAndHostIdentifierTest.scala
@@ -48,4 +48,13 @@ class MethodAndHostIdentifierTest extends FunSuite with Awaits with Exceptions {
     req.version = Version.Http10
     assert(await(identifier(req))._1 == Dst.Path(Path.read("/prefix/1.0/POST/drum/bass")))
   }
+
+  test("l5d-dst-concrete") {
+    val identifier = MethodAndHostIdentifier(Path.Utf8("https"), false)
+    val req = Request()
+    req.uri = "/some/path?other=stuff"
+    req.host = "domain"
+    req.headerMap.add("l5d-dst-concrete", "/#/io.l5d.fs/foo")
+    assert(await(identifier(req))._1 == Dst.Path(Path.read("/#/io.l5d.fs/foo")))
+  }
 }

--- a/router/http/src/test/scala/io/buoyant/router/http/PathIdentifierTest.scala
+++ b/router/http/src/test/scala/io/buoyant/router/http/PathIdentifierTest.scala
@@ -55,4 +55,12 @@ class PathIdentifierTest extends FunSuite with Awaits with Exceptions {
     req.uri = "/mysvc/subsvc/!"
     assert(await(identifier(req))._1 == Dst.Path(Path.read("/http/mysvc/subsvc")))
   }
+
+  test("l5d-dst-concrete") {
+    val identifier = PathIdentifier(Path.Utf8("http"), 2)
+    val req = Request()
+    req.uri = "/mysvc/subsvc"
+    req.headerMap.add("l5d-dst-concrete", "/#/io.l5d.fs/foo")
+    assert(await(identifier(req))._1 == Dst.Path(Path.read("/#/io.l5d.fs/foo")))
+  }
 }


### PR DESCRIPTION
If linkerd receives a request with the l5d-dst-concrete header set, use that as the request's name.

This can be useful in setups where a request passes through multiple linkerds (such as linkerd-to-linkerd) and the dst assigned by the first linkerd should be used by the second.