### PR TITLE
Convert docs to use tables for param definitions.

### DIFF
--- a/linkerd/docs/announcer.md
+++ b/linkerd/docs/announcer.md
@@ -1,7 +1,7 @@
 # Announcers
 
 An announcer registers servers in service discovery.  Each server may specify
-a list of concrete names to announce as in the [announce](config.md#announce)
+a list of concrete names to announce as in the [announce](#announce)
 server key.  Each announcer has a prefix and will only announce names that
 begin with that prefix.
 

--- a/linkerd/docs/announcer.md
+++ b/linkerd/docs/announcer.md
@@ -10,9 +10,9 @@ begin with that prefix.
 These parameters are available to the announcer regardless of kind. Announcers may also have kind-specific parameters.
 </aside>
 
-Key | Default Value | Value Description
---- | ------------- | -----------------
-kind | _required_ | `io.l5d.serversets`
+Key | Default Value | Description
+--- | ------------- | -----------
+kind | _required_ | Only `io.l5d.serversets` is available at this time.
 prefix | kind-specific | Announces names beginning with `/#/<prefix>`.
 
 ## Serversets
@@ -21,8 +21,8 @@ kind: `io.l5d.serversets`
 
 Announce to ZooKeeper using the serverset format.
 
-Key | Default Value | Value Description
---- | ------------- | -----------------
+Key | Default Value | Description
+--- | ------------- | -----------
 prefix | `io.l5d.serversets` | Announces names beginning with `/#/<prefix>`.
 zkAddrs | _required_ | A list of ZooKeeper addresses, each of which have `host` and `port` parameters.
-pathPrefix | `/discovery` | the ZooKeeper path under which services should be registered.
+pathPrefix | `/discovery` | The ZooKeeper path under which services should be registered.

--- a/linkerd/docs/announcer.md
+++ b/linkerd/docs/announcer.md
@@ -5,22 +5,24 @@ a list of concrete names to announce as in the [announce](config.md#announce)
 server key.  Each announcer has a prefix and will only announce names that
 begin with that prefix.
 
-An announcer config block has the following parameters:
 
-* *kind* -- The name of the announcer plugin
-* *prefix* -- This announcer will announce names beginning with `/#/<prefix>`.
-  Some announcers may configure a default prefix; see the specific announcer
-  section for details.
-* *announcer-specific parameters*.
+<aside class="notice">
+These parameters are available to the announcer regardless of kind. Announcers may also have kind-specific parameters.
+</aside>
+
+Key | Default Value | Value Description
+--- | ------------- | -----------------
+kind | _required_ | `io.l5d.serversets`
+prefix | kind-specific | Announces names beginning with `/#/<prefix>`.
 
 ## Serversets
 
-`io.l5d.serversets`
+kind: `io.l5d.serversets`
 
 Announce to ZooKeeper using the serverset format.
 
-* *zkAddrs* -- list of ZooKeeper addresses:
-  * *host* --  the ZooKeeper host.
-  * *port* --  the ZooKeeper port.
-* *pathPrefix* -- (optional) the ZooKeeper path under which services should be registered. (default:
-  /discovery)
+Key | Default Value | Value Description
+--- | ------------- | -----------------
+prefix | `io.l5d.serversets` | Announces names beginning with `/#/<prefix>`.
+zkAddrs | _required_ | A list of ZooKeeper addresses, each of which have `host` and `port` parameters.
+pathPrefix | `/discovery` | the ZooKeeper path under which services should be registered.

--- a/linkerd/docs/client_tls.md
+++ b/linkerd/docs/client_tls.md
@@ -18,10 +18,10 @@ routers:
 In order to accept incoming tls traffic, the tls parameter must be defined on
 the server.
 
-Key | Default Value | Value Description
---- | ------------- | -----------------
-certPath | _required_ | File path to the TLS certificate file
-keyPath | _required_ | File path to the TLS key file
+Key | Default Value | Description
+--- | ------------- | -----------
+certPath | _required_ | File path to the TLS certificate file.
+keyPath | _required_ | File path to the TLS key file.
 
 See [Transparent TLS with linkerd](https://blog.buoyant.io/2016/03/24/transparent-tls-with-linkerd/) for more on how to generate certificate
 and key files.
@@ -44,9 +44,9 @@ the client.
 A client TLS object describes how linkerd should use TLS when sending requests
 to destination services.
 
-Key | Default Value | Value Description
---- | ------------- | -----------------
-kind | _required_ | [io.l5d.noValidation](#no-validation-tls), [io.l5d.static](#static-tls), or [io.l5d.boundPath](#tls-with-bound-path)
+Key | Default Value | Description
+--- | ------------- | -----------
+kind | _required_ | Either [io.l5d.noValidation](#no-validation-tls), [io.l5d.static](#static-tls), or [io.l5d.boundPath](#tls-with-bound-path).
 
 <aside class="notice">
 TLS objects may also have protocol-specific parameters.
@@ -78,10 +78,10 @@ Uses a single common name for all TLS requests.  This assumes all servers
 that the router connects to use the same TLS cert (or all use certs
 generated with the same common name).
 
-Key | Default Value | Value Description
---- | ------------- | -----------------
+Key | Default Value | Description
+--- | ------------- | -----------
 commonName | _required_ | The common name to use for all TLS requests.
-caCertPath | ? | The path to the CA cert used for common name validation.
+caCertPath | N/A | The path to the CA cert used for common name validation.
 
 ### TLS with Bound Path
 
@@ -100,17 +100,17 @@ kind: `io.l5d.boundPath`
 Determine the common name based on the destination bound path.  This plugin
 supports the following options:
 
-Key | Default Value | Value Description
---- | ------------- | -----------------
+Key | Default Value | Description
+--- | ------------- | -----------
 caCertPath | ? | The path to the CA cert used for common name validation.
-names | _required_ | A list of [name matchers]("#bound-path-name-matchers")
+names | _required_ | A list of [name matchers]("#bound-path-name-matchers").
 strict | true | When true, paths that fail to match any prefixes throw an exception.
 
 #### Bound Path Name Matchers
 
-Key | Default Value | Value Description
---- | ------------- | -----------------
-prefix | _required_ | A path prefix.  All destinations which match this prefix will use this entry to determine the common name.  Wildcards and variable capture are allowed (see: `io.buoyant.linkerd.util.PathMatcher`)
+Key | Default Value | Description
+--- | ------------- | -----------
+prefix | _required_ | A path prefix.  All destinations which match this prefix will use this entry to determine the common name.  Wildcards and variable capture are allowed (see: `io.buoyant.linkerd.util.PathMatcher`).
 commonNamePattern | _required_ | The common name to use for destinations matching the above prefix.  Variables captured in the prefix may be used in this string.
 
 See [Transparent TLS with linkerd](https://blog.buoyant.io/2016/03/24/transparent-tls-with-linkerd/) for more on how boundPath matches prefixes when routing requests.

--- a/linkerd/docs/client_tls.md
+++ b/linkerd/docs/client_tls.md
@@ -1,4 +1,32 @@
-# Client TLS
+# TLS
+
+## Server TLS
+
+```yaml
+routers:
+- protocol: http
+  servers:
+  - port: 4140
+    # accept incoming TLS traffic from remote linkerd
+    tls:
+      certPath: /certificates/certificate.pem
+      keyPath: /certificates/key.pem
+  baseDtab: |
+    /http => /$/inet/127.1/8080;
+```
+
+In order to accept incoming tls traffic, the tls parameter must be defined on
+the server.
+
+Key | Default Value | Value Description
+--- | ------------- | -----------------
+certPath | _required_ | File path to the TLS certificate file
+keyPath | _required_ | File path to the TLS key file
+
+See [Transparent TLS with linkerd](https://blog.buoyant.io/2016/03/24/transparent-tls-with-linkerd/) for more on how to generate certificate
+and key files.
+
+## Client TLS
 
 >Client TLS is defined in the client section of routers:
 
@@ -6,26 +34,36 @@
 routers:
 - protocol: http
   client:
-    tls: ...
+    tls:
+      kind: io.l5d.noValidation
 ```
 
-A client TLS object describes how linkerd should use TLS when sending requests
-to destination services.  A client TLS config block must contain a `kind`
-parameter which indicates which client TLS plugin to use as well as any
-parameters specific to the plugin.
+In order to send outgoing tls traffic, the tls parameter must be defined on
+the client.
 
-## No Validation
+A client TLS object describes how linkerd should use TLS when sending requests
+to destination services.
+
+Key | Default Value | Value Description
+--- | ------------- | -----------------
+kind | _required_ | [io.l5d.noValidation](#no-validation-tls), [io.l5d.static](#static-tls), or [io.l5d.boundPath](#tls-with-bound-path)
+
+<aside class="notice">
+TLS objects may also have protocol-specific parameters.
+</aside>
+
+### No Validation TLS
 
 ```yaml
 tls:
   kind: io.l5d.noValidation
 ```
 
-`io.l5d.noValidation`
+kind: `io.l5d.noValidation`
 
 <aside class="warning">This skips hostname validation and is unsafe.</aside>
 
-## Static
+### Static TLS
 
 ```yaml
 tls:
@@ -34,17 +72,18 @@ tls:
   caCertPath: /foo/caCert.pem
 ```
 
-`io.l5d.static`
+kind: `io.l5d.static`
 
-Use a single common name for all TLS requests.  This assumes that all servers
-that the router connects to all use the same TLS cert (or all use certs
-generated with the same common name).  This plugin supports the following
-options:
+Uses a single common name for all TLS requests.  This assumes all servers
+that the router connects to use the same TLS cert (or all use certs
+generated with the same common name).
 
-* *commonName* -- Required.  The common name to use for all TLS requests.
-* *caCertPath* -- Optional.  Use the given CA cert for common name validation.
+Key | Default Value | Value Description
+--- | ------------- | -----------------
+commonName | _required_ | The common name to use for all TLS requests.
+caCertPath | ? | The path to the CA cert used for common name validation.
 
-## Bound Path
+### TLS with Bound Path
 
 ```yaml
 tls:
@@ -56,21 +95,25 @@ tls:
   strict: false
 ```
 
-`io.l5d.boundPath`
+kind: `io.l5d.boundPath`
 
 Determine the common name based on the destination bound path.  This plugin
 supports the following options:
 
-* *caCertPath* -- Optional.  Use the given CA cert for common name validation.
-* *names* -- Required.  A list of name matchers which each must be an object
-  containing:
-  * *prefix* -- A path prefix.  All destinations which match this prefix
-    will use this entry to determine the common name.  Wildcards and variable
-    capture are allowed (see: `io.buoyant.linkerd.util.PathMatcher`)
-  * *commonNamePattern* -- The common name to use for destinations matching
-    the above prefix.  Variables captured in the prefix may be used in this
-    string.
-* *strict* -- Optional. When true, paths that fail to match any prefixes throw
-    an exception. Defaults to true.
+Key | Default Value | Value Description
+--- | ------------- | -----------------
+caCertPath | ? | The path to the CA cert used for common name validation.
+names | _required_ | A list of [name matchers]("#bound-path-name-matchers")
+strict | true | When true, paths that fail to match any prefixes throw an exception.
+
+#### Bound Path Name Matchers
+
+Key | Default Value | Value Description
+--- | ------------- | -----------------
+prefix | _required_ | A path prefix.  All destinations which match this prefix will use this entry to determine the common name.  Wildcards and variable capture are allowed (see: `io.buoyant.linkerd.util.PathMatcher`)
+commonNamePattern | _required_ | The common name to use for destinations matching the above prefix.  Variables captured in the prefix may be used in this string.
+
+See [Transparent TLS with linkerd](https://blog.buoyant.io/2016/03/24/transparent-tls-with-linkerd/) for more on how boundPath matches prefixes when routing requests.
+
 
 

--- a/linkerd/docs/config.md
+++ b/linkerd/docs/config.md
@@ -51,12 +51,12 @@ the `config/` directory.
 
 The configuration may be specified as a JSON or YAML object. There are no requirements on field ordering, though it's generally good style to start a router with the _protocol_. Four top level keys are supported:
 
-Key | Required? | Value Description
---- | --------- | -----------------
-[Admin](#administrative-interface) | no | Configures linkerd's administrative interface.
-[Routers](#routers) | yes | Configures linkerd's RPC support for various protocols.
-[Namers](#namers-and-service-discovery) | no | Configures linkerd's integration with various service discovery backends.
-[Tracers](#tracers) | no | Configures linkerd's request instrumentation.
+Key | Required | Description
+--- | -------- | -----------
+[admin](#administrative-interface) | no | Configures linkerd's administrative interface.
+[routers](#routers) | yes | Configures linkerd's RPC support for various protocols.
+[namers](#namers-and-service-discovery) | no | Configures linkerd's integration with various service discovery backends.
+[tracers](#tracers) | no | Configures linkerd's request instrumentation.
 
 
 ### Administrative interface
@@ -70,9 +70,9 @@ linkerd supports an administrative interface, both as a web ui and a collection
 of json endpoints. The exposed admin port is configurable via a top-level
 `admin` section.
 
-Key | Default Value | Value Description
---- | ------------- | -----------------
-port | `9990` | Port for the admin interface
+Key | Default Value | Description
+--- | ------------- | -----------
+port | `9990` | Port for the admin interface.
 
 ### Routers
 

--- a/linkerd/docs/config.md
+++ b/linkerd/docs/config.md
@@ -1,26 +1,6 @@
 # Introduction
 
-> A minimal linkerd configuration example, which forwards all requests on `localhost:8080` to `localhost:8888`
-
-
-
-```yaml
-routers:
-- protocol: http
-  baseDtab: /http => /$/inet/127.1/8888
-  servers:
-  - port: 8080
-```
-
-linkerd's configuration is controlled via config file, which must be provided
-as a command-line argument. It may be a local file path or `-` to
-indicate that the configuration should be read from the standard input.
-For convenience, the release package includes a default `linkerd.yaml` file in
-the `config/` directory.
-
-### File Format
-
-> A more complex linkerd config example
+> A linkerd config example
 
 ```yaml
 admin:
@@ -59,19 +39,27 @@ tracers:
   sampleRate: 0.02
 ```
 
-The configuration may be specified as a JSON or YAML object, as described
-below.  Four top level keys are supported:
+Welcome to the Configuration Reference for linkerd!
 
-* [Admin](#admin)
-* [Routers](#routers)
-* [Namers](#namers)
-* [Tracers](#tracers)
+linkerd's configuration is controlled via config file, which must be provided
+as a command-line argument. It may be a local file path or `-` to
+indicate that the configuration should be read from the standard input.
+For convenience, the release package includes a default `linkerd.yaml` file in
+the `config/` directory.
 
-There are no requirements on field ordering, though it's generally
-good style to start a router with the _protocol_.
+#### File Format
 
-<a name="admin"></a>
-## Administrative interface
+The configuration may be specified as a JSON or YAML object. There are no requirements on field ordering, though it's generally good style to start a router with the _protocol_. Four top level keys are supported:
+
+Key | Required? | Value Description
+--- | --------- | -----------------
+[Admin](#administrative-interface) | no | Configures linkerd's administrative interface.
+[Routers](#routers) | yes | Configures linkerd's RPC support for various protocols.
+[Namers](#namers-and-service-discovery) | no | Configures linkerd's integration with various service discovery backends.
+[Tracers](#tracers) | no | Configures linkerd's request instrumentation.
+
+
+### Administrative interface
 
 ```yaml
 admin:
@@ -80,174 +68,30 @@ admin:
 
 linkerd supports an administrative interface, both as a web ui and a collection
 of json endpoints. The exposed admin port is configurable via a top-level
-`admin` section
+`admin` section.
 
-* *admin* -- Config section for the admin interface, contains keys:
-  * *port* -- Port for the admin interface (default is `9990`)
+Key | Default Value | Value Description
+--- | ------------- | -----------------
+port | `9990` | Port for the admin interface
 
-<a name="routers"></a>
-## Routers
+### Routers
+
+> A minimal linkerd configuration example, which forwards all requests on `localhost:8080` to `localhost:8888`
 
 ```yaml
 routers:
 - protocol: http
-  servers: ...
-  client: ...
-  interpreter: ...
-  announcers: ...
+  baseDtab: /http => /$/inet/127.1/8888
+  servers:
+  - port: 8080
 ```
 
 All configurations must define a **routers** key, the value of which
-must be an array of router configurations. Each router implements RPC
-for a supported protocol. (linkerd doesn't need to understand the payload in an
-RPC call, but it does need to know enough about the protocol to determine the
-logical name of the destination.)
+must be an array of router configurations. Each router implements RPC for a supported protocol. linkerd doesn't need to understand the payload in an RPC call, but it does need to know enough about the protocol to determine the logical name of the destination.
 
-Routers also include **servers**, which define their entry points, and
-**client**, which configures how clients are built.
+See [routers](#routers1).
 
-Additionally, any of the [basic router params](#basic-router-params)
-may be specified in the top-level object as defaults.
-
-Each router must be configured as an object with the following params:
-
-* *protocol* -- a protocol name must match one of the loaded configuration plugins (e.g. _http_, _mux_).
-  linkerd currently supports the following protocols:
-  * [HTTP/1.1](#http-1-1-protocol), by using the value *http*;
-  * [Thrift](#thrift-protocol), by using the value *thrift*; and
-  * [Mux](#mux-protocol-experimental) (experimental), by using the value *mux*.
-* [basic router params](#basic-router-params) or protocol-specific router params
-* *servers* -- a list of server objects with the following params:
-  * [basic server params](#basic-server-params) or protocol-specific server params
-* *client* -- an object containing [basic client params](#basic-client-params)
-  or protocol-specific client params
-* *interpreter* (optional) -- an
-  [interpreter](#interpreter) object determining what module will be used to
-  process destinations.  (default: default)
-  * protocol-specific module params, if any (the _default_ module has none)
-* *announcers* (optional) -- a list of service discovery
-  [announcers](#announcers) that servers can announce to.
-
-<a name="basic-router-params"></a>
-### Basic router parameters
-
-```yaml
-routers:
-- protocol: http
-  label: myPackIce
-  dstPrefix: /walruses/http
-  baseDtab: |
-    /host                => /#/io.l5d.fs;
-    /walruses/http/1.1/* => /host;
-  failFast: false
-  timeoutMs: 10000
-  bindingTimeoutMs: 5000
-  bindingCache:
-    paths: 100
-    trees: 100
-    bounds: 100
-    clients: 100
-  responseClassifier: io.l5d.nonRetryable5XX
-```
-
-* *label* -- The name of the router (in stats and the admin ui). (default: the
-  protocol name)
-* *baseDtab* -- Sets the base delegation table. See
-  [dtabs](https://linkerd.io/doc/dtabs/) for more. (default: an empty dtab)
-* *dstPrefix* -- A path prefix to be used on request destinations.
-  (default is protocol dependent)
-* *failFast* -- If `true`, connection failures are punished more aggressively.
-  Should not be used with small destination pools. (default: false)
-* *timeoutMs* -- Per-request timeout in milliseconds. (default: no timeout)
-* *bindingTimeoutMs* -- Optional.  The maximum amount of time in milliseconds to
-  spend binding a path.  (default: 10 seconds)
-* *bindingCache* -- Optional.  Configure the size of binding cache.  It must be
-  an object containing keys:
-  * *paths* -- Optional.  Size of the path cache.  (default: 100)
-  * *trees* -- Optional.  Size of the tree cache.  (default: 100)
-  * *bounds* -- Optional.  Size of the bound cache.  (default: 100)
-  * *clients* -- Optional.  Size of the client cache.  (default: 10)
-* *responseClassifier* -- Optional. A
-  (sometimes protocol-specific) [response classifier](#http-response-classifiers)
-  that determines which responses should be considered failures and, of those,
-  which should be considered [retryable](#retries).
-  (default: _io.l5d.nonRetryable5XX_)
-
-<a name="basic-server-params"></a>
-### Basic server parameters
-
-```yaml
-servers:
-- port: 8080
-  ip: 0.0.0.0
-  tls:
-    certPath: /foo/cert.pem
-    keyPath: /foo/key.pem
-  maxConcurrentRequests: 1000
-  announce:
-    - /#/io.l5d.fs/web
-```
-
-* *port* -- The TCP port number. Protocols may provide default
-values. If no default is provided, the port parameter is required.
-* *ip* -- The local IP address.  By default, the loopback address is
-used.  A value like `0.0.0.0` configures the server to listen on all
-local IPv4 interfaces.
-* *tls* -- The server will serve over TLS if this parameter is provided.
-  It must be an object containing keys:
-  * *certPath* -- File path to the TLS certificate file
-  * *keyPath* -- File path to the TLS key file
-* *maxConcurrentRequests* -- Optional.  The maximum number of concurrent
-requests the server will accept.  (default: unlimited)
-<a name="announce"></a>
-* *announce* -- Optional.  A list of concrete names to announce using the
-  router's [announcers](#announcers).
-
-<a name="basic-client-params"></a>
-### Basic client parameters
-
-```yaml
-client:
-  hostConnectionPool:
-    minSize: 0
-    maxSize: 1000
-    idleTimeMs: 10000
-    maxWaiters: 5000
-  tls:
-    kind: io.l5d.noValidation
-    commonName: foo
-    caCertPath: /foo/caCert.pem
-  loadBalancer:
-    kind: ewma
-    enableProbation: false
-  retries:
-    backoff:
-      kind: jittered
-      minMs: 10
-      maxMs: 10000
-```
-
-* *hostConnectionPool* -- Optional.  Configure the number of connections to
-maintain to each destination host.  It must be an object containing keys:
-  * *minSize* -- Optional. The minimum number of connections to maintain to each
-  host.  (default: 0)
-  * *maxSize* -- Optional.  The maximum number of connections to maintain to
-  each host.  (default: Int.MaxValue)
-  * *idleTimeMs* -- Optional.  The amount of idle time for which a connection is
-  cached in milliseconds.  (default: forever)
-  * *maxWaiters* -- Optional.  The maximum number of connection requests that
-  are queued when the connection concurrency exceeds maxSize.  (default:
-  Int.MaxValue)
-* *tls* -- Optional.  The router will make requests
-  using TLS if this parameter is provided.  It must be a
-  [client TLS](#client-tls) object.
-* *loadBalancer* -- Optional.  A
-  [load balancer](#load-balancer) object.  (default: p2c)
-* *retries* -- Optional. A [retry policy](#retries) for all clients created by
-  this router.
-
-<a name="service-discovery-and-naming"></a>
-## Service discovery and naming
+### Namers and Service Discovery
 
 ```yaml
 namers:
@@ -259,16 +103,13 @@ linkerd supports a variety of common service discovery backends, including
 ZooKeeper and Consul. linkerd provides abstractions on top of service discovery
 lookups that allow the use of arbitrary numbers of service discovery backends,
 and for precedence and failover rules to be expressed between them. This logic
-is governed by the [routing](#basic-router-params) configuration.
+is governed by the [routing](#router-parameters) configuration.
 
 Naming and service discovery are configured via the `namers` section of the
 configuration file.  A namer acts on paths that start with `/#` followed by the
-namer's prefix.
+namer's prefix. See [namers](#namers).
 
-* *namers* -- An array of [namer](#namers) objects.
-
-<a name="tracers"></a>
-## Tracers
+### Tracers
 
 ```yaml
 tracers:
@@ -278,6 +119,4 @@ tracers:
 
 Requests that are routed by linkerd are also traceable using Finagle's built-in
 tracing instrumentation. Trace data can be exported from a linkerd process by
-configuring tracers via a top-level `tracers` section:
-
-* *tracers* -- An array of [tracer](#tracers10) objects.
+configuring tracers via a top-level `tracers` section. See [tracers](#tracers10).

--- a/linkerd/docs/interpreter.md
+++ b/linkerd/docs/interpreter.md
@@ -25,7 +25,7 @@ kind | `default` | Either `default`, `io.l5d.namerd`, or `io.l5d.fs`.
 kind: `default`
 
 The default interpreter resolves names via the configured
-[`namers`](config.md#namers), with a fallback to the default Finagle
+[`namers`](#namers), with a fallback to the default Finagle
 `Namer.Global` that handles paths of the form `/$/`.
 
 ## namerd
@@ -53,7 +53,7 @@ maxSeconds | 10 minutes | The maximum number of seconds to wait before retrying.
 kind: `io.l5d.fs`
 
 The file-system interpreter resolves names via the configured
-[`namers`](config.md#namers), just like the default interpreter, but also uses
+[`namers`](#namers), just like the default interpreter, but also uses
 a dtab read from a file on the local file-system.  The specified file is watched
 for changes so that the dtab may be edited live.
 

--- a/linkerd/docs/interpreter.md
+++ b/linkerd/docs/interpreter.md
@@ -16,9 +16,9 @@ An interpreter determines how names are resolved.
 These parameters are available to the identifier regardless of kind. Identifiers may also have kind-specific parameters.
 </aside>
 
-Key | Default Value | Value Description
---- | ------------- | -----------------
-kind | `default` | `default`, `io.l5d.namerd`, or `io.l5d.fs`
+Key | Default Value | Description
+--- | ------------- | -----------
+kind | `default` | Either `default`, `io.l5d.namerd`, or `io.l5d.fs`.
 
 ## Default
 
@@ -35,16 +35,16 @@ kind: `io.l5d.namerd`
 The namerd interpreter offloads the responsibilities of name resolution to the
 namerd service.  Any namers configured in this linkerd are not used.
 
-Key | Default Value | Value Description
---- | ------------- | -----------------
-dst | _required_ | A finagle path locating the namerd service.
+Key | Default Value | Description
+--- | ------------- | -----------
+dst | _required_ | A Finagle path locating the namerd service.
 namespace | `default` | The name of the namerd dtab to use.
 retry | see [namerd retry](#namerd-retry) | An object configuring retry backoffs for requests to namerd.
 
 ### namerd retry
 
-Key | Default Value | Value Description
---- | ------------- | -----------------
+Key | Default Value | Description
+--- | ------------- | -----------
 baseSeconds | 5 seconds | The base number of seconds to wait before retrying.
 maxSeconds | 10 minutes | The maximum number of seconds to wait before retrying.
 
@@ -57,6 +57,6 @@ The file-system interpreter resolves names via the configured
 a dtab read from a file on the local file-system.  The specified file is watched
 for changes so that the dtab may be edited live.
 
-Key | Default Value | Value Description
---- | ------------- | -----------------
+Key | Default Value | Description
+--- | ------------- | -----------
 dtabFile | _required_ | The file-system path to a file containing a dtab.

--- a/linkerd/docs/interpreter.md
+++ b/linkerd/docs/interpreter.md
@@ -10,10 +10,19 @@ routers:
     dst: /$/inet/1.2.3.4/4180
 ```
 
-An interpreter determines how names are resolved.  An interpreter config block
-must contain a `kind` parameter which indicates which interpreter plugin to use.
+An interpreter determines how names are resolved.
+
+<aside class="notice">
+These parameters are available to the identifier regardless of kind. Identifiers may also have kind-specific parameters.
+</aside>
+
+Key | Default Value | Value Description
+--- | ------------- | -----------------
+kind | `default` | `default`, `io.l5d.namerd`, or `io.l5d.fs`
 
 ## Default
+
+kind: `default`
 
 The default interpreter resolves names via the configured
 [`namers`](config.md#namers), with a fallback to the default Finagle
@@ -21,28 +30,33 @@ The default interpreter resolves names via the configured
 
 ## namerd
 
-`io.l5d.namerd`
+kind: `io.l5d.namerd`
 
 The namerd interpreter offloads the responsibilities of name resolution to the
-namerd service.  Any namers configured in this linkerd are not used.  This
-interpreter accepts the following parameters:
+namerd service.  Any namers configured in this linkerd are not used.
 
-* *dst* -- Required.  A finagle path locating the namerd service.
-* *namespace* -- Optional.  This indicates which namerd dtab to use.
-  (default: default)
-*retry* -- Optional.  An object configuring retry backoffs for requests to
- namerd.  (default: (5 seconds, 10 minutes))
-  * *baseSeconds* -- The base number of seconds to wait before retrying.
-  * *maxSeconds* -- The maximum number of seconds to wait before retrying.
+Key | Default Value | Value Description
+--- | ------------- | -----------------
+dst | _required_ | A finagle path locating the namerd service.
+namespace | `default` | The name of the namerd dtab to use.
+retry | see [namerd retry](#namerd-retry) | An object configuring retry backoffs for requests to namerd.
+
+### namerd retry
+
+Key | Default Value | Value Description
+--- | ------------- | -----------------
+baseSeconds | 5 seconds | The base number of seconds to wait before retrying.
+maxSeconds | 10 minutes | The maximum number of seconds to wait before retrying.
 
 ## File-System
 
-`io.l5d.fs`
+kind: `io.l5d.fs`
 
 The file-system interpreter resolves names via the configured
 [`namers`](config.md#namers), just like the default interpreter, but also uses
 a dtab read from a file on the local file-system.  The specified file is watched
-for changes so that the dtab may be edited live.  This interpreter accepts the
-following parameters:
+for changes so that the dtab may be edited live.
 
-* *dtabFile* -- Required.  The file-system path to a file containing a dtab.
+Key | Default Value | Value Description
+--- | ------------- | -----------------
+dtabFile | _required_ | The file-system path to a file containing a dtab.

--- a/linkerd/docs/load_balancer.md
+++ b/linkerd/docs/load_balancer.md
@@ -1,5 +1,7 @@
 # Load Balancer
 
+> Example load balancer configuration
+
 ```yaml
 routers:
 - ...
@@ -10,44 +12,65 @@ routers:
       decayTimeMs: 15000
 ```
 
-Specifies a load balancer to use.  It must be an object containing keys:
+<aside class="notice">
+These parameters are available to the loadbalancer regardless of kind. The loadbalancer may also have kind-specific parameters.
+</aside>
 
-  * *kind* -- One of the supported load balancers.
-  * *enableProbation* -- Optional.  Controls whether endpoints are eagerly evicted from
-    service discovery. (default: true)
-    See Finagle's [LoadBalancerFactory.EnableProbation](https://github.com/twitter/finagle/blob/develop/finagle-core/src/main/scala/com/twitter/finagle/loadbalancer/LoadBalancerFactory.scala#L28)
-  * Any options specific to the load balancer.
-
-If unspecified, p2c is used. Current load balancers include:
+Key | Default Value | Value Description
+--- | ------------- | -----------------
+kind | `p2c` | `p2c`, `ewma`, `aperture`, or `heap`
+enableProbation | `true` | If `true`, endpoints are eagerly evicted from service discovery. See Finagle's [LoadBalancerFactory.EnableProbation](https://github.com/twitter/finagle/blob/develop/finagle-core/src/main/scala/com/twitter/finagle/loadbalancer/LoadBalancerFactory.scala#L28)
 
 [p2c]: https://twitter.github.io/finagle/guide/Clients.html#power-of-two-choices-p2c-least-loaded
 [ewma]: https://twitter.github.io/finagle/guide/Clients.html#power-of-two-choices-p2c-peak-ewma
 [aperture]: https://twitter.github.io/finagle/guide/Clients.html#aperture-least-loaded
 [heap]: https://twitter.github.io/finagle/guide/Clients.html#heap-least-loaded
 
-## [p2c][p2c]
+## Power of Two Choices: Least Loaded
 
-p2c supports the following options (see [here][p2c] for option semantics and defaults):
+kind: `p2c`
 
-* *maxEffort* -- Optional.
+<aside class="success">
+  Learn more about p2c and how to configure it via <a target="_blank" href="https://twitter.github.io/finagle/guide/Clients.html#power-of-two-choices-p2c-least-loaded">finagle's documentation</a>
+</aside>
 
-## [ewma][ewma]
+Key | Default Value | Value Description
+--- | ------------- | -----------------
+maxEffort | `5` | The number of times a load balancer can retry if the previously picked node was marked unavailable.
 
-ewma supports the following options (see [here][ewma] for option semantics and defaults):
+## Power of Two Choices: Peak EWMA
 
-* *maxEffort* -- Optional.
-* *decayTimeMs* -- Optional.
+kind: `ewma`
 
-## [aperture][aperture]
+<aside class="success">
+  Learn more about ewma and how to configure it via <a target="_blank" href="https://twitter.github.io/finagle/guide/Clients.html#power-of-two-choices-p2c-peak-ewma">finagle's documentation</a>
+</aside>
 
-aperture supports the following options (see [here][aperture] for option semantics and defaults):
+Key | Default Value | Value Description
+--- | ------------- | -----------------
+maxEffort | `5` | The number of times a load balancer can retry if the previously picked node was marked unavailable.
+decayTimeMs | 10 seconds | The window of latency observations.
 
-* *maxEffort* -- Optional.
-* *smoothWindowMs* -- Optional.
-* *lowLoad* -- Optional.
-* *highLoad* -- Optional.
-* *minAperture* -- Optional.
+## Aperture: Least Loaded
 
-## [heap][heap]
+kind: `aperture`
 
-heap does not support any options.
+<aside class="success">
+  Learn more about aperture and how to configure it via <a target="_blank" href="https://twitter.github.io/finagle/guide/Clients.html#aperture-least-loaded">finagle's documentation</a>
+</aside>
+
+Key | Default Value | Value Description
+--- | ------------- | -----------------
+maxEffort | `5` | The number of times a load balancer can retry if the previously picked node was marked unavailable.
+smoothWin | 5 seconds |  the window of concurrent load observation
+lowLoad | `0.5` | The lower bound of the load band used to adjust an aperture
+highLoad | `2` | The upper bound of the load band used to adjust an aperture
+minAperture | `1` | The minimum size of the aperture
+
+## Heap: Least Loaded
+
+kind: `heap`
+
+<aside class="success">
+  Learn more about heap and how to configure it via <a target="_blank" href="https://twitter.github.io/finagle/guide/Clients.html#heap-least-loaded">finagle's documentation</a>
+</aside>

--- a/linkerd/docs/load_balancer.md
+++ b/linkerd/docs/load_balancer.md
@@ -16,10 +16,10 @@ routers:
 These parameters are available to the loadbalancer regardless of kind. The loadbalancer may also have kind-specific parameters.
 </aside>
 
-Key | Default Value | Value Description
---- | ------------- | -----------------
-kind | `p2c` | `p2c`, `ewma`, `aperture`, or `heap`
-enableProbation | `true` | If `true`, endpoints are eagerly evicted from service discovery. See Finagle's [LoadBalancerFactory.EnableProbation](https://github.com/twitter/finagle/blob/develop/finagle-core/src/main/scala/com/twitter/finagle/loadbalancer/LoadBalancerFactory.scala#L28)
+Key | Default Value | Description
+--- | ------------- | -----------
+kind | `p2c` | Either `p2c`, `ewma`, `aperture`, or `heap`.
+enableProbation | `true` | If `true`, endpoints are eagerly evicted from service discovery. See Finagle's [LoadBalancerFactory.EnableProbation](https://github.com/twitter/finagle/blob/develop/finagle-core/src/main/scala/com/twitter/finagle/loadbalancer/LoadBalancerFactory.scala#L28).
 
 [p2c]: https://twitter.github.io/finagle/guide/Clients.html#power-of-two-choices-p2c-least-loaded
 [ewma]: https://twitter.github.io/finagle/guide/Clients.html#power-of-two-choices-p2c-peak-ewma
@@ -31,11 +31,11 @@ enableProbation | `true` | If `true`, endpoints are eagerly evicted from service
 kind: `p2c`
 
 <aside class="success">
-  Learn more about p2c and how to configure it via <a target="_blank" href="https://twitter.github.io/finagle/guide/Clients.html#power-of-two-choices-p2c-least-loaded">finagle's documentation</a>
+  Learn more about p2c and how to configure it via <a target="_blank" href="https://twitter.github.io/finagle/guide/Clients.html#power-of-two-choices-p2c-least-loaded">Finagle's documentation</a>.
 </aside>
 
-Key | Default Value | Value Description
---- | ------------- | -----------------
+Key | Default Value | Description
+--- | ------------- | -----------
 maxEffort | `5` | The number of times a load balancer can retry if the previously picked node was marked unavailable.
 
 ## Power of Two Choices: Peak EWMA
@@ -43,11 +43,11 @@ maxEffort | `5` | The number of times a load balancer can retry if the previousl
 kind: `ewma`
 
 <aside class="success">
-  Learn more about ewma and how to configure it via <a target="_blank" href="https://twitter.github.io/finagle/guide/Clients.html#power-of-two-choices-p2c-peak-ewma">finagle's documentation</a>
+  Learn more about ewma and how to configure it via <a target="_blank" href="https://twitter.github.io/finagle/guide/Clients.html#power-of-two-choices-p2c-peak-ewma">Finagle's documentation</a>.
 </aside>
 
-Key | Default Value | Value Description
---- | ------------- | -----------------
+Key | Default Value | Description
+--- | ------------- | -----------
 maxEffort | `5` | The number of times a load balancer can retry if the previously picked node was marked unavailable.
 decayTimeMs | 10 seconds | The window of latency observations.
 
@@ -56,21 +56,21 @@ decayTimeMs | 10 seconds | The window of latency observations.
 kind: `aperture`
 
 <aside class="success">
-  Learn more about aperture and how to configure it via <a target="_blank" href="https://twitter.github.io/finagle/guide/Clients.html#aperture-least-loaded">finagle's documentation</a>
+  Learn more about aperture and how to configure it via <a target="_blank" href="https://twitter.github.io/finagle/guide/Clients.html#aperture-least-loaded">Finagle's documentation</a>.
 </aside>
 
-Key | Default Value | Value Description
---- | ------------- | -----------------
+Key | Default Value | Description
+--- | ------------- | -----------
 maxEffort | `5` | The number of times a load balancer can retry if the previously picked node was marked unavailable.
-smoothWin | 5 seconds |  the window of concurrent load observation
-lowLoad | `0.5` | The lower bound of the load band used to adjust an aperture
-highLoad | `2` | The upper bound of the load band used to adjust an aperture
-minAperture | `1` | The minimum size of the aperture
+smoothWin | 5 seconds |  The window of concurrent load observation.
+lowLoad | `0.5` | The lower bound of the load band used to adjust an aperture.
+highLoad | `2` | The upper bound of the load band used to adjust an aperture.
+minAperture | `1` | The minimum size of the aperture.
 
 ## Heap: Least Loaded
 
 kind: `heap`
 
 <aside class="success">
-  Learn more about heap and how to configure it via <a target="_blank" href="https://twitter.github.io/finagle/guide/Clients.html#heap-least-loaded">finagle's documentation</a>
+  Learn more about heap and how to configure it via <a target="_blank" href="https://twitter.github.io/finagle/guide/Clients.html#heap-least-loaded">Finagle's documentation</a>
 </aside>

--- a/linkerd/docs/namer.md
+++ b/linkerd/docs/namer.md
@@ -7,28 +7,48 @@ namers:
   rootDir: disco
 ```
 
-A namer binds a concrete name to a physical address.
-http://twitter.github.io/finagle/guide/Names.html
+A namer binds a [concrete name to a physical address](http://twitter.github.io/finagle/guide/Names.html).
 
-A namer config block has the following parameters:
+<aside class="notice">
+These parameters are available to the namer regardless of kind. Namers may also have kind-specific parameters.
+</aside>
 
-* *kind* -- The name of the namer plugin
-* *prefix* -- This namer will resolve names beginning with `/#/<prefix>`.  Some
-  namers may configure a default prefix; see the specific namer section for
-  details.
-* *experimental* -- Set this to `true` to enable the namer if it is experimental.
-* *namer-specific parameters*.
+Key | Default Value | Value Description
+--- | ------------- | -----------------
+kind | _required_ | `io.l5d.fs`, `io.l5d.serversets`, `io.l5d.consul`, `io.l5d.k8s`, `io.l5d.marathon`, or `io.l5d.zkLeader`
+prefix | namer dependent | Resolves names with `/#/<prefix>`
+experimental | `false` | Set this to `true` to enable the namer if it is experimental.
 
 <a name="fs"></a>
 ## File-based service discovery
 
-> Example filesystem directory:
+kind: `io.l5d.fs`
+
+### File-based Configuration
+
+> Example fs configuration:
+
+```yaml
+namers:
+- kind: io.l5d.fs
+  rootDir: disco
+```
+
+> Then reference the namer in the dtab to use it:
+
+```
+baseDtab: |
+  /http/1.1/* => /#/io.l5d.fs
+```
+
+> With the filesystem directory:
 
 ```bash
 $ ls disco/
 apps    users   web
 ```
-> And an example of what the contents of the files might look like:
+
+> The contents of the files look similar to this:
 
 ```bash
 $ cat config/web
@@ -36,8 +56,6 @@ $ cat config/web
 192.0.2.105 8080
 192.0.2.210 8080
 ```
-
-`io.l5d.fs`
 
 linkerd ships with a simple file-based service discovery mechanism, called the
 *file-based namer*. This system is intended to act as a structured form of
@@ -61,41 +79,34 @@ addresses.
 linkerd watches all files in this directory, so files can be added, removed, or
 updated, and linkerd will pick up the changes automatically.
 
-The file-based namer is configured with kind `io.l5d.fs`, and these parameters:
+Key | Default Value | Value Description
+--- | ------------- | -----------------
+prefix | `io.l5d.fs` | Resolves names with `/#/<prefix>`
+rootDir | _required_ | the directory containing name files as described above.
 
-* *rootDir* -- the directory containing name files as described above.
+### File-based Path Parameters
 
-For example:
+> Dtab Path Format:
+
 ```yaml
-namers:
-- kind: io.l5d.fs
-  rootDir: disco
+/#/<prefix>/<fileName>
 ```
 
-The default _prefix_ for the file-based namer is `io.l5d.fs`.
-
-Once configured, to use the file-based namer, you must reference it in
-the dtab. For example:
-```
-baseDtab: |
-  /http/1.1/* => /#/io.l5d.fs
-```
+Key | Required? | Value Description
+--- | --------- | -----------------
+prefix | yes | Tells linkerd to resolve the request path using the fs namer.
+fileName | yes | The file in `rootDir` to use when resolving this request
 
 <a name="serversets"></a>
 ## ZooKeeper ServerSets service discovery
 
-`io.l5d.serversets`
+kind: `io.l5d.serversets`
 
-linkerd provides support for [ZooKeeper
-ServerSets](https://twitter.github.io/commons/apidocs/com/twitter/common/zookeeper/ServerSet.html).
 
-The ServerSets namer is configured with kind `io.l5d.serversets`, and these parameters:
+### ServerSets Configuration
 
-* *zkAddrs* -- list of ZooKeeper addresses:
-  * *host* --  the ZooKeeper host.
-  * *port* --  the ZooKeeper port.
+> Example ServerSets configuration:
 
-For example:
 ```yaml
 namers:
 - kind: io.l5d.serversets
@@ -104,19 +115,44 @@ namers:
     port: 2181
 ```
 
-The default _prefix_ is `io.l5d.serversets`.
+> Then reference the namer in the dtab to use it:
 
-Once configured, to use the ServerSets namer, you must reference it in
-the dtab. For example:
-```
+```yaml
 baseDtab: |
   /http/1.1/* => /#/io.l5d.serversets/discovery/prod;
 ```
 
+linkerd provides support for [ZooKeeper
+ServerSets](https://twitter.github.io/commons/apidocs/com/twitter/common/zookeeper/ServerSet.html).
+
+Key | Default Value | Value Description
+--- | ------------- | -----------------
+prefix | `io.l5d.serversets` | Resolves names with `/#/<prefix>`
+zkAddrs | _required_ | A list of ZooKeeper addresses, each of which have `host` and `port` parameters.
+
+### ServerSets Path Parameters
+
+> Dtab Path Format:
+
+```yaml
+/#/<prefix>/<zkHosts>/<zkPath>[:<endpoint>]
+```
+
+Key | Required? | Value Description
+--- | --------- | -----------------
+prefix | yes | Tells linkerd to resolve the request path using the serversets namer
+zkHosts | yes | The ZooKeeper host to use for this request
+zkPath | yes | The ZooKeeper path to use for this request
+endpoint | no | The ZooKeeper endpoint to use for this request
+
 <a name="consul"></a>
 ## Consul service discovery (experimental)
 
-> Example Consul config
+kind: `io.l5d.consul`
+
+### Consul Configuration
+
+> Configure a consul namer:
 
 ```yaml
 namers:
@@ -125,46 +161,58 @@ namers:
   host: 127.0.0.1
   port: 2181
   includeTag: true
-  useHealthCheck: true
   setHost: true
 ```
 
-`io.l5d.consul`
-
-linkerd provides support for service discovery via
-[Consul](https://www.consul.io/). Note that this support is still considered
-experimental so you must set `experimental: true` to use this namer.
-
-The Consul namer is configured with kind `io.l5d.consul`, and these parameters:
-
-* *host* --  the Consul host. (default: localhost)
-* *port* --  the Consul port. (default: 8500)
-* *includeTag* -- whether to read a Consul tag from the path.  (default: false)
-* *useHealthCheck* -- whether to rely on Consul health checks.  (default: false)
-* *token* -- Optional. The auth token to use when making API calls.
-* *setHost* --  if set to true (default: false) will instruct Linkerd
-                to override `Host` header value of forwarded HTTP
-                requests to `${name}.service.${datacenter}.${domain}`
-                when Consul concrete name is used to handle the request
-                (`$domain` fetched from Consul).
-
-
-The default _prefix_ is `io.l5d.consul`.
+> Then reference the namer in the dtab to use it:
 
 ```
 baseDtab: |
   /http/1.1/* => /#/io.l5d.consul/dc1/prod;
 ```
 
-Once configured, to use the Consul namer, you must reference it in
-the dtab. The Consul namer takes two path components: `datacenter` and
-`serviceName`.  If `includeTag` is true, then it takes three path components:
-`datacenter`, `tag`, and `serviceName`.
+linker provides support for service discovery via [Consul](https://www.consul.io/).
+
+Key | Default Value | Value Description
+--- | ------------- | -----------------
+prefix | `io.l5d.consul` | Resolves names with `/#/<prefix>`
+experimental | _required_ | Because this namer is still considered experimental, you must set this to `true` to use it.
+host | `localhost` | The Consul host.
+port | `8500` | The Consul port.
+includeTag | `false` | if `true`, read a Consul tag from the path.
+token | no authentication | The auth token to use when making API calls.
+setHost | `false` | if `true`, HTTP requests resolved by Consul will have their Host header overwritten to `${serviceName}.service.${datacenter}.${domain}`. `$domain` is fetched from Consul
+
+### Consul Path Parameters
+
+> Dtab Path Format when includeTag is false
+
+```yaml
+/#/<prefix>/<datacenter>/<serviceName>
+```
+
+> Dtab Path Format when includeTag is true
+
+```yaml
+/#/<prefix>/<datacenter>/<tag>/<serviceName>
+```
+
+Key | Required? | Value Description
+--- | --------- | -----------------
+prefix | yes | Tells linkerd to resolve the request path using the consul namer
+datacenter | yes | The Consul datacenter to use for this request
+tag | yes if includeTag is `true` | The Consul tag to use for this request
+serviceName | yes | The Consul service name to use for this request
+
 
 <a name="k8s"></a>
 ## Kubernetes service discovery (experimental)
 
-> Example k8s config
+kind : `io.l5d.k8s`
+
+### K8s Configuration
+
+> Configure a K8s namer
 
 ```yaml
 namers:
@@ -174,41 +222,50 @@ namers:
   port: 8001
 ```
 
-`io.l5d.k8s`
-
-linkerd provides support for service discovery via
-[Kubernetes](https://k8s.io/). Note that this support is still considered
-experimental so you must set `experimental: true` to use this namer.
-
-The Kubernetes namer is configured with kind `io.l5d.k8s`, and these parameters:
-
-* *host* -- the Kubernetes master host. (default: localhost)
-* *port* -- the Kubernetes master port. (default: 8001)
-
-The Kubernetes namer does not support TLS.  Instead, you should run `kubectl proxy` on each host
-which will create a local proxy for securely talking to the Kubernetes cluster API.
-
-The default _prefix_ is `io.l5d.k8s`.
-
-The Kubernetes namer takes three path components: `namespace`, `port-name` and
-`svc-name`:
-
-* namespace: the Kubernetes namespace.
-* port-name: the port name.
-* svc-name: the name of the service.
+> Then reference the namer in the dtab to use it:
 
 ```
 baseDtab: |
   /http/1.1/* => /#/io.l5d.k8s/prod/http;
 ```
 
-Once configured, to use the Kubernetes namer, you must reference it in
-the dtab.
+linkerd provides support for service discovery via
+[Kubernetes](https://k8s.io/).
+
+Key | Default Value | Value Description
+--- | ------------- | -----------------
+prefix | `io.l5d.k8s` | Resolves names with `/#/<prefix>`
+experimental | _required_ | Because this namer is still considered experimental, you must set this to `true` to use it.
+host | `localhost` | The Kubernetes master host.
+port | `8001` | The Kubernetes master post.
+
+The Kubernetes namer does not support TLS.  Instead, you should run `kubectl proxy` on each host
+which will create a local proxy for securely talking to the Kubernetes cluster API. See (the k8s guide)["https://linkerd.io/doc/latest/k8s/"] for more information.
+
+### K8s Path Parameters
+
+> Dtab Path Format
+
+```yaml
+/#/<prefix>/<namespace>/<port-name>/<svc-name>
+```
+
+Key | Required? | Value Description
+--- | --------- | -----------------
+prefix | yes | Tells linkerd to resolve the request path using the k8s namer
+namespace | yes | the Kubernetes namespace
+port-name | yes | the port name
+svc-name | yes | the name of the service
+
 
 <a name="marathon"></a>
 ## Marathon service discovery (experimental)
 
-> Example marathon config
+kind: `io.l5d.marathon`
+
+### Marathon Configuration
+
+> Configure a marathon namer
 
 ```yaml
 namers:
@@ -220,32 +277,7 @@ namers:
   uriPrefix:    /marathon
   ttlMs:        500
 ```
-
-`io.l5d.marathon`
-
-linkerd provides support for service discovery via
-[Marathon](https://mesosphere.github.io/marathon/). Note that this support is still considered
-experimental so you must set `experimental: true` to use this namer.
-
-The Marathon namer is configured with kind `io.l5d.marathon`, and these parameters:
-
-* *host* -- the Marathon master host. (default: marathon.mesos)
-* *port* -- the Marathon master port. (default: 80)
-* *uriPrefix* -- the Marathon API prefix. (default: empty string). This prefix
-  depends on your Marathon configuration. For example, running Marathon
-  locally, the API is avaiable at `localhost:8080/v2/`, while the default setup
-  on AWS/DCOS is `$(dcos config show core.dcos_url)/marathon/v2/apps`.
-* *ttlMs* -- the polling timeout in milliseconds against the marathon API
-  (default: 5000)
-
-
-The default _prefix_ is `io.l5d.marathon`.
-
-The Marathon namer takes any number of path components. The path should
-correspond to the app id of a marathon application. For example, the app with
-id "/users" can be reached with `/#/io.l5d.marathon/users`. Likewise, the app
-with id "/appgroup/usergroup/users" can be reached with
-`/#/io.l5d.marathon/appgroup/usergroup/users`.
+> Then reference the namer in the dtab to use it:
 
 ```
 baseDtab: |
@@ -254,20 +286,57 @@ baseDtab: |
   /http/1.1/* => /host;
 ```
 
-Once configured, to use the Marathon namer, you must reference it in
-the dtab.
+linkerd provides support for service discovery via
+[Marathon](https://mesosphere.github.io/marathon/).
+
+Key | Default Value | Value Description
+--- | ------------- | -----------------
+prefix | `io.l5d.marathon` | Resolves names with `/#/<prefix>`
+experimental | _required_ | Because this namer is still considered experimental, you must set this to `true` to use it.
+host | `marathon.mesos` | the Marathon master host.
+port | `80` | the Marathon master port.
+uriPrefix | none | the Marathon API prefix. This prefix depends on your Marathon configuration. For example, running Marathon locally, the API is avaiable at `localhost:8080/v2/`, while the default setup on AWS/DCOS is `$(dcos config show core.dcos_url)/marathon/v2/apps`.
+ttlMs | `500` | the polling timeout in milliseconds against the marathon API.
+
+### Marathon Path Parameters
+
+> Dtab Path Format
+
+```yaml
+/#/<prefix>/<appId>
+```
+
+Key | Required? | Value Description
+--- | --------- | -----------------
+prefix | yes | Tells linkerd to resolve the request path using the marathon namer
+appId | yes | The app id of a marathon application. This id can be multiple path segments long. For example, the app with id "/users" can be reached with `/#/io.l5d.marathon/users`. Likewise, the app with id "/appgroup/usergroup/users" can be reached with `/#/io.l5d.marathon/appgroup/usergroup/users`.
+
+
 
 <a name="zkLeader"></a>
 ## ZooKeeper Leader
 
-`io.l5d.zkLeader`
+kind: `io.l5d.zkLeader`
 
-A namer backed by ZooKeeper leader election. The path processed by this namer is treated as the
-ZooKeeper path of a leader group. The namer resolves to the address stored in the data of the
-leader.
+### ZK Leader Configuration
 
-The ZooKeeper Leader namer is configured with kind `io.l5d.zkLeader` and these parameters:
+A namer backed by ZooKeeper leader election.
 
-* *zkAddrs* -- list of ZooKeeper addresses:
-  * *host* --  the ZooKeeper host.
-  * *port* --  the ZooKeeper port.
+Key | Default Value | Value Description
+--- | ------------- | -----------------
+prefix | `io.l5d.zkLeader` | Resolves names with `/#/<prefix>`
+zkAddrs | _required_ | A list of ZooKeeper addresses, each of which have `host` and `port` parameters.
+
+### ZK Leader Path Parameters
+
+> Dtab Path Format
+
+```yaml
+/#/<prefix>/<zkPath>
+```
+
+Key | Required? | Value Description
+--- | --------- | -----------------
+prefix | yes | Tells linkerd to resolve the request path using the marathon namer
+zkPath | yes | The ZooKeeper path of a leader group. This path can be multiple path segments long. The namer resolves to the address stored in the data of the leader.
+

--- a/linkerd/docs/namer.md
+++ b/linkerd/docs/namer.md
@@ -13,10 +13,10 @@ A namer binds a [concrete name to a physical address](http://twitter.github.io/f
 These parameters are available to the namer regardless of kind. Namers may also have kind-specific parameters.
 </aside>
 
-Key | Default Value | Value Description
---- | ------------- | -----------------
-kind | _required_ | `io.l5d.fs`, `io.l5d.serversets`, `io.l5d.consul`, `io.l5d.k8s`, `io.l5d.marathon`, or `io.l5d.zkLeader`
-prefix | namer dependent | Resolves names with `/#/<prefix>`
+Key | Default Value | Description
+--- | ------------- | -----------
+kind | _required_ | Either `io.l5d.fs`, `io.l5d.serversets`, `io.l5d.consul`, `io.l5d.k8s`, `io.l5d.marathon`, or `io.l5d.zkLeader`.
+prefix | namer dependent | Resolves names with `/#/<prefix>`.
 experimental | `false` | Set this to `true` to enable the namer if it is experimental.
 
 <a name="fs"></a>
@@ -79,9 +79,9 @@ addresses.
 linkerd watches all files in this directory, so files can be added, removed, or
 updated, and linkerd will pick up the changes automatically.
 
-Key | Default Value | Value Description
---- | ------------- | -----------------
-prefix | `io.l5d.fs` | Resolves names with `/#/<prefix>`
+Key | Default Value | Description
+--- | ------------- | -----------
+prefix | `io.l5d.fs` | Resolves names with `/#/<prefix>`.
 rootDir | _required_ | the directory containing name files as described above.
 
 ### File-based Path Parameters
@@ -92,10 +92,10 @@ rootDir | _required_ | the directory containing name files as described above.
 /#/<prefix>/<fileName>
 ```
 
-Key | Required? | Value Description
---- | --------- | -----------------
+Key | Required | Description
+--- | -------- | -----------
 prefix | yes | Tells linkerd to resolve the request path using the fs namer.
-fileName | yes | The file in `rootDir` to use when resolving this request
+fileName | yes | The file in `rootDir` to use when resolving this request.
 
 <a name="serversets"></a>
 ## ZooKeeper ServerSets service discovery
@@ -125,9 +125,9 @@ baseDtab: |
 linkerd provides support for [ZooKeeper
 ServerSets](https://twitter.github.io/commons/apidocs/com/twitter/common/zookeeper/ServerSet.html).
 
-Key | Default Value | Value Description
---- | ------------- | -----------------
-prefix | `io.l5d.serversets` | Resolves names with `/#/<prefix>`
+Key | Default Value | Description
+--- | ------------- | -----------
+prefix | `io.l5d.serversets` | Resolves names with `/#/<prefix>`.
 zkAddrs | _required_ | A list of ZooKeeper addresses, each of which have `host` and `port` parameters.
 
 ### ServerSets Path Parameters
@@ -138,12 +138,12 @@ zkAddrs | _required_ | A list of ZooKeeper addresses, each of which have `host` 
 /#/<prefix>/<zkHosts>/<zkPath>[:<endpoint>]
 ```
 
-Key | Required? | Value Description
---- | --------- | -----------------
-prefix | yes | Tells linkerd to resolve the request path using the serversets namer
-zkHosts | yes | The ZooKeeper host to use for this request
-zkPath | yes | The ZooKeeper path to use for this request
-endpoint | no | The ZooKeeper endpoint to use for this request
+Key | Required | Description
+--- | -------- | -----------
+prefix | yes | Tells linkerd to resolve the request path using the serversets namer.
+zkHosts | yes | The ZooKeeper host to use for this request.
+zkPath | yes | The ZooKeeper path to use for this request.
+endpoint | no | The ZooKeeper endpoint to use for this request.
 
 <a name="consul"></a>
 ## Consul service discovery (experimental)
@@ -173,15 +173,15 @@ baseDtab: |
 
 linker provides support for service discovery via [Consul](https://www.consul.io/).
 
-Key | Default Value | Value Description
---- | ------------- | -----------------
-prefix | `io.l5d.consul` | Resolves names with `/#/<prefix>`
+Key | Default Value | Description
+--- | ------------- | -----------
+prefix | `io.l5d.consul` | Resolves names with `/#/<prefix>`.
 experimental | _required_ | Because this namer is still considered experimental, you must set this to `true` to use it.
 host | `localhost` | The Consul host.
 port | `8500` | The Consul port.
-includeTag | `false` | if `true`, read a Consul tag from the path.
+includeTag | `false` | If `true`, read a Consul tag from the path.
 token | no authentication | The auth token to use when making API calls.
-setHost | `false` | if `true`, HTTP requests resolved by Consul will have their Host header overwritten to `${serviceName}.service.${datacenter}.${domain}`. `$domain` is fetched from Consul
+setHost | `false` | If `true`, HTTP requests resolved by Consul will have their Host header overwritten to `${serviceName}.service.${datacenter}.${domain}`. `$domain` is fetched from Consul.
 
 ### Consul Path Parameters
 
@@ -197,12 +197,12 @@ setHost | `false` | if `true`, HTTP requests resolved by Consul will have their 
 /#/<prefix>/<datacenter>/<tag>/<serviceName>
 ```
 
-Key | Required? | Value Description
---- | --------- | -----------------
-prefix | yes | Tells linkerd to resolve the request path using the consul namer
-datacenter | yes | The Consul datacenter to use for this request
-tag | yes if includeTag is `true` | The Consul tag to use for this request
-serviceName | yes | The Consul service name to use for this request
+Key | Required | Description
+--- | -------- | -----------
+prefix | yes | Tells linkerd to resolve the request path using the consul namer.
+datacenter | yes | The Consul datacenter to use for this request.
+tag | yes if includeTag is `true` | The Consul tag to use for this request.
+serviceName | yes | The Consul service name to use for this request.
 
 
 <a name="k8s"></a>
@@ -232,15 +232,17 @@ baseDtab: |
 linkerd provides support for service discovery via
 [Kubernetes](https://k8s.io/).
 
-Key | Default Value | Value Description
---- | ------------- | -----------------
-prefix | `io.l5d.k8s` | Resolves names with `/#/<prefix>`
+Key | Default Value | Description
+--- | ------------- | -----------
+prefix | `io.l5d.k8s` | Resolves names with `/#/<prefix>`.
 experimental | _required_ | Because this namer is still considered experimental, you must set this to `true` to use it.
 host | `localhost` | The Kubernetes master host.
 port | `8001` | The Kubernetes master post.
 
+<aside class="notice">
 The Kubernetes namer does not support TLS.  Instead, you should run `kubectl proxy` on each host
-which will create a local proxy for securely talking to the Kubernetes cluster API. See (the k8s guide)["https://linkerd.io/doc/latest/k8s/"] for more information.
+which will create a local proxy for securely talking to the Kubernetes cluster API. See (the k8s guide)[https://linkerd.io/doc/latest/k8s/] for more information.
+</aside>
 
 ### K8s Path Parameters
 
@@ -250,12 +252,12 @@ which will create a local proxy for securely talking to the Kubernetes cluster A
 /#/<prefix>/<namespace>/<port-name>/<svc-name>
 ```
 
-Key | Required? | Value Description
---- | --------- | -----------------
-prefix | yes | Tells linkerd to resolve the request path using the k8s namer
-namespace | yes | the Kubernetes namespace
-port-name | yes | the port name
-svc-name | yes | the name of the service
+Key | Required | Description
+--- | -------- | -----------
+prefix | yes | Tells linkerd to resolve the request path using the k8s namer.
+namespace | yes | The Kubernetes namespace.
+port-name | yes | The port name.
+svc-name | yes | The name of the service.
 
 
 <a name="marathon"></a>
@@ -289,14 +291,14 @@ baseDtab: |
 linkerd provides support for service discovery via
 [Marathon](https://mesosphere.github.io/marathon/).
 
-Key | Default Value | Value Description
---- | ------------- | -----------------
-prefix | `io.l5d.marathon` | Resolves names with `/#/<prefix>`
+Key | Default Value | Description
+--- | ------------- | -----------
+prefix | `io.l5d.marathon` | Resolves names with `/#/<prefix>`.
 experimental | _required_ | Because this namer is still considered experimental, you must set this to `true` to use it.
-host | `marathon.mesos` | the Marathon master host.
-port | `80` | the Marathon master port.
-uriPrefix | none | the Marathon API prefix. This prefix depends on your Marathon configuration. For example, running Marathon locally, the API is avaiable at `localhost:8080/v2/`, while the default setup on AWS/DCOS is `$(dcos config show core.dcos_url)/marathon/v2/apps`.
-ttlMs | `500` | the polling timeout in milliseconds against the marathon API.
+host | `marathon.mesos` | The Marathon master host.
+port | `80` | The Marathon master port.
+uriPrefix | none | The Marathon API prefix. This prefix depends on your Marathon configuration. For example, running Marathon locally, the API is avaiable at `localhost:8080/v2/`, while the default setup on AWS/DCOS is `$(dcos config show core.dcos_url)/marathon/v2/apps`.
+ttlMs | `500` | The polling timeout in milliseconds against the marathon API.
 
 ### Marathon Path Parameters
 
@@ -306,9 +308,9 @@ ttlMs | `500` | the polling timeout in milliseconds against the marathon API.
 /#/<prefix>/<appId>
 ```
 
-Key | Required? | Value Description
---- | --------- | -----------------
-prefix | yes | Tells linkerd to resolve the request path using the marathon namer
+Key | Required | Description
+--- | -------- | -----------
+prefix | yes | Tells linkerd to resolve the request path using the marathon namer.
 appId | yes | The app id of a marathon application. This id can be multiple path segments long. For example, the app with id "/users" can be reached with `/#/io.l5d.marathon/users`. Likewise, the app with id "/appgroup/usergroup/users" can be reached with `/#/io.l5d.marathon/appgroup/usergroup/users`.
 
 
@@ -322,9 +324,9 @@ kind: `io.l5d.zkLeader`
 
 A namer backed by ZooKeeper leader election.
 
-Key | Default Value | Value Description
---- | ------------- | -----------------
-prefix | `io.l5d.zkLeader` | Resolves names with `/#/<prefix>`
+Key | Default Value | Description
+--- | ------------- | -----------
+prefix | `io.l5d.zkLeader` | Resolves names with `/#/<prefix>`.
 zkAddrs | _required_ | A list of ZooKeeper addresses, each of which have `host` and `port` parameters.
 
 ### ZK Leader Path Parameters
@@ -335,8 +337,8 @@ zkAddrs | _required_ | A list of ZooKeeper addresses, each of which have `host` 
 /#/<prefix>/<zkPath>
 ```
 
-Key | Required? | Value Description
---- | --------- | -----------------
-prefix | yes | Tells linkerd to resolve the request path using the marathon namer
+Key | Required | Description
+--- | -------- | -----------
+prefix | yes | Tells linkerd to resolve the request path using the marathon namer.
 zkPath | yes | The ZooKeeper path of a leader group. This path can be multiple path segments long. The namer resolves to the address stored in the data of the leader.
 

--- a/linkerd/docs/protocol-http.md
+++ b/linkerd/docs/protocol-http.md
@@ -42,17 +42,17 @@ The HTTP/1.1 protocol is used when the *protocol* option of the
 [routers configuration block](#router-parameters) is set to *http*.
 This protocol has additional configuration options on the *routers* block.
 
-Key | Default Value | Value Description
---- | ------------- | -----------------
-dstPrefix | `http` | A path prefix used by [Http-specific identifiers](#http-1-1-identifiers)
+Key | Default Value | Description
+--- | ------------- | -----------
+dstPrefix | `http` | A path prefix used by [Http-specific identifiers](#http-1-1-identifiers).
 httpAccessLog | none | Sets the access log path.  If not specified, no access log is written.
-identifier | `io.l5d.methodAndHost` | see [Http-specific identifiers](#http-1-1-identifiers)
-maxChunkKB | 8KB | The maximum size of an HTTP chunk
-maxHeadersKB | 8KB | The maximum size of all headers in an HTTP message
-maxInitialLineKB | 4KB | The maximum size of an initial HTTP message line
-maxRequestKB | 5MB | The maximum size of a non-chunked HTTP request payload
-maxResponseKB | 5MB | The maximum size of a non-chunked HTTP response payload
-compressionLevel | `-1`, automatically compresses textual content types with compression level 6 | The compression level to use (on 0-9)
+identifier | `io.l5d.methodAndHost` | See [Http-specific identifiers](#http-1-1-identifiers).
+maxChunkKB | 8KB | The maximum size of an HTTP chunk.
+maxHeadersKB | 8KB | The maximum size of all headers in an HTTP message.
+maxInitialLineKB | 4KB | The maximum size of an initial HTTP message line.
+maxRequestKB | 5MB | The maximum size of a non-chunked HTTP request payload.
+maxResponseKB | 5MB | The maximum size of a non-chunked HTTP response payload.
+compressionLevel | `-1`, automatically compresses textual content types with compression level 6 | The compression level to use (on 0-9).
 
 <aside class="warning">
 These memory constraints are selected to allow reliable
@@ -68,9 +68,9 @@ request; these names are then matched against the dtab. (See the [linkerd
 routing overview](https://linkerd.io/doc/latest/routing/) for more details on
 this.) All HTTP/1.1 identifiers have a `kind`.
 
-Key | Default Value | Value Description
---- | ------------- | -----------------
-kind | _required_ | either [`io.l5d.methodAndHost`](#method-and-host-identifier) or [`io.l5d.path`](#path-identifier)
+Key | Default Value | Description
+--- | ------------- | -----------
+kind | _required_ | Either [`io.l5d.methodAndHost`](#method-and-host-identifier) or [`io.l5d.path`](#path-identifier).
 
 <a name="method-and-host-identifier"></a>
 ### Method and Host Identifier
@@ -90,8 +90,8 @@ identifier:
   httpUriInDst: true
 ```
 
-Key | Default Value | Value Description
---- | ------------- | -----------------
+Key | Default Value | Description
+--- | ------------- | -----------
 httpUriInDst | `false` | If `true` http paths are appended to destinations. This allows a form of path-prefix routing. This option is **not** recommended as performance implications may be severe; Use the [path identifier](#path-identifier) instead.
 
 
@@ -109,9 +109,9 @@ httpUriInDst | `false` | If `true` http paths are appended to destinations. This
   / dstPrefix / "1.0" / method [/ uri* ]
 ```
 
-Key | Default Value | Value Description
---- | ------------- | -----------------
-dstPrefix | `http` | The `dstPrefix` as set in the routers block
+Key | Default Value | Description
+--- | ------------- | -----------
+dstPrefix | `http` | The `dstPrefix` as set in the routers block.
 method | N/A | The HTTP method of the current request, ie `OPTIONS`, `GET`, `HEAD`, `POST`, `PUT`, `DELETE`, `TRACE`, or `CONNECT`.
 host | N/A | The value of the current request's Host header. [Case sensitive!](https://github.com/BuoyantIO/linkerd/issues/106). Not used in HTTP/1.0.
 uri | Not used | Only considered a part of the logical name if the config option `httpUriInDst` is `true`.
@@ -144,8 +144,8 @@ routers:
     port: 5000
 ```
 
-Key | Default Value | Value Description
---- | ------------- | -----------------
+Key | Default Value | Description
+--- | ------------- | -----------
 segments | `1` | Number of segments from the path that are appended to destinations.
 consume | `false` | Whether to additionally strip the consumed segments from the HTTP request proxied to the final destination service. This only affects the request sent to the destination service; it does not affect identification or routing.
 
@@ -157,8 +157,8 @@ consume | `false` | Whether to additionally strip the consumed segments from the
   / dstPrefix [/ *urlPath ]
 ```
 
-Key | Default Value | Value Description
---- | ------------- | -----------------
+Key | Default Value | Description
+--- | ------------- | -----------
 dstPrefix | `http` | The `dstPrefix` as set in the routers block.
 urlPath | N/A | A path from the URL whose number of segments is set in the identifier block.
 
@@ -183,9 +183,9 @@ netty4 implementation on both the client and server:
 An _engine_ may be configured on HTTP clients and servers, causing an
 alternate HTTP implementation to be used.
 
-Key | Default Value | Value Description
---- | ------------- | -----------------
-kind | `netty3` | either `netty3` or `netty4` (`netty4` will become default in an upcoming release)
+Key | Default Value | Description
+--- | ------------- | -----------
+kind | `netty3` | Either `netty3` or `netty4` (`netty4` will become default in an upcoming release).
 
 <a name="http-headers"></a>
 ## HTTP Headers
@@ -201,9 +201,9 @@ for all linkerd features to work.
 
 Header | Description
 ------ | -----------
-`dtab-local` | deprecated. Use `l5d-ctx-dtab` and `l5d-dtab`.
-`l5d-ctx-deadline` | describes time bounds within which a request is expected to be satisfied. Currently deadlines are only advisory and do not factor into request cancellation.
-`l5d-ctx-trace` | encodes Zipkin-style trace IDs and flags so that trace annotations emitted by linkerd may be correlated.
+`dtab-local` | Deprecated. Use `l5d-ctx-dtab` and `l5d-dtab`.
+`l5d-ctx-deadline` | Describes time bounds within which a request is expected to be satisfied. Currently deadlines are only advisory and do not factor into request cancellation.
+`l5d-ctx-trace` | Encodes Zipkin-style trace IDs and flags so that trace annotations emitted by linkerd may be correlated.
 
 <aside class="warning">
 Edge services should take care to ensure these headers are not set
@@ -222,8 +222,8 @@ _User headers_ enable user-overrides.
 
 Header | Description
 ------ | -----------
-`l5d-dtab` | a client-specified delegation override
-`l5d-sample` | a client-specified trace sample rate override
+`l5d-dtab` | A client-specified delegation override.
+`l5d-sample` | A client-specified trace sample rate override.
 
 <aside class="notice">
 If linkerd processes incoming requests for applications
@@ -245,10 +245,10 @@ The informational headers linkerd emits on outgoing requests.
 
 Header | Description
 ------ | -----------
-`l5d-dst-logical` | the logical name of the request as identified by linkerd
-`l5d-dst-concrete` | the concrete client name after delegation
-`l5d-dst-residual` | an optional residual path remaining after delegation
-`l5d-reqid` | a token that may be used to correlate requests in a callgraph across services and linkerd instances
+`l5d-dst-logical` | The logical name of the request as identified by linkerd.
+`l5d-dst-concrete` | The concrete client name after delegation.
+`l5d-dst-residual` | An optional residual path remaining after delegation.
+`l5d-reqid` | A token that may be used to correlate requests in a callgraph across services and linkerd instances.
 
 Applications are not required to forward these headers on downstream
 requests.
@@ -265,7 +265,7 @@ The informational headers linkerd emits on outgoing responses.
 
 Header | Description
 ------ | -----------
-`l5d-err` | indicates a linkerd-generated error. Error responses that do not have this header are application errors.
+`l5d-err` | Indicates a linkerd-generated error. Error responses that do not have this header are application errors.
 
 Applications are not required to forward these headers on upstream
 responses.

--- a/linkerd/docs/protocol-http.md
+++ b/linkerd/docs/protocol-http.md
@@ -1,31 +1,25 @@
 # HTTP/1.1 protocol
 
-The HTTP/1.1 protocol is used when the *protocol* option of the
-[routers configuration block](config.md#routers) is set to *http*.
-With this protocol selected, configuration options on the *routers* block
-include:
+> Below: http-specific configuration options
 
-* *httpAccessLog* -- Sets the access log path.  If not specified, no
-access log is written.
-* *identifier* -- [Http-specific identifier](#protocol-http-identifiers) (default:
-io.l5d.methodAndHost)
-* *maxChunkKB* -- The maximum size of an HTTP chunk (default: 8KB)
-* *maxHeadersKB* -- The maximum size of all headers in an HTTP message (default: 8KB)
-* *maxInitialLineKB* -- The maximum size of an initial HTTP
-  message line (default: 4KB)
-* *maxRequestKB* -- The maximum size of a non-chunked HTTP request
-  payload (default: 5MB)
-* *maxResponseKB* -- The maximum size of a non-chunked HTTP response
-  payload (default: 5MB)
-* *compressionLevel* -- The compression level to use (on 0-9)
-  (default: -1, automatically compresses textual content types with
-  compression level 6)
+```yaml
+routers:
+- protocol: http
+  httpAccessLog: access.log
+  identifier: io.l5d.methodAndHost
+  maxChunkKB: 8KB
+  maxHeadersKB: 8KB
+  maxInitialLineKB: 4KB
+  maxRequestKB: 5MB
+  maxResponseKB: 5MB
+  servers:
+    port: 5000
+```
 
-<aside class="warning">
-These memory constraints are selected to allow reliable
-concurrent usage of linkerd. Changing these parameters may
-significantly alter linkerd's performance characteristics.
-</aside>
+> Below: an example HTTP router config that routes all `POST` requests to 8091
+and all other requests to 8081,
+using the default identifier of `io.l5d.methodAndHost`,
+listening on port 5000
 
 ```yaml
 routers:
@@ -38,81 +32,106 @@ routers:
   servers:
     port: 5000
 ```
+> The baseDtab above is written to work with the
+[`methodAndHost` identifier](#method-and-host-identifier).
+Using a different identifier would require a different set of dtab rules.
 
-As an example, here's an HTTP router config that routes all `POST`
-requests to 8091 and all other requests to 8081, using the default
-identifier of `io.l5d.methodAndHost`, listening on port 5000:
+protocol: `http`
 
-<aside class="notice">
-The dtab is written in terms of names produced by the
-`methodAndHost` identifier. Using a different identifier would require a
-different set of dtab rules. See the next section for more on identifiers.
+The HTTP/1.1 protocol is used when the *protocol* option of the
+[routers configuration block](#router-parameters) is set to *http*.
+This protocol has additional configuration options on the *routers* block.
+
+Key | Default Value | Value Description
+--- | ------------- | -----------------
+dstPrefix | `http` | A path prefix used by [Http-specific identifiers](#http-1-1-identifiers)
+httpAccessLog | none | Sets the access log path.  If not specified, no access log is written.
+identifier | `io.l5d.methodAndHost` | see [Http-specific identifiers](#http-1-1-identifiers)
+maxChunkKB | 8KB | The maximum size of an HTTP chunk
+maxHeadersKB | 8KB | The maximum size of all headers in an HTTP message
+maxInitialLineKB | 4KB | The maximum size of an initial HTTP message line
+maxRequestKB | 5MB | The maximum size of a non-chunked HTTP request payload
+maxResponseKB | 5MB | The maximum size of a non-chunked HTTP response payload
+compressionLevel | `-1`, automatically compresses textual content types with compression level 6 | The compression level to use (on 0-9)
+
+<aside class="warning">
+These memory constraints are selected to allow reliable
+concurrent usage of linkerd. Changing these parameters may
+significantly alter linkerd's performance characteristics.
 </aside>
 
-<a name="protocol-http-identifiers"></a>
+<a name="http-1-1-identifiers"></a>
 ## HTTP/1.1 Identifiers
 
 Identifiers are responsible for creating logical *names* from an incoming
 request; these names are then matched against the dtab. (See the [linkerd
 routing overview](https://linkerd.io/doc/latest/routing/) for more details on
-this.) HTTP/1.1 identifiers are configured with the following parameters:
+this.) All HTTP/1.1 identifiers have a `kind`.
 
-* *kind* -- The fully-qualified class name of an identifier. Current
-identifiers include:
-  * *io.l5d.methodAndHost*
-  * *io.l5d.path*
-* other identifier-specific parameters
+Key | Default Value | Value Description
+--- | ------------- | -----------------
+kind | _required_ | either [`io.l5d.methodAndHost`](#method-and-host-identifier) or [`io.l5d.path`](#path-identifier)
 
-### The Method and Host Identifier
+<a name="method-and-host-identifier"></a>
+### Method and Host Identifier
 
-This identifier is selected by setting the *kind* value of the *identifier*
-configuration block to `io.l5d.methodAndHost`.
+kind: `io.l5d.methodAndHost`.
 
 With this identifier, HTTP requests are turned into logical names using a
-combination of Host header, method, and (optionally) URI. Configuration
-settings include:
+combination of Host header, method, and (optionally) URI.
 
-* *httpUriInDst* -- If `true` http paths are appended to destinations. This
-  allows a form of path-prefix routing. This option is **not** recommended as
-  performance implications may be severe; it has been supplanted by the path
-  identifier below. (default: false)
+#### Namer Configuration:
 
-The methodAndHost identifier generates HTTP/1.1 logical names of the form:
+> Configuration example
+
+```yaml
+identifier:
+  kind: io.l5d.methodAndHost
+  httpUriInDst: true
+```
+
+Key | Default Value | Value Description
+--- | ------------- | -----------------
+httpUriInDst | `false` | If `true` http paths are appended to destinations. This allows a form of path-prefix routing. This option is **not** recommended as performance implications may be severe; Use the [path identifier](#path-identifier) instead.
+
+
+#### Namer Path Parameters:
+
+> Dtab Path Format for HTTP/1.1
+
 ```
   / dstPrefix / "1.1" / method / host [/ uri* ]
 ```
-For HTTP/1.0 requests, logical names are of the form:
+
+> Dtab Path Format for HTTP/1.0
+
 ```
   / dstPrefix / "1.0" / method [/ uri* ]
 ```
 
-In both cases, `uri` is only considered a part of the logical name if the
-config option `httpUriInDst` is true.
+Key | Default Value | Value Description
+--- | ------------- | -----------------
+dstPrefix | `http` | The `dstPrefix` as set in the routers block
+method | N/A | The HTTP method of the current request, ie `OPTIONS`, `GET`, `HEAD`, `POST`, `PUT`, `DELETE`, `TRACE`, or `CONNECT`.
+host | N/A | The value of the current request's Host header. [Case sensitive!](https://github.com/BuoyantIO/linkerd/issues/106). Not used in HTTP/1.0.
+uri | Not used | Only considered a part of the logical name if the config option `httpUriInDst` is `true`.
 
-Note that `dstPrefix`, if unset in the identifier configuration block,
-defaults to "http".
+<a name="path-identifier"></a>
+### Path Identifier
 
-### The Path Identifier
-
-This identifier is selected by setting the *kind* value of an *identifier*
-block to `io.l5d.path`.
+kind: `io.l5d.path`
 
 With this identifier, HTTP requests are turned into names based only on the
 path component of the URL, using a configurable number of "/" separated
-segments from the start of their HTTP path. Configuration options include:
+segments from the start of their HTTP path.
 
-* *segments* -- Number of segments from the path that are appended to
-  destinations. (default: 1)
-* *consume* -- Whether to additionally strip the consumed segments from the
-  HTTP request proxied to the final destination service. (default: false)
+#### Namer Configuration:
 
-Note that *consume* only affects the request sent to the destination service;
-it does not affect identification or routing.
-
-The path identifier generates logical names of the form:
-```
-  / dstPrefix / [*segments* number of segments from the URL path]
-```
+> With this configuration, a request to `:5000/true/love/waits.php` will be
+mapped to `/http/true/love` and will be routed based on this name by the
+corresponding dtab. Additionally, because `consume` is true, after routing,
+requests will be proxied to the destination service with `/waits.php` as the
+path component of the URL.
 
 ```yaml
 routers:
@@ -125,26 +144,32 @@ routers:
     port: 5000
 ```
 
-Note that `dstPrefix`, if unset in the identifier configuration block,
-defaults to "http". For example, here's a router configured with the path
-identifier
+Key | Default Value | Value Description
+--- | ------------- | -----------------
+segments | `1` | Number of segments from the path that are appended to destinations.
+consume | `false` | Whether to additionally strip the consumed segments from the HTTP request proxied to the final destination service. This only affects the request sent to the destination service; it does not affect identification or routing.
 
-With this configuration, a request to `:5000/true/love/waits.php` will be
-mapped to `/http/true/love` and will be routed based on this name by the
-corresponding dtab. Additionally, because `consume` is true, after routing,
-requests will be proxied to the destination service with `/waits.php` as the
-path component of the URL.
+#### Namer Path Parameters:
 
+> Dtab Path Format
+
+```
+  / dstPrefix [/ *urlPath ]
+```
+
+Key | Default Value | Value Description
+--- | ------------- | -----------------
+dstPrefix | `http` | The `dstPrefix` as set in the routers block.
+urlPath | N/A | A path from the URL whose number of segments is set in the identifier block.
+
+<a name="http-engines"></a>
 ## HTTP Engines
 
-An _engine_ may be configured on HTTP clients and servers, causing an
-alternate HTTP implementation to be used. Currently there are two
-supported HTTP implementations: _netty3_ (default) and _netty4_ (will
-become default in an upcoming release).
+> This configures an HTTP router that uses the new
+netty4 implementation on both the client and server:
 
 ```yaml
 - protocol: http
-  ...
   servers:
   - port: 4141
     ip: 0.0.0.0
@@ -155,78 +180,98 @@ become default in an upcoming release).
       kind: netty4
 ```
 
-For example, the following configures an HTTP router that uses the new
-netty4 implementation on both the client and server:
+An _engine_ may be configured on HTTP clients and servers, causing an
+alternate HTTP implementation to be used.
 
+Key | Default Value | Value Description
+--- | ------------- | -----------------
+kind | `netty3` | either `netty3` or `netty4` (`netty4` will become default in an upcoming release)
+
+<a name="http-headers"></a>
 ## HTTP Headers
 
 linkerd reads and sets several headers prefixed by `l5d-`.
 
+<a name="context-headers"></a>
 ### Context Headers
 
 _Context headers_ (`l5d-ctx-*`) are generated and read by linkerd
 instances. Applications should forward all context headers in order
-for all linkerd features to work. These headers include:
+for all linkerd features to work.
 
-- `dtab-local`: currently (until the next release of finagle), the
-  `dtab-local` header is used to propagate dtab context. In an
-  upcoming release this header will no longer be honored, in favor of
-  `l5d-ctx-dtab` and `l5d-dtab`.
-- `l5d-ctx-deadline`: describes time bounds within which a request is
-  expected to be satisfied. Currently deadlines are only advisory and
-  do not factor into request cancellation.
-- `l5d-ctx-trace`: encodes Zipkin-style trace IDs and flags so that
-  trace annotations emitted by linkerd may be correlated.
+Header | Description
+------ | -----------
+`dtab-local` | deprecated. Use `l5d-ctx-dtab` and `l5d-dtab`.
+`l5d-ctx-deadline` | describes time bounds within which a request is expected to be satisfied. Currently deadlines are only advisory and do not factor into request cancellation.
+`l5d-ctx-trace` | encodes Zipkin-style trace IDs and flags so that trace annotations emitted by linkerd may be correlated.
 
+<aside class="warning">
 Edge services should take care to ensure these headers are not set
 from untrusted sources.
+</aside>
 
 ### User Headers
 
-_User headers_ are useful to allow user-overrides
+> Append a dtab override to the baseDtab for this request
 
-- `l5d-dtab`: a client-specified delegation override
-- `l5d-sample`: a client-specified trace sample rate override
+```shell
+curl -H 'l5d-dtab: /host/web => /host/web-v2' "localhost:5000"
+```
 
-Note that if linkerd processes incoming requests for applications
+_User headers_ enable user-overrides.
+
+Header | Description
+------ | -----------
+`l5d-dtab` | a client-specified delegation override
+`l5d-sample` | a client-specified trace sample rate override
+
+<aside class="notice">
+If linkerd processes incoming requests for applications
 (i.e. in linker-to-linker configurations), applications do not need to
-provide special treatment for these headers since linkerd does _not_
+provide special treatment for these headers since linkerd does <b>not</b>
 forward these headers (and instead translates them into context
-headers). If applications receive traffic directly, they _should_
+headers). If applications receive traffic directly, they <b>should</b>
 forward these headers.
+</aside>
 
+<aside class="warning">
 Edge services should take care to ensure these headers are not set
 from untrusted sources.
+</aside>
 
 ### Informational Request Headers
 
-In addition to the context headers, linkerd may emit the following
-headers on outgoing requests:
+The informational headers linkerd emits on outgoing requests.
 
-- `l5d-dst-logical`: the logical name of the request as identified by linkerd
-- `l5d-dst-concrete`: the concrete client name after delegation
-- `l5d-dst-residual`: an optional residual path remaining after delegation
-- `l5d-reqid`: a token that may be used to correlate requests in a
-               callgraph across services and linkerd instances
+Header | Description
+------ | -----------
+`l5d-dst-logical` | the logical name of the request as identified by linkerd
+`l5d-dst-concrete` | the concrete client name after delegation
+`l5d-dst-residual` | an optional residual path remaining after delegation
+`l5d-reqid` | a token that may be used to correlate requests in a callgraph across services and linkerd instances
 
 Applications are not required to forward these headers on downstream
 requests.
 
-The value of the _dst_ headers may include service discovery
+<aside class="notice">
+The value of the dst headers may include service discovery
 information including host names.  Operators may opt to remove these
 headers from requests sent to the outside world.
+</aside>
 
 ### Informational Response Headers
 
-linkerd may emit the following _informational_ headers on outgoing
-responses:
+The informational headers linkerd emits on outgoing responses.
 
-- `l5d-err`: indicates a linkerd-generated error. Error responses
-             that do not have this header are application errors.
+Header | Description
+------ | -----------
+`l5d-err` | indicates a linkerd-generated error. Error responses that do not have this header are application errors.
 
 Applications are not required to forward these headers on upstream
 responses.
 
+<aside class="notice">
 The value of this header may include service discovery information
 including host names. Operators may opt to remove this header from
 responses sent to the outside world.
+</aside>

--- a/linkerd/docs/protocol-mux.md
+++ b/linkerd/docs/protocol-mux.md
@@ -19,14 +19,14 @@ protocol](http://twitter.github.io/finagle/guide/Protocols.html#mux).
 
 ## Mux Router Parameters
 
-Key | Default Value | Value Description
---- | ------------- | -----------------
-dstPrefix | `mux` | A path prefix used in `baseDtab`
+Key | Default Value | Description
+--- | ------------- | -----------
+dstPrefix | `mux` | A path prefix used in `baseDtab`.
 
 ## Mux Server Parameters
 
-Key | Default Value | Value Description
---- | ------------- | -----------------
+Key | Default Value | Description
+--- | ------------- | -----------
 port | `4141` | The TCP port number.
 
 

--- a/linkerd/docs/protocol-mux.md
+++ b/linkerd/docs/protocol-mux.md
@@ -1,10 +1,6 @@
 # Mux Protocol (experimental)
 
-linkerd experimentally supports the [mux
-protocol](http://twitter.github.io/finagle/guide/Protocols.html#mux).
-
-The default _dstPrefix_ is `/mux`.
-The default server _port_ is 4141.
+>A mux router configuration that routes requests to port 9001
 
 ```yaml
 
@@ -15,4 +11,23 @@ routers:
   baseDtab: |
     /overNineThousand => /$/inet/127.0.1/9001;
 ```
-As an example: Here's a mux router configuration that routes requests to port 9001
+
+protocol: `mux`
+
+linkerd experimentally supports the [mux
+protocol](http://twitter.github.io/finagle/guide/Protocols.html#mux).
+
+## Mux Router Parameters
+
+Key | Default Value | Value Description
+--- | ------------- | -----------------
+dstPrefix | `mux` | A path prefix used in `baseDtab`
+
+## Mux Server Parameters
+
+Key | Default Value | Value Description
+--- | ------------- | -----------------
+port | `4141` | The TCP port number.
+
+
+

--- a/linkerd/docs/protocol-thrift.md
+++ b/linkerd/docs/protocol-thrift.md
@@ -1,40 +1,7 @@
 # Thrift Protocol
 
-Since the Thrift protocol does not encode a destination name in the message
-itself, routing must be done per port. This implies one port per Thrift
-service. For out-of-the-box configuration, this means that the contents of
-`disco/thrift` will be treated as a newline-delimited list of `host:port`
-combinations for a specific thrift service.
 
-The default _dstPrefix_ is `/thrift`.
-
-Router configuration options include:
-* *thriftMethodInDst* -- if `true`, thrift method names are appended to
-  destinations for outgoing requests. (default: false)
-
-Thrift servers define additional parameters:
-
-* *thriftFramed* -- if `true`, a framed thrift transport is used for incoming
-  requests; otherwise, a buffered transport is used. Typically this setting
-  matches the router's `thriftFramed` param. (default: true)
-* *thriftProtocol* -- allows the thrift protocol to be chosen;
-   currently supports 'binary' for `TBinaryProtocol` (default) and
-   'compact' for `TCompactProtocol`. Typically this setting matches
-   the router's client `thriftProtocol` param.
-
-The default server _port_ is 4114.
-
-Thrift also supports additional *client* parameters:
-
-* *thriftFramed* -- if `true`, a framed thrift transport is used for outgoing
-  requests; otherwise, a buffered transport is used. Typically this setting
-  matches the router's servers' `thriftFramed` param. (default: true)
-* *thriftProtocol* -- allows the thrift protocol to be chosen;
-   currently supports `binary` for `TBinaryProtocol` (default) and
-   `compact` for `TCompactProtocol`. Typically this setting matches
-   the router's servers' `thriftProtocol` param.
-* *attemptTTwitterUpgrade* -- controls whether thrift protocol upgrade should be
-   attempted.  (default: true)
+> This config routes thrift (via buffered transport using the TCompactProtocol) from port 4004 to port 5005
 
 ```yaml
 routers:
@@ -52,6 +19,38 @@ routers:
     thriftProtocol: compact
 ```
 
-As an example: Here's a thrift router configuration that routes thrift--via
-buffered transport using the TCompactProtocol --from port 4004 to port 5005
+protocol: `thrift`
+
+Since the Thrift protocol does not encode a destination name in the message
+itself, routing must be done per port. This implies one port per Thrift
+service. For out-of-the-box configuration, this means that the contents of
+`disco/thrift` will be treated as a newline-delimited list of `host:port`
+combinations for a specific thrift service.
+
+## Thrift Router Parameters
+
+Key | Default Value | Value Description
+--- | ------------- | -----------------
+dstPrefix | `thrift` | A path prefix used in `baseDtab`
+thriftMethodInDst | `false` | if `true`, thrift method names are appended to destinations for outgoing requests.
+
+
+## Thrift Server Parameters
+
+Key | Default Value | Value Description
+--- | ------------- | -----------------
+port | `4114` | The TCP port number.
+thriftFramed | `true` | if `true`, a framed thrift transport is used for incoming requests; otherwise, a buffered transport is used. Typically this setting matches the router's `thriftFramed` param.
+thriftProtocol | `binary` | either `binary` (TBinaryProtocol) or `compact` (TCompantProtocol). Typically this setting matches the router's client `thriftProtocol` param.
+
+## Thrift Client Parameters
+
+Key | Default Value | Value Description
+--- | ------------- | -----------------
+thriftFramed | `true` | if `true`, a framed thrift transport is used for outgoing requests; otherwise, a buffered transport is used. Typically this setting matches the router's servers' `thriftFramed` param.
+thriftProtocol | `binary` | either `binary` (TBinaryProtocol) or `compact` (TCompantProtocol). Typically this setting matches the router's servers' `thriftProtocol` param.
+attemptTTwitterUpgrade | `true` | controls whether thrift protocol upgrade should be attempted.
+
+
+
 

--- a/linkerd/docs/protocol-thrift.md
+++ b/linkerd/docs/protocol-thrift.md
@@ -29,27 +29,27 @@ combinations for a specific thrift service.
 
 ## Thrift Router Parameters
 
-Key | Default Value | Value Description
---- | ------------- | -----------------
-dstPrefix | `thrift` | A path prefix used in `baseDtab`
-thriftMethodInDst | `false` | if `true`, thrift method names are appended to destinations for outgoing requests.
+Key | Default Value | Description
+--- | ------------- | -----------
+dstPrefix | `thrift` | A path prefix used in `baseDtab`.
+thriftMethodInDst | `false` | If `true`, thrift method names are appended to destinations for outgoing requests.
 
 
 ## Thrift Server Parameters
 
-Key | Default Value | Value Description
---- | ------------- | -----------------
+Key | Default Value | Description
+--- | ------------- | -----------
 port | `4114` | The TCP port number.
-thriftFramed | `true` | if `true`, a framed thrift transport is used for incoming requests; otherwise, a buffered transport is used. Typically this setting matches the router's `thriftFramed` param.
-thriftProtocol | `binary` | either `binary` (TBinaryProtocol) or `compact` (TCompantProtocol). Typically this setting matches the router's client `thriftProtocol` param.
+thriftFramed | `true` | If `true`, a framed thrift transport is used for incoming requests; otherwise, a buffered transport is used. Typically this setting matches the router's `thriftFramed` param.
+thriftProtocol | `binary` | Either `binary` (TBinaryProtocol) or `compact` (TCompantProtocol). Typically this setting matches the router's client `thriftProtocol` param.
 
 ## Thrift Client Parameters
 
-Key | Default Value | Value Description
---- | ------------- | -----------------
-thriftFramed | `true` | if `true`, a framed thrift transport is used for outgoing requests; otherwise, a buffered transport is used. Typically this setting matches the router's servers' `thriftFramed` param.
-thriftProtocol | `binary` | either `binary` (TBinaryProtocol) or `compact` (TCompantProtocol). Typically this setting matches the router's servers' `thriftProtocol` param.
-attemptTTwitterUpgrade | `true` | controls whether thrift protocol upgrade should be attempted.
+Key | Default Value | Description
+--- | ------------- | -----------
+thriftFramed | `true` | If `true`, a framed thrift transport is used for outgoing requests; otherwise, a buffered transport is used. Typically this setting matches the router's servers' `thriftFramed` param.
+thriftProtocol | `binary` | Either `binary` (TBinaryProtocol) or `compact` (TCompantProtocol). Typically this setting matches the router's servers' `thriftProtocol` param.
+attemptTTwitterUpgrade | `true` | Controls whether thrift protocol upgrade should be attempted.
 
 
 

--- a/linkerd/docs/response_classifier.md
+++ b/linkerd/docs/response_classifier.md
@@ -1,40 +1,52 @@
 # HTTP Response Classifiers
-> Example Response Classifier
+> Example response classifier config
 
 ```yaml
 routers:
 - ...
+  client:
   responseClassifier:
     kind: io.l5d.retryableRead5XX
 ```
 
 Response classifiers determine which HTTP responses are considered to
 be failures (for the purposes of success rate calculation) and which
-of these responses may be [retried](retries.md). A response classifier
-config block must contain a `kind` parameter which indicates which classifier
-plugin to use.  By default, the _io.l5d.nonRetryable5XX_ classifier is used.
+of these responses may be [retried](#retries).
+
+<aside class="notice">
+These parameters are available to the classifier regardless of kind. Classifiers may also have kind-specific parameters.
+</aside>
+
+Key | Default Value | Value Description
+--- | ------------- | -----------------
+kind | `io.l5d.nonRetryable5XX` | `io.l5d.nonRetryable5XX`, `io.l5d.retryableRead5XX`, or `io.l5d.retryableIdempotent5XX`
+
 
 ## Non-Retryable 5XX
 
-`io.l5d.nonRetryable5XX`
+kind: `io.l5d.nonRetryable5XX`
 
 All 5XX responses are considered to be failures and none of these
 requests are considered to be retryable.
 
 ## Retryable Read 5XX
 
-`io.l5d.retryableRead5XX`
+kind: `io.l5d.retryableRead5XX`
 
 All 5XX responses are considered to be failures. However, `GET`,
 `HEAD`, `OPTIONS`, and `TRACE` requests may be retried automatically.
 
+<aside class="warning">
 Requests with chunked bodies are NEVER considered to be retryable.
+</aside>
 
 ## Retryable Idempotent 5XX
 
-`io.l5d.retryableIdempotent5XX`
+kind: `io.l5d.retryableIdempotent5XX`
 
 Like _io.l5d.retryableRead5XX_, but `PUT` and `DELETE` requests may
 also be retried.
 
+<aside class="warning">
 Requests with chunked bodies are NEVER considered to be retryable.
+</aside>

--- a/linkerd/docs/response_classifier.md
+++ b/linkerd/docs/response_classifier.md
@@ -17,9 +17,9 @@ of these responses may be [retried](#retries).
 These parameters are available to the classifier regardless of kind. Classifiers may also have kind-specific parameters.
 </aside>
 
-Key | Default Value | Value Description
---- | ------------- | -----------------
-kind | `io.l5d.nonRetryable5XX` | `io.l5d.nonRetryable5XX`, `io.l5d.retryableRead5XX`, or `io.l5d.retryableIdempotent5XX`
+Key | Default Value | Description
+--- | ------------- | -----------
+kind | `io.l5d.nonRetryable5XX` | Either `io.l5d.nonRetryable5XX`, `io.l5d.retryableRead5XX`, or `io.l5d.retryableIdempotent5XX`.
 
 
 ## Non-Retryable 5XX

--- a/linkerd/docs/retries.md
+++ b/linkerd/docs/retries.md
@@ -16,35 +16,67 @@ routers:
 ```
 
 linkerd can automatically retry requests on certain failures (for example,
-connection errors).  A retries config block is an object with the following
-parameters:
+connection errors) and can be configured via the retries block.
 
-* *budget* -- Optional. Determines _how many_ failed requests are
-  eligible to be retried.
-  * *minRetriesPerSec* -- Optional. The minimum rate of retries
-    allowed in order to accommodate clients that have just started
-    issuing requests as well as clients that do not issue many
-    requests per window. Must be non-negative and if `0`, then no
-    reserve is given. (Default: 10)
-  * *percentCanRetry* -- Optional. The percentage of calls that can
-    be retried. This is in addition to any retries allowed for via
-    `minRetriesPerSec`.  Must be >= 0 and <= 1000. As an example, if
-    `0.1` is used, then for every 10 non-retry calls , 1 retry will
-    be allowed. If `2.0` is used then every non-retry call will
-    allow 2 retries. (Default: 0.2)
-  * *ttlSecs* -- Optional. The amount of time in seconds that
-    successful calls are considered when calculating retry budgets
-    (Default: 10)
-* *backoff* -- Optional. Determines which backoff algorithm should
-be used (see below).
-  * *kind* -- The name of a backoff algorithm. Either _constant_ or
-    _jittered_.
+Key | Default Value | Value Description
+--- | ------------- | -----------------
+budget | see [retry budget](#retry-budget-parameters) | Object that determins _how many_ failed requests are eligible to be retried.
+backoff | see [retry backoff](#retry-backoff-parameters) | Object that determines which backoff algorithm should be used
 
-The _constant_ backoff policy takes a single configuration parameter:
-* _ms_ -- The number of milliseconds to wait before each retry.
 
-The _jittered_ backoff policy uses a
-[decorrelated jitter](http://www.awsarchitectureblog.com/2015/03/backoff.html)
-backoff algorithm and requires two configuration parameters:
-* _minMs_ -- The minimum number of milliseconds to wait before each retry.
-* _maxMs_ -- The maximum number of milliseconds to wait before each retry.
+## Retry Budget Parameters
+
+> For every 10 non-retry calls, allow 1 retry
+
+```yaml
+client:
+  retries:
+    budget:
+      percentCanRetry: 0.1
+```
+
+> For every non-retry call, allow 2 retries
+
+```yaml
+client:
+  retries:
+    budget:
+      percentCanRetry: 2.0
+```
+
+Key | Default Value | Value Description
+--- | ------------- | -----------------
+minRetriesPerSec | `10` | The minimum rate of retries allowed in order to accommodate clients that have just started issuing requests, as well as clients that do not issue many requests per window. Must be non-negative. If `0`, no reserve is given.
+percentCanRetry | `0.2` | The percentage of calls that can be retried. This is in addition to any retries allowed via `minRetriesPerSec`.  Must be >= `0` and <= `1000`.
+ttlSecs | `10` | The amount of time in seconds that successful calls are considered when calculating retry budgets
+
+## Retry Backoff Parameters
+
+<aside class="notice">
+These parameters are available to the backoff regardless of kind. Backoffs may also have kind-specific parameters.
+</aside>
+
+Key | Default Value | Value Description
+--- | ------------- | -----------------
+kind | _required_ | `constant` or `jittered`
+
+### Constant Backoff
+
+kind: `constant`
+
+Key | Default Value | Value Description
+--- | ------------- | -----------------
+ms | `0` | The number of milliseconds to wait before each retry.
+
+### Jittered Backoff
+
+kind: `jittered`
+
+Uses a [decorrelated jitter](http://www.awsarchitectureblog.com/2015/03/backoff.html) backoff algorithm.
+
+Key | Default Value | Value Description
+--- | ------------- | -----------------
+minMs | _required_ | The minimum number of milliseconds to wait before each retry.
+maxMs | _required_ | The maximum number of milliseconds to wait before each retry.
+
+

--- a/linkerd/docs/retries.md
+++ b/linkerd/docs/retries.md
@@ -18,10 +18,10 @@ routers:
 linkerd can automatically retry requests on certain failures (for example,
 connection errors) and can be configured via the retries block.
 
-Key | Default Value | Value Description
---- | ------------- | -----------------
-budget | see [retry budget](#retry-budget-parameters) | Object that determins _how many_ failed requests are eligible to be retried.
-backoff | see [retry backoff](#retry-backoff-parameters) | Object that determines which backoff algorithm should be used
+Key | Default Value | Description
+--- | ------------- | -----------
+budget | See [retry budget](#retry-budget-parameters) | Object that determins _how many_ failed requests are eligible to be retried.
+backoff | See [retry backoff](#retry-backoff-parameters) | Object that determines which backoff algorithm should be used.
 
 
 ## Retry Budget Parameters
@@ -44,11 +44,11 @@ client:
       percentCanRetry: 2.0
 ```
 
-Key | Default Value | Value Description
---- | ------------- | -----------------
+Key | Default Value | Description
+--- | ------------- | -----------
 minRetriesPerSec | `10` | The minimum rate of retries allowed in order to accommodate clients that have just started issuing requests, as well as clients that do not issue many requests per window. Must be non-negative. If `0`, no reserve is given.
 percentCanRetry | `0.2` | The percentage of calls that can be retried. This is in addition to any retries allowed via `minRetriesPerSec`.  Must be >= `0` and <= `1000`.
-ttlSecs | `10` | The amount of time in seconds that successful calls are considered when calculating retry budgets
+ttlSecs | `10` | The amount of time in seconds that successful calls are considered when calculating retry budgets.
 
 ## Retry Backoff Parameters
 
@@ -56,16 +56,16 @@ ttlSecs | `10` | The amount of time in seconds that successful calls are conside
 These parameters are available to the backoff regardless of kind. Backoffs may also have kind-specific parameters.
 </aside>
 
-Key | Default Value | Value Description
---- | ------------- | -----------------
-kind | _required_ | `constant` or `jittered`
+Key | Default Value | Description
+--- | ------------- | -----------
+kind | _required_ | Either `constant` or `jittered`.
 
 ### Constant Backoff
 
 kind: `constant`
 
-Key | Default Value | Value Description
---- | ------------- | -----------------
+Key | Default Value | Description
+--- | ------------- | -----------
 ms | `0` | The number of milliseconds to wait before each retry.
 
 ### Jittered Backoff
@@ -74,8 +74,8 @@ kind: `jittered`
 
 Uses a [decorrelated jitter](http://www.awsarchitectureblog.com/2015/03/backoff.html) backoff algorithm.
 
-Key | Default Value | Value Description
---- | ------------- | -----------------
+Key | Default Value | Description
+--- | ------------- | -----------
 minMs | _required_ | The minimum number of milliseconds to wait before each retry.
 maxMs | _required_ | The maximum number of milliseconds to wait before each retry.
 

--- a/linkerd/docs/routers.md
+++ b/linkerd/docs/routers.md
@@ -28,18 +28,18 @@ routers:
   responseClassifier: io.l5d.nonRetryable5XX
 ```
 
-Key | Default Value | Value Description
---- | ------------- | -----------------
-protocol | _required_ | either "[http](#http-1-1-protocol)", "[thrift](#thrift-protocol)", or "[mux](#mux-protocol-experimental)"
-servers | _required_ | a list of [server objects](#servers)
-announcers | an empty list | a list of service discovery [announcers](#announcers) that servers can announce to.
+Key | Default Value | Description
+--- | ------------- | -----------
+protocol | _required_ | Either [`http`](#http-1-1-protocol), [`thrift`](#thrift-protocol), or [`mux`](#mux-protocol-experimental).
+servers | _required_ | A list of [server objects](#servers).
+announcers | an empty list | A list of service discovery [announcers](#announcers) that servers can announce to.
 baseDtab | an empty dtab | Sets the base delegation table. See [dtabs](https://linkerd.io/doc/dtabs/) for more.
 bindingTimeoutMs | 10 seconds | The maximum amount of time in milliseconds to spend binding a path.
 bindingCache | see [binding cache](#binding-cache) | Binding cache size configuration.
-client | an empty object | an object of [client params](#basic-client-params)
+client | an empty object | An object of [client params](#basic-client-params).
 dstPrefix | protocol dependent | A path prefix to be used on request destinations.
 failFast | `false` | If `true`, connection failures are punished more aggressively. Should not be used with small destination pools.
-interpreter | default interpreter | an [interpreter object](#interpreter) determining what module will be used to process destinations.
+interpreter | default interpreter | An [interpreter object](#interpreter) determining what module will be used to process destinations.
 label | the value of *protocol* | The name of the router (in stats and the admin ui)
 response Classifier | `io.l5d.nonRetryable5XX` | A (sometimes protocol-specific) [response classifier](#http-response-classifiers) that determines which responses should be considered failures and, of those, which should be considered [retryable](#retries).
 timeoutMs | no timeout | Per-request timeout in milliseconds.
@@ -57,12 +57,12 @@ timeoutMs | no timeout | Per-request timeout in milliseconds.
     clients: 10
 ```
 
-Key | Default Value | Value Description
+Key | Default Value | Description
 -------------- | -------------- | --------------
-paths | `100` | Size of the path cache in KB
-trees | `100` | Size of the trees cache in KB
-bounds | `100` | Size of the bounds cache in KB
-clients | `10` | Size of the clients cache in KB
+paths | `100` | Max number of paths in the path cache.
+trees | `100` | Max number of trees in the tree cache.
+bounds | `100` | Max number of bounds in the bounds cache.
+clients | `10` | Max number of clients in the clients cache.
 
 <a name="server-parameters"></a>
 ## Server Parameters
@@ -83,13 +83,13 @@ servers:
     - /#/io.l5d.serversets/discovery/prod/web
 ```
 
-Key | Default Value | Value Description
---- | ------------- | -----------------
+Key | Default Value | Description
+--- | ------------- | -----------
 port | protocol dependent | The TCP port number. Protocols may provide default values. If no default is provided, the port parameter is required.
 ip | loopback address | The local IP address. A value like 0.0.0.0 configures the server to listen on all local IPv4 interfaces.
 tls | no tls | The server will serve over TLS if this parameter is provided. see [TLS](#server-tls).
 maxConcurrentRequests | unlimited | The maximum number of concurrent requests the server will accept.
-announce | an empty list | A list of concrete names to announce using the router's [announcers](#announcers)
+announce | an empty list | A list of concrete names to announce using the router's [announcers](#announcers).
 
 
 <a name="client-parameters"></a>
@@ -117,9 +117,9 @@ client:
       maxMs: 10000
 ```
 
-Key | Default Value | Value Description
---- | ------------- | -----------------
-hostConnectionPool | an empty object | see [hostConnectionPool](#host-connection-pool).
+Key | Default Value | Description
+--- | ------------- | -----------
+hostConnectionPool | An empty object | see [hostConnectionPool](#host-connection-pool).
 tls | no tls | The router will make requests using TLS if this parameter is provided.  It must be a [client TLS](#client-tls) object.
 loadBalancer | [p2c](#power-of-two-choices-least-loaded) | A [load balancer](#load-balancer) object.
 retries | see [retries](#retries) | A [retry policy](#retries) for all clients created by this router.
@@ -135,8 +135,8 @@ client:
     maxWaiters: 5000
 ```
 
-Key | Default Value | Value Description
---- | ------------- | -----------------
+Key | Default Value | Description
+--- | ------------- | -----------
 minSize | `0` | The minimum number of connections to maintain to each host.
 maxSize | Int.MaxValue | The maximum number of connections to maintain to each host.
 idleTimeMs | forever | The amount of idle time for which a connection is cached in milliseconds.

--- a/linkerd/docs/routers.md
+++ b/linkerd/docs/routers.md
@@ -1,0 +1,143 @@
+<a name="routers"></a>
+# Routers
+
+All configurations must define a **routers** key, the value of which
+must be an array of router configurations. Routers also include **servers**, which define their entry points, and **client**, which configures how clients are built.
+
+## Router Parameters
+
+<aside class="notice">
+These parameters are available to the router regardless of protocol. Routers may also have protocol-specific parameters.
+</aside>
+
+```yaml
+routers:
+- protocol: http
+  servers: ...
+  client: ...
+  announcers: ...
+  bindingCache: ...
+  label: myPackIce
+  dstPrefix: /walruses/http
+  baseDtab: |
+    /host                => /#/io.l5d.fs;
+    /walruses/http/1.1/* => /host;
+  failFast: false
+  timeoutMs: 10000
+  bindingTimeoutMs: 5000
+  responseClassifier: io.l5d.nonRetryable5XX
+```
+
+Key | Default Value | Value Description
+--- | ------------- | -----------------
+protocol | _required_ | either "[http](#http-1-1-protocol)", "[thrift](#thrift-protocol)", or "[mux](#mux-protocol-experimental)"
+servers | _required_ | a list of [server objects](#servers)
+announcers | an empty list | a list of service discovery [announcers](#announcers) that servers can announce to.
+baseDtab | an empty dtab | Sets the base delegation table. See [dtabs](https://linkerd.io/doc/dtabs/) for more.
+bindingTimeoutMs | 10 seconds | The maximum amount of time in milliseconds to spend binding a path.
+bindingCache | see [binding cache](#binding-cache) | Binding cache size configuration.
+client | an empty object | an object of [client params](#basic-client-params)
+dstPrefix | protocol dependent | A path prefix to be used on request destinations.
+failFast | `false` | If `true`, connection failures are punished more aggressively. Should not be used with small destination pools.
+interpreter | default interpreter | an [interpreter object](#interpreter) determining what module will be used to process destinations.
+label | the value of *protocol* | The name of the router (in stats and the admin ui)
+response Classifier | `io.l5d.nonRetryable5XX` | A (sometimes protocol-specific) [response classifier](#http-response-classifiers) that determines which responses should be considered failures and, of those, which should be considered [retryable](#retries).
+timeoutMs | no timeout | Per-request timeout in milliseconds.
+
+### Binding Cache
+
+```yaml
+- protocol: http
+  servers:
+    - port: 9000
+  bindingCache:
+    paths: 100
+    trees: 100
+    bounds: 100
+    clients: 10
+```
+
+Key | Default Value | Value Description
+-------------- | -------------- | --------------
+paths | `100` | Size of the path cache in KB
+trees | `100` | Size of the trees cache in KB
+bounds | `100` | Size of the bounds cache in KB
+clients | `10` | Size of the clients cache in KB
+
+<a name="server-parameters"></a>
+## Server Parameters
+
+<aside class="notice">
+These parameters are available to the server regardless of protocol. Servers may also have protocol-specific parameters.
+</aside>
+
+```yaml
+servers:
+- port: 8080
+  ip: 0.0.0.0
+  tls:
+    certPath: /foo/cert.pem
+    keyPath: /foo/key.pem
+  maxConcurrentRequests: 1000
+  announce:
+    - /#/io.l5d.serversets/discovery/prod/web
+```
+
+Key | Default Value | Value Description
+--- | ------------- | -----------------
+port | protocol dependent | The TCP port number. Protocols may provide default values. If no default is provided, the port parameter is required.
+ip | loopback address | The local IP address. A value like 0.0.0.0 configures the server to listen on all local IPv4 interfaces.
+tls | no tls | The server will serve over TLS if this parameter is provided. see [TLS](#server-tls).
+maxConcurrentRequests | unlimited | The maximum number of concurrent requests the server will accept.
+announce | an empty list | A list of concrete names to announce using the router's [announcers](#announcers)
+
+
+<a name="client-parameters"></a>
+## Client Parameters
+
+
+<aside class="notice">
+These parameters are available to the client regardless of protocol. Clients may also have protocol-specific parameters.
+</aside>
+
+
+```yaml
+client:
+  tls:
+    kind: io.l5d.noValidation
+    commonName: foo
+    caCertPath: /foo/caCert.pem
+  loadBalancer:
+    kind: ewma
+    enableProbation: false
+  retries:
+    backoff:
+      kind: jittered
+      minMs: 10
+      maxMs: 10000
+```
+
+Key | Default Value | Value Description
+--- | ------------- | -----------------
+hostConnectionPool | an empty object | see [hostConnectionPool](#host-connection-pool).
+tls | no tls | The router will make requests using TLS if this parameter is provided.  It must be a [client TLS](#client-tls) object.
+loadBalancer | [p2c](#power-of-two-choices-least-loaded) | A [load balancer](#load-balancer) object.
+retries | see [retries](#retries) | A [retry policy](#retries) for all clients created by this router.
+
+#### Host Connection Pool
+
+```yaml
+client:
+  hostConnectionPool:
+    minSize: 0
+    maxSize: 1000
+    idleTimeMs: 10000
+    maxWaiters: 5000
+```
+
+Key | Default Value | Value Description
+--- | ------------- | -----------------
+minSize | `0` | The minimum number of connections to maintain to each host.
+maxSize | Int.MaxValue | The maximum number of connections to maintain to each host.
+idleTimeMs | forever | The amount of idle time for which a connection is cached in milliseconds.
+maxWaiters | Int.MaxValue | The maximum number of connection requests that are queued when the connection concurrency exceeds maxSize.

--- a/linkerd/docs/tracer.md
+++ b/linkerd/docs/tracer.md
@@ -7,9 +7,9 @@ tracing instrumentation.
 These parameters are available to the tracer regardless of kind. Tracers may also have kind-specific parameters.
 </aside>
 
-Key | Default Value | Value Description
---- | ------------- | -----------------
-kind | _required_ | `io.l5d.zipkin`
+Key | Default Value | Description
+--- | ------------- | -----------
+kind | _required_ | Only `io.l5d.zipkin` is available at this time.
 debugTrace | `false` | If `true`, print all traces to the console. Note this overrides the global `-com.twitter.finagle.tracing.debugTrace` flag, and will default to that flag if not set here.
 
 
@@ -30,8 +30,8 @@ kind: `io.l5d.zipkin`
 
 Finagle's [zipkin-tracer](https://github.com/twitter/finagle/tree/develop/finagle-zipkin).
 
-Key | Default Value | Value Description
---- | ------------- | -----------------
+Key | Default Value | Description
+--- | ------------- | -----------
 host | `localhost` | Host to send trace data to.
 port | `9410` | Port to send trace data to.
 sampleRate | `0.001` | What percentage of requests to trace.

--- a/linkerd/docs/tracer.md
+++ b/linkerd/docs/tracer.md
@@ -1,15 +1,17 @@
 # Tracers
 
 Requests that are routed by linkerd are also traceable using Finagle's built-in
-tracing instrumentation.  A tracer config object has the following parameters:
+tracing instrumentation.
 
-* *kind* -- The name of the tracer plugin
-* *debugTrace* -- Print all traces to the console. Note this overrides the
-global `-com.twitter.finagle.tracing.debugTrace` flag, and will default to
-that flag if not set here.
-* Any options specific to the tracer
+<aside class="notice">
+These parameters are available to the tracer regardless of kind. Tracers may also have kind-specific parameters.
+</aside>
 
-Current tracers include:
+Key | Default Value | Value Description
+--- | ------------- | -----------------
+kind | _required_ | `io.l5d.zipkin`
+debugTrace | `false` | If `true`, print all traces to the console. Note this overrides the global `-com.twitter.finagle.tracing.debugTrace` flag, and will default to that flag if not set here.
+
 
 ## Zipkin
 
@@ -24,10 +26,13 @@ tracers:
   debugTrace: true
 ```
 
-`io.l5d.zipkin`
+kind: `io.l5d.zipkin`
 
 Finagle's [zipkin-tracer](https://github.com/twitter/finagle/tree/develop/finagle-zipkin).
 
-* *host* -- Optional. Host to send trace data to. (default: localhost)
-* *port* -- Optional. Port to send trace data to. (default: 9410)
-* *sampleRate* -- Optional. How much data to collect. (default: 0.001)
+Key | Default Value | Value Description
+--- | ------------- | -----------------
+host | `localhost` | Host to send trace data to.
+port | `9410` | Port to send trace data to.
+sampleRate | `0.001` | What percentage of requests to trace.
+


### PR DESCRIPTION
Problem:
I like the conversational tone of our docs :) But when it comes to reference
documentation, having more structure would make it easier to scan for information.

Solution:
I moved the parameter definitions from a bullet format to a table format. I
staged these changes at https://buoyant.io/slate-linkerd/ so folks can compare
with https://buoyant.io/linkerd