### PR TITLE
Useful toString for ConsulApiError trait

### DIFF
--- a/consul/src/main/scala/io/buoyant/consul/v1/package.scala
+++ b/consul/src/main/scala/io/buoyant/consul/v1/package.scala
@@ -9,6 +9,9 @@ package object v1 {
 
   trait ConsulApiError extends Throwable {
     def rsp: http.Response
+
+    override def toString: String =
+      s"${this.getClass.getSimpleName}(${rsp.statusCode}: ${rsp.contentString})"
   }
   case class UnexpectedResponse(rsp: http.Response) extends ConsulApiError
   case class NotFound(rsp: http.Response) extends ConsulApiError


### PR DESCRIPTION
It gives log messages like:
```
  retrying consul request on error Forbidden(403: rpc error: ACL not found)
```
rather than
```
  retrying consul request on error io.buoyant.consul.v1.package$Forbidden
```