### PR TITLE
ConsulNamer reorganization

### DIFF
--- a/namer/consul/src/main/scala/io/buoyant/namer/consul/ConsulNamer.scala
+++ b/namer/consul/src/main/scala/io/buoyant/namer/consul/ConsulNamer.scala
@@ -1,11 +1,8 @@
 package io.buoyant.namer.consul
 
 import com.twitter.finagle._
-import com.twitter.logging.Logger
 import com.twitter.util._
-import io.buoyant.consul._
-import io.buoyant.consul.v1.{ServiceNode, UnexpectedResponse}
-import io.buoyant.namer.Metadata
+import io.buoyant.consul.v1
 
 object ConsulNamer {
 
@@ -14,107 +11,43 @@ object ConsulNamer {
     consulApi: v1.ConsulApi,
     agentApi: v1.AgentApi,
     setHost: Boolean = false
-  ): Namer = new Tagged(Base(consulApi, agentApi, setHost), prefix)
+  ): Namer = {
+    val lookup = new LookupCache(consulApi, agentApi, setHost)
+    new TaggedNamer(lookup, prefix)
+  }
 
   def untagged(
     prefix: Path,
     consulApi: v1.ConsulApi,
     agentApi: v1.AgentApi,
     setHost: Boolean = false
-  ): Namer = new Untagged(Base(consulApi, agentApi, setHost), prefix)
+  ): Namer = {
+    val lookup = new LookupCache(consulApi, agentApi, setHost)
+    new UntaggedNamer(lookup, prefix)
+  }
 
-  private[this] class Tagged(base: Base, prefix: Path) extends Namer {
+  private[this] class TaggedNamer(lookup: LookupCache, prefix: Path) extends Namer {
 
     def lookup(path: Path): Activity[NameTree[Name]] =
       path.take(3) match {
         case id@Path.Utf8(dc, tag, service) =>
           val k = SvcKey(service, Some(tag))
-          base.lookup(dc, k, prefix ++ id, path.drop(3))
+          lookup(dc, k, prefix ++ id, path.drop(3))
 
         case _ => Activity.value(NameTree.Neg)
       }
   }
 
-  private[this] class Untagged(base: Base, prefix: Path) extends Namer {
+  private[this] class UntaggedNamer(lookup: LookupCache, prefix: Path) extends Namer {
 
     def lookup(path: Path): Activity[NameTree[Name]] =
       path.take(2) match {
         case id@Path.Utf8(dc, service) =>
           val k = SvcKey(service, None)
-          base.lookup(dc, k, prefix ++ id, path.drop(2))
+          lookup(dc, k, prefix ++ id, path.drop(2))
 
         case _ => Activity.value(NameTree.Neg)
       }
-  }
-
-  private[this] case class Base(
-    consulApi: v1.ConsulApi,
-    agentApi: v1.AgentApi,
-    setHost: Boolean = false
-  ) {
-
-    def lookup(
-      dcName: String,
-      svcKey: SvcKey,
-      id: Path,
-      residual: Path
-    ): Activity[NameTree[Name]] = {
-      log.debug("consul lookup: %s %s", id.show)
-      watchDc(dcName).map { services =>
-        services.get(svcKey) match {
-          case None =>
-            log.debug("consul dc %s service %s missing", dcName, svcKey)
-            NameTree.Neg
-
-          case Some(addr) =>
-            log.debug("consul ns %s service %s found + %s", dcName, svcKey, residual.show)
-            NameTree.Leaf(Name.Bound(addr, id, residual))
-        }
-      }
-    }
-
-    private[this] lazy val domain: Activity[Option[String]] =
-      if (setHost) {
-        Activity.future(agentApi.localAgent(retry = true)).map { la =>
-          val dom = la.Config.flatMap(_.Domain).getOrElse("consul")
-          Some(dom.stripPrefix(".").stripSuffix("."))
-        }
-      } else Activity.value(None)
-
-    protected[this] def watchDc(dc: String): Activity[Map[SvcKey, Var[Addr]]] =
-      domain.flatMap { domain =>
-        Activity(Dc.get(dc, domain).services).map(_.mapValues(_.addrs))
-      }
-
-    /**
-     * Contains all cached responses from the Consul API
-     */
-    private[this] object Dc {
-      private[this] val activity: ActUp[Map[String, DcCache]] =
-        Var(Activity.Pending)
-
-      /**
-       * Returns existing datacenter cache with that name
-       * or creates a new one
-       */
-      def get(name: String, domain: Option[String]): DcCache =
-        synchronized {
-          activity.sample() match {
-            case Activity.Ok(snap) => snap.getOrElse(name, mkAndUpdate(snap, name, domain))
-            case _ => mkAndUpdate(Map.empty, name, domain)
-          }
-        }
-
-      private[this] def mkAndUpdate(
-        cache: Map[String, DcCache],
-        name: String,
-        domain: Option[String]
-      ): DcCache = {
-        val dc = new DcCache(consulApi, name, domain)
-        activity() = Activity.Ok(cache + (name -> dc))
-        dc
-      }
-    }
   }
 
 }

--- a/namer/consul/src/main/scala/io/buoyant/namer/consul/ConsulNamer.scala
+++ b/namer/consul/src/main/scala/io/buoyant/namer/consul/ConsulNamer.scala
@@ -15,11 +15,6 @@ class ConsulNamer(
   setHost: Boolean = false
 ) extends Namer {
 
-  import ConsulNamer._
-
-  private[this] def domainFuture(): Future[Option[String]] =
-    agentApi.localAgent().map { la => la.Config.flatMap(_.Domain).map(_.stripPrefix(".").stripSuffix(".")) }
-
   /**
    * Accepts names in the form:
    * /<datacenter>/<svc-name>/residual/path
@@ -78,213 +73,22 @@ class ConsulNamer(
      * Returns existing datacenter cache with that name
      * or creates a new one
      */
-    def get(name: String): DcCache = synchronized {
-      activity.sample() match {
-        case Activity.Ok(snap) =>
-          snap.getOrElse(name, {
-            val dc = new DcCache(name, Var(Activity.Pending))
-            activity() = Activity.Ok(snap + (name -> dc))
-            dc
-          })
-
-        case _ =>
-          val dc = new DcCache(name, Var(Activity.Pending))
-          activity() = Activity.Ok(Map(name -> dc))
-          dc
-      }
-    }
-  }
-
-  /**
-   * Contains all cached serviceNodes responses for a particular serviceName
-   * in a particular datacenter
-   */
-  case class SvcCache(datacenter: String, key: SvcKey, updateableAddr: VarUp[Addr]) {
-
-    def addrs: VarUp[Addr] = updateableAddr
-
-    var index = "0"
-    val _ = init()
-
-    def setIndex(idx: String) = {
-      index = idx
-    }
-
-    def mkRequest(): Future[Seq[ServiceNode]] =
-      consulApi
-        .serviceNodes(key.name, datacenter = Some(datacenter), tag = key.tag, blockingIndex = Some(index), retry = true)
-        .map { indexedNodes =>
-          indexedNodes.index.foreach(setIndex)
-          indexedNodes.value
-        }
-
-    def clear(): Unit = synchronized {
-      updateableAddr() = Addr.Pending
-    }
-
-    def init(): Future[Unit] = mkRequest().flatMap(update).handle(handleUnexpected)
-
-    def serviceNodeToAddr(node: ServiceNode): Option[Address] = {
-      (node.Address, node.ServiceAddress, node.ServicePort) match {
-        case (_, Some(serviceIp), Some(port)) if !serviceIp.isEmpty =>
-          Some(Address(serviceIp, port))
-        case (Some(nodeIp), _, Some(port)) if !nodeIp.isEmpty =>
-          Some(Address(nodeIp, port))
-        case _ => None
-      }
-    }
-
-    def update(nodes: Seq[ServiceNode]): Future[Unit] = {
-      val metaFuture =
-        if (setHost)
-          domainFuture().map { domainOption =>
-            val domain = domainOption.getOrElse("consul")
-            val authority = key.tag match {
-              case Some(tag) => s"$tag.${key.name}.service.$datacenter.$domain"
-              case None => s"${key.name}.service.$datacenter.$domain"
-            }
-            Addr.Metadata(Metadata.authority -> authority)
-          }
-        else
-          Future.value(Addr.Metadata.empty)
-
-      metaFuture.flatMap { meta =>
-        synchronized {
-          try {
-            val socketAddrs = nodes.flatMap(serviceNodeToAddr).toSet
-            updateableAddr() = if (socketAddrs.isEmpty) Addr.Neg else Addr.Bound(socketAddrs, meta)
-          } catch {
-            // in the event that we are trying to parse an invalid addr
-            case e: IllegalArgumentException =>
-              updateableAddr() = Addr.Failed(e)
-          }
-        }
-        mkRequest().flatMap(update).handle(handleUnexpected)
-      }
-    }
-
-    val handleUnexpected: PartialFunction[Throwable, Unit] = {
-      case e: ChannelClosedException =>
-        log.error(s"""lost consul connection while querying for $datacenter/$key updates""")
-      case e: Throwable =>
-        updateableAddr() = Addr.Failed(e)
-    }
-  }
-
-  case class SvcKey(name: String, tag: Option[String]) {
-    override def toString = tag match {
-      case Some(t) => s"$name:$t"
-      case None => name
-    }
-  }
-
-  /**
-   * Contains all cached serviceMap responses and the mapping of names
-   * to SvcCaches for a particular datacenter.
-   */
-  class DcCache(name: String, activity: ActUp[Map[SvcKey, SvcCache]]) {
-
-    def services: Var[Activity.State[Map[SvcKey, SvcCache]]] = activity
-
-    var index = "0"
-    val _ = init()
-
-    def setIndex(idx: String) = {
-      index = idx
-    }
-
-    def mkRequest(): Future[Seq[SvcKey]] =
-      consulApi
-        .serviceMap(datacenter = Some(name), blockingIndex = Some(index), retry = true)
-        .map { indexedSvcs =>
-          indexedSvcs.index.foreach(setIndex)
-          indexedSvcs.value.flatMap {
-            case (svcName, tags) =>
-              tags.map(tag => SvcKey(svcName, Some(tag))) :+ SvcKey(svcName, None)
-          }.toSeq
-        }
-
-    def clear(): Unit = synchronized {
-      activity.sample() match {
-        case Activity.Ok(snap) =>
-          for (svc <- snap.values) {
-            svc.clear()
-          }
-        case _ =>
-      }
-      activity() = Activity.Pending
-    }
-
-    def init(): Future[Unit] =
-      mkRequest().flatMap { svcKeys =>
-
-        val services = Map(svcKeys.map { svcKey =>
-          svcKey -> mkSvc(svcKey)
-        }: _*)
-
-        synchronized {
-          activity() = Activity.Ok(services)
-        }
-
-        mkRequest().flatMap(update)
-      }.handle {
-        case e: UnexpectedResponse => activity() = Activity.Ok(Map.empty)
-        case e: Throwable => activity() = Activity.Failed(e)
-      }
-
-    def update(serviceKeys: Seq[SvcKey]): Future[Unit] = {
+    def get(name: String): DcCache =
       synchronized {
-        val svcs = services.sample() match {
-          case Activity.Ok(svcs) => svcs
-          case _ => Map.empty[SvcKey, SvcCache]
-        }
-
-        serviceKeys.foreach { key =>
-          if (!svcs.contains(key))
-            add(key)
-        }
-
-        svcs.foreach {
-          case (key, _) =>
-            if (!serviceKeys.contains(key))
-              delete(key)
+        activity.sample() match {
+          case Activity.Ok(snap) => snap.getOrElse(name, mkAndUpdate(snap, name))
+          case _ => mkAndUpdate(Map.empty, name)
         }
       }
 
-      mkRequest().flatMap(update)
+    private[this] def mkAndUpdate(cache: Map[String, DcCache], name: String): DcCache = {
+      val dc = mk(name)
+      activity() = Activity.Ok(cache + (name -> dc))
+      dc
     }
 
-    private[this] def mkSvc(svcKey: SvcKey): SvcCache = SvcCache(name, svcKey, Var(Addr.Pending))
-
-    private[this] def add(serviceKey: SvcKey): Unit = {
-      log.debug("consul added: %s", serviceKey)
-      val svcs = services.sample() match {
-        case Activity.Ok(svcs) => svcs
-        case _ => Map.empty[SvcKey, SvcCache]
-      }
-      activity() = Activity.Ok(svcs + (serviceKey -> mkSvc(serviceKey)))
-    }
-
-    private[this] def delete(serviceKey: SvcKey): Unit = {
-      log.debug("consul deleted: %s", serviceKey)
-      val svcs = services.sample() match {
-        case Activity.Ok(svcs) => svcs
-        case _ => Map.empty[SvcKey, SvcCache]
-      }
-      svcs.get(serviceKey) match {
-        case Some(svc) =>
-          svc.clear()
-          activity() = Activity.Ok(svcs - serviceKey)
-        case _ =>
-      }
-    }
-
+    private[this] def mk(name: String): DcCache =
+      new DcCache(consulApi, agentApi, name, Var(Activity.Pending), setHost)
   }
 
-}
-
-object ConsulNamer {
-  type VarUp[T] = Var[T] with Updatable[T]
-  type ActUp[T] = VarUp[Activity.State[T]]
-  private val log = Logger.get(getClass.getName)
 }

--- a/namer/consul/src/main/scala/io/buoyant/namer/consul/ConsulNamer.scala
+++ b/namer/consul/src/main/scala/io/buoyant/namer/consul/ConsulNamer.scala
@@ -7,98 +7,114 @@ import io.buoyant.consul._
 import io.buoyant.consul.v1.{ServiceNode, UnexpectedResponse}
 import io.buoyant.namer.Metadata
 
-class ConsulNamer(
-  idPrefix: Path,
-  consulApi: v1.ConsulApi,
-  agentApi: v1.AgentApi,
-  includeTag: Boolean = false,
-  setHost: Boolean = false
-) extends Namer {
+object ConsulNamer {
 
-  /**
-   * Accepts names in the form:
-   * /<datacenter>/<svc-name>/residual/path
-   * or, if `includeTag` is true, in the form:
-   * /<datacenter>/<tag>/<svc-name>/residual/path
-   */
-  def lookup(path: Path): Activity[NameTree[Name]] =
-    path match {
-      case Path.Utf8(dcName, serviceName, residual@_*) if !includeTag =>
-        lookup(
-          dcName,
-          SvcKey(serviceName, None),
-          idPrefix ++ Path.Utf8(dcName, serviceName),
-          Path.Utf8(residual: _*)
-        )
-      case Path.Utf8(dcName, tag, serviceName, residual@_*) if includeTag =>
-        lookup(
-          dcName,
-          SvcKey(serviceName, Some(tag)),
-          idPrefix ++ Path.Utf8(dcName, tag, serviceName),
-          Path.Utf8(residual: _*)
-        )
-      case _ =>
-        Activity.value(NameTree.Neg)
-    }
+  def tagged(
+    prefix: Path,
+    consulApi: v1.ConsulApi,
+    agentApi: v1.AgentApi,
+    setHost: Boolean = false
+  ): Namer = new Tagged(Base(consulApi, agentApi, setHost), prefix)
 
-  def lookup(
-    dcName: String,
-    svcKey: SvcKey,
-    id: Path,
-    residual: Path
-  ): Activity[NameTree[Name]] = {
-    log.debug("consul lookup: %s %s", id.show)
-    domain.flatMap { domain =>
-      Activity(Dc.get(dcName, domain).services).map { services =>
-        log.debug("consul dc %s initial state: %s", dcName, services.keys.mkString(", "))
+  def untagged(
+    prefix: Path,
+    consulApi: v1.ConsulApi,
+    agentApi: v1.AgentApi,
+    setHost: Boolean = false
+  ): Namer = new Untagged(Base(consulApi, agentApi, setHost), prefix)
+
+  private[this] class Tagged(base: Base, prefix: Path) extends Namer {
+
+    def lookup(path: Path): Activity[NameTree[Name]] =
+      path.take(3) match {
+        case id@Path.Utf8(dc, tag, service) =>
+          val k = SvcKey(service, Some(tag))
+          base.lookup(dc, k, prefix ++ id, path.drop(3))
+
+        case _ => Activity.value(NameTree.Neg)
+      }
+  }
+
+  private[this] class Untagged(base: Base, prefix: Path) extends Namer {
+
+    def lookup(path: Path): Activity[NameTree[Name]] =
+      path.take(2) match {
+        case id@Path.Utf8(dc, service) =>
+          val k = SvcKey(service, None)
+          base.lookup(dc, k, prefix ++ id, path.drop(2))
+
+        case _ => Activity.value(NameTree.Neg)
+      }
+  }
+
+  private[this] case class Base(
+    consulApi: v1.ConsulApi,
+    agentApi: v1.AgentApi,
+    setHost: Boolean = false
+  ) {
+
+    def lookup(
+      dcName: String,
+      svcKey: SvcKey,
+      id: Path,
+      residual: Path
+    ): Activity[NameTree[Name]] = {
+      log.debug("consul lookup: %s %s", id.show)
+      watchDc(dcName).map { services =>
         services.get(svcKey) match {
           case None =>
             log.debug("consul dc %s service %s missing", dcName, svcKey)
             NameTree.Neg
 
-          case Some(service) =>
+          case Some(addr) =>
             log.debug("consul ns %s service %s found + %s", dcName, svcKey, residual.show)
-            NameTree.Leaf(Name.Bound(service.addrs, id, residual))
+            NameTree.Leaf(Name.Bound(addr, id, residual))
         }
       }
     }
-  }
 
-  private[this] lazy val domain: Activity[Option[String]] =
-    if (setHost) {
-      Activity.future(agentApi.localAgent(retry = true)).map { la =>
-        val dom = la.Config.flatMap(_.Domain).getOrElse("consul")
-        Some(dom.stripPrefix(".").stripSuffix("."))
+    private[this] lazy val domain: Activity[Option[String]] =
+      if (setHost) {
+        Activity.future(agentApi.localAgent(retry = true)).map { la =>
+          val dom = la.Config.flatMap(_.Domain).getOrElse("consul")
+          Some(dom.stripPrefix(".").stripSuffix("."))
+        }
+      } else Activity.value(None)
+
+    protected[this] def watchDc(dc: String): Activity[Map[SvcKey, Var[Addr]]] =
+      domain.flatMap { domain =>
+        Activity(Dc.get(dc, domain).services).map(_.mapValues(_.addrs))
       }
-    } else Activity.value(None)
-
-  /**
-   * Contains all cached responses from the Consul API
-   */
-  private[this] object Dc {
-    private[this] val activity: ActUp[Map[String, DcCache]] =
-      Var(Activity.Pending)
 
     /**
-     * Returns existing datacenter cache with that name
-     * or creates a new one
+     * Contains all cached responses from the Consul API
      */
-    def get(name: String, domain: Option[String]): DcCache =
-      synchronized {
-        activity.sample() match {
-          case Activity.Ok(snap) => snap.getOrElse(name, mkAndUpdate(snap, name, domain))
-          case _ => mkAndUpdate(Map.empty, name, domain)
-        }
-      }
+    private[this] object Dc {
+      private[this] val activity: ActUp[Map[String, DcCache]] =
+        Var(Activity.Pending)
 
-    private[this] def mkAndUpdate(
-      cache: Map[String, DcCache],
-      name: String,
-      domain: Option[String]
-    ): DcCache = {
-      val dc = new DcCache(consulApi, name, domain)
-      activity() = Activity.Ok(cache + (name -> dc))
-      dc
+      /**
+       * Returns existing datacenter cache with that name
+       * or creates a new one
+       */
+      def get(name: String, domain: Option[String]): DcCache =
+        synchronized {
+          activity.sample() match {
+            case Activity.Ok(snap) => snap.getOrElse(name, mkAndUpdate(snap, name, domain))
+            case _ => mkAndUpdate(Map.empty, name, domain)
+          }
+        }
+
+      private[this] def mkAndUpdate(
+        cache: Map[String, DcCache],
+        name: String,
+        domain: Option[String]
+      ): DcCache = {
+        val dc = new DcCache(consulApi, name, domain)
+        activity() = Activity.Ok(cache + (name -> dc))
+        dc
+      }
     }
   }
+
 }

--- a/namer/consul/src/main/scala/io/buoyant/namer/consul/DcCache.scala
+++ b/namer/consul/src/main/scala/io/buoyant/namer/consul/DcCache.scala
@@ -1,0 +1,112 @@
+package io.buoyant.namer.consul
+
+import com.twitter.finagle._
+import com.twitter.util._
+import io.buoyant.consul._
+import io.buoyant.consul.v1.{ServiceNode, UnexpectedResponse}
+import io.buoyant.namer.Metadata
+
+/**
+ * Contains all cached serviceMap responses and the mapping of names
+ * to SvcCaches for a particular datacenter.
+ */
+private[consul] class DcCache(
+  consulApi: v1.ConsulApi,
+  agentApi: v1.AgentApi,
+  name: String,
+  activity: ActUp[Map[SvcKey, SvcCache]],
+  setHost: Boolean
+) {
+
+  def services: Var[Activity.State[Map[SvcKey, SvcCache]]] = activity
+
+  private[this] var index = "0"
+  val running =
+    mkRequest().flatMap { svcKeys =>
+      val services = svcKeys.map { k => k -> mkSvc(k) }.toMap
+      synchronized {
+        activity() = Activity.Ok(services)
+      }
+      mkRequest().flatMap(update)
+    }.handle {
+      case e: UnexpectedResponse => activity() = Activity.Ok(Map.empty)
+      case e: Throwable => activity() = Activity.Failed(e)
+    }
+
+  private[this] def setIndex(idx: Option[String]) = idx match {
+    case None =>
+    case Some(idx) =>
+      index = idx
+  }
+
+  def mkRequest(): Future[Seq[SvcKey]] =
+    consulApi
+      .serviceMap(datacenter = Some(name), blockingIndex = Some(index), retry = true)
+      .map { indexedSvcs =>
+        setIndex(indexedSvcs.index)
+        indexedSvcs.value.flatMap {
+          case (svcName, tags) =>
+            tags.map(tag => SvcKey(svcName, Some(tag))) :+ SvcKey(svcName, None)
+        }.toSeq
+      }
+
+  def clear(): Unit = synchronized {
+    activity.sample() match {
+      case Activity.Ok(snap) =>
+        for (svc <- snap.values) {
+          svc.clear()
+        }
+      case _ =>
+    }
+    activity() = Activity.Pending
+  }
+
+  def update(serviceKeys: Seq[SvcKey]): Future[Unit] = {
+    synchronized {
+      val svcs = services.sample() match {
+        case Activity.Ok(svcs) => svcs
+        case _ => Map.empty[SvcKey, SvcCache]
+      }
+
+      serviceKeys.foreach { key =>
+        if (!svcs.contains(key))
+          add(key)
+      }
+
+      svcs.foreach {
+        case (key, _) =>
+          if (!serviceKeys.contains(key))
+            delete(key)
+      }
+    }
+
+    mkRequest().flatMap(update)
+  }
+
+  private[this] def mkSvc(svcKey: SvcKey): SvcCache =
+    SvcCache(consulApi, agentApi, name, svcKey, Var(Addr.Pending), setHost)
+
+  private[this] def add(serviceKey: SvcKey): Unit = {
+    log.debug("consul added: %s", serviceKey)
+    val svcs = services.sample() match {
+      case Activity.Ok(svcs) => svcs
+      case _ => Map.empty[SvcKey, SvcCache]
+    }
+    activity() = Activity.Ok(svcs + (serviceKey -> mkSvc(serviceKey)))
+  }
+
+  private[this] def delete(serviceKey: SvcKey): Unit = {
+    log.debug("consul deleted: %s", serviceKey)
+    val svcs = services.sample() match {
+      case Activity.Ok(svcs) => svcs
+      case _ => Map.empty[SvcKey, SvcCache]
+    }
+    svcs.get(serviceKey) match {
+      case Some(svc) =>
+        svc.clear()
+        activity() = Activity.Ok(svcs - serviceKey)
+      case _ =>
+    }
+  }
+
+}

--- a/namer/consul/src/main/scala/io/buoyant/namer/consul/DcCache.scala
+++ b/namer/consul/src/main/scala/io/buoyant/namer/consul/DcCache.scala
@@ -2,9 +2,7 @@ package io.buoyant.namer.consul
 
 import com.twitter.finagle._
 import com.twitter.util._
-import io.buoyant.consul._
-import io.buoyant.consul.v1.{Indexed, ServiceNode, UnexpectedResponse}
-import io.buoyant.namer.Metadata
+import io.buoyant.consul.v1
 
 /**
  * Contains all cached serviceMap responses and the mapping of names
@@ -28,8 +26,8 @@ private[consul] class DcCache(
       index = idx
   }
 
-  private[this] val indexed: Indexed[Map[String, Seq[String]]] => Set[SvcKey] = {
-    case Indexed(services, idx) =>
+  private[this] val indexed: v1.Indexed[Map[String, Seq[String]]] => Set[SvcKey] = {
+    case v1.Indexed(services, idx) =>
       setIndex(idx)
       services.flatMap {
         case (svcName, tags) =>
@@ -86,9 +84,9 @@ private[consul] class DcCache(
   }
 
   private[this] def mkSvc(svcKey: SvcKey): SvcCache =
-    SvcCache(consulApi, name, svcKey, domain)
+    new SvcCache(consulApi, name, svcKey, domain)
 
-  val running: Future[Unit] =
+  private[this] val running: Future[Unit] =
     mkRequest().flatMap { svcKeys =>
       val services = svcKeys.map { k => k -> mkSvc(k) }.toMap
       synchronized {
@@ -96,7 +94,7 @@ private[consul] class DcCache(
       }
       mkRequest().flatMap(update)
     }.handle {
-      case e: UnexpectedResponse => activity() = Activity.Ok(Map.empty)
+      case e: v1.UnexpectedResponse => activity() = Activity.Ok(Map.empty)
       case e: Throwable => activity() = Activity.Failed(e)
     }
 

--- a/namer/consul/src/main/scala/io/buoyant/namer/consul/LookupCache.scala
+++ b/namer/consul/src/main/scala/io/buoyant/namer/consul/LookupCache.scala
@@ -1,0 +1,79 @@
+package io.buoyant.namer.consul
+
+import com.twitter.finagle._
+import com.twitter.util._
+import io.buoyant.consul.v1
+
+/**
+ * A helper supporting service resolution in consul, caching results
+ * and watching for new updates.
+ */
+private[consul] class LookupCache(
+  consulApi: v1.ConsulApi,
+  agentApi: v1.AgentApi,
+  setHost: Boolean = false
+) {
+
+  def apply(
+    dcName: String,
+    svcKey: SvcKey,
+    id: Path,
+    residual: Path
+  ): Activity[NameTree[Name]] = {
+    log.debug("consul lookup: %s %s", id.show)
+    watchDc(dcName).map { services =>
+      services.get(svcKey) match {
+        case None =>
+          log.debug("consul dc %s service %s missing", dcName, svcKey)
+          NameTree.Neg
+
+        case Some(addr) =>
+          log.debug("consul ns %s service %s found + %s", dcName, svcKey, residual.show)
+          NameTree.Leaf(Name.Bound(addr, id, residual))
+      }
+    }
+  }
+
+  private[this] lazy val domain: Activity[Option[String]] =
+    if (setHost) {
+      Activity.future(agentApi.localAgent(retry = true)).map { la =>
+        val dom = la.Config.flatMap(_.Domain).getOrElse("consul")
+        Some(dom.stripPrefix(".").stripSuffix("."))
+      }
+    } else Activity.value(None)
+
+  protected[this] def watchDc(dc: String): Activity[Map[SvcKey, Var[Addr]]] =
+    domain.flatMap { domain =>
+      Activity(Dc.get(dc, domain).services).map(_.mapValues(_.addrs))
+    }
+
+  /**
+   * Contains all cached responses from the Consul API
+   */
+  private[this] object Dc {
+    private[this] val activity: ActUp[Map[String, DcCache]] =
+      Var(Activity.Pending)
+
+    /**
+     * Returns existing datacenter cache with that name
+     * or creates a new one
+     */
+    def get(name: String, domain: Option[String]): DcCache =
+      synchronized {
+        activity.sample() match {
+          case Activity.Ok(snap) => snap.getOrElse(name, mkAndUpdate(snap, name, domain))
+          case _ => mkAndUpdate(Map.empty, name, domain)
+        }
+      }
+
+    private[this] def mkAndUpdate(
+      cache: Map[String, DcCache],
+      name: String,
+      domain: Option[String]
+    ): DcCache = {
+      val dc = new DcCache(consulApi, name, domain)
+      activity() = Activity.Ok(cache + (name -> dc))
+      dc
+    }
+  }
+}

--- a/namer/consul/src/main/scala/io/buoyant/namer/consul/SvcCache.scala
+++ b/namer/consul/src/main/scala/io/buoyant/namer/consul/SvcCache.scala
@@ -1,0 +1,102 @@
+package io.buoyant.namer.consul
+
+import com.twitter.finagle._
+import com.twitter.util._
+import io.buoyant.consul._
+import io.buoyant.consul.v1.{ServiceNode, UnexpectedResponse}
+import io.buoyant.namer.Metadata
+
+private[consul] case class SvcKey(name: String, tag: Option[String]) {
+  override def toString = tag match {
+    case Some(t) => s"$name:$t"
+    case None => name
+  }
+}
+
+/**
+ * Contains all cached serviceNodes responses for a particular serviceName
+ * in a particular datacenter
+ */
+private[consul] case class SvcCache(
+  catalogApi: v1.ConsulApi,
+  agentApi: v1.AgentApi,
+  datacenter: String,
+  key: SvcKey,
+  updateableAddr: VarUp[Addr],
+  setHost: Boolean
+) {
+
+  def addrs: VarUp[Addr] = updateableAddr
+
+  var index = "0"
+  val _ = init()
+
+  def setIndex(idx: String) = {
+    index = idx
+  }
+
+  def mkRequest(): Future[Seq[ServiceNode]] =
+    catalogApi
+      .serviceNodes(key.name, datacenter = Some(datacenter), tag = key.tag, blockingIndex = Some(index), retry = true)
+      .map { indexedNodes =>
+        indexedNodes.index.foreach(setIndex)
+        indexedNodes.value
+      }
+
+  def clear(): Unit = synchronized {
+    updateableAddr() = Addr.Pending
+  }
+
+  def init(): Future[Unit] = mkRequest().flatMap(update).handle(handleUnexpected)
+
+  def serviceNodeToAddr(node: ServiceNode): Option[Address] = {
+    (node.Address, node.ServiceAddress, node.ServicePort) match {
+      case (_, Some(serviceIp), Some(port)) if !serviceIp.isEmpty =>
+        Some(Address(serviceIp, port))
+      case (Some(nodeIp), _, Some(port)) if !nodeIp.isEmpty =>
+        Some(Address(nodeIp, port))
+      case _ => None
+    }
+  }
+
+  private[this] def domainFuture(): Future[String] =
+    agentApi.localAgent().map { la =>
+      la.Config.flatMap(_.Domain).getOrElse("consul")
+        .stripPrefix(".").stripSuffix(".")
+    }
+
+  def update(nodes: Seq[ServiceNode]): Future[Unit] = {
+    val metaFuture =
+      if (setHost)
+        domainFuture().map { domain =>
+          val authority = key.tag match {
+            case Some(tag) => s"$tag.${key.name}.service.$datacenter.$domain"
+            case None => s"${key.name}.service.$datacenter.$domain"
+          }
+          Addr.Metadata(Metadata.authority -> authority)
+        }
+      else
+        Future.value(Addr.Metadata.empty)
+
+    metaFuture.flatMap { meta =>
+      synchronized {
+        try {
+          val socketAddrs = nodes.flatMap(serviceNodeToAddr).toSet
+          updateableAddr() = if (socketAddrs.isEmpty) Addr.Neg else Addr.Bound(socketAddrs, meta)
+        } catch {
+          // in the event that we are trying to parse an invalid addr
+          case e: IllegalArgumentException =>
+            updateableAddr() = Addr.Failed(e)
+        }
+      }
+      mkRequest().flatMap(update).handle(handleUnexpected)
+    }
+  }
+
+  val handleUnexpected: PartialFunction[Throwable, Unit] = {
+    case e: ChannelClosedException =>
+      log.error(s"""lost consul connection while querying for $datacenter/$key updates""")
+    case e: Throwable =>
+      updateableAddr() = Addr.Failed(e)
+  }
+}

--- a/namer/consul/src/main/scala/io/buoyant/namer/consul/package.scala
+++ b/namer/consul/src/main/scala/io/buoyant/namer/consul/package.scala
@@ -1,0 +1,10 @@
+package io.buoyant.namer
+
+import com.twitter.logging.Logger
+import com.twitter.util.{Activity, Updatable, Var}
+
+package object consul {
+  private[consul]type VarUp[T] = Var[T] with Updatable[T]
+  private[consul]type ActUp[T] = VarUp[Activity.State[T]]
+  val log = Logger.get("io.buoyant.namer.consul")
+}

--- a/namer/consul/src/test/scala/io/buoyant/namer/consul/ConsulNamerTest.scala
+++ b/namer/consul/src/test/scala/io/buoyant/namer/consul/ConsulNamerTest.scala
@@ -27,9 +27,11 @@ class ConsulNamerTest extends FunSuite with Awaits {
     case Activity.Ok(NameTree.Leaf(bound: Name.Bound)) =>
       bound.addr.sample() match {
         case Addr.Bound(addrs, metadata) => f(addrs, metadata)
-        case _ => assert(false)
+        case Addr.Failed(e) => throw e
+        case addr => fail(s"unexpected addr: $addr")
       }
-    case _ => assert(false)
+    case Activity.Failed(e) => throw e
+    case state => fail(s"unexpected state: $state")
   }
 
   class TestAgentApi(domain: String) extends AgentApi(null, "/v1") {

--- a/namer/consul/src/test/scala/io/buoyant/namer/consul/ConsulNamerTest.scala
+++ b/namer/consul/src/test/scala/io/buoyant/namer/consul/ConsulNamerTest.scala
@@ -47,11 +47,10 @@ class ConsulNamerTest extends FunSuite with Awaits {
         retry: Boolean = false
       ): Future[Indexed[Map[String, Seq[String]]]] = Future.never
     }
-    val namer = new ConsulNamer(
+    val namer = ConsulNamer.untagged(
       testPath,
       new TestCatalogApi(),
       new TestAgentApi("acme.co"),
-      includeTag = false,
       setHost = false
     )
     @volatile var state: Activity.State[NameTree[Name]] = Activity.Pending
@@ -69,7 +68,7 @@ class ConsulNamerTest extends FunSuite with Awaits {
         retry: Boolean = false
       ): Future[Indexed[Map[String, Seq[String]]]] = Future.exception(ChannelWriteException(null))
     }
-    val namer = new ConsulNamer(testPath, new TestApi(), new TestAgentApi("acme.co"), false, false)
+    val namer = ConsulNamer.untagged(testPath, new TestApi(), new TestAgentApi("acme.co"))
     @volatile var state: Activity.State[NameTree[Name]] = Activity.Pending
 
     namer.lookup(Path.read("/dc1/servicename/residual")).states respond { state = _ }
@@ -99,7 +98,7 @@ class ConsulNamerTest extends FunSuite with Awaits {
         case _ => Future.never //don't respond to blocking index calls
       }
     }
-    val namer = new ConsulNamer(testPath, new TestApi(), new TestAgentApi("acme.co"), false, false)
+    val namer = ConsulNamer.untagged(testPath, new TestApi(), new TestAgentApi("acme.co"))
     @volatile var state: Activity.State[NameTree[Name]] = Activity.Pending
 
     namer.lookup(Path.read("/nosuchdc/servicename/residual")).states respond { state = _ }
@@ -129,7 +128,7 @@ class ConsulNamerTest extends FunSuite with Awaits {
         case _ => Future.never //don't respond to blocking index calls
       }
     }
-    val namer = new ConsulNamer(testPath, new TestApi(), new TestAgentApi("acme.co"), false, false)
+    val namer = ConsulNamer.untagged(testPath, new TestApi(), new TestAgentApi("acme.co"))
     @volatile var state: Activity.State[NameTree[Name]] = Activity.Pending
 
     namer.lookup(Path.read("/dc1/nosuchservice/residual")).states respond { state = _ }
@@ -164,7 +163,7 @@ class ConsulNamerTest extends FunSuite with Awaits {
         case _ => Future.never //don't respond to blocking index calls
       }
     }
-    val namer = new ConsulNamer(testPath, new TestApi(), new TestAgentApi("acme.co"), false, false)
+    val namer = ConsulNamer.untagged(testPath, new TestApi(), new TestAgentApi("acme.co"))
     @volatile var state: Activity.State[NameTree[Name]] = Activity.Pending
 
     namer.lookup(Path.read("/dc1/servicename/residual")).states respond { state = _ }
@@ -202,11 +201,10 @@ class ConsulNamerTest extends FunSuite with Awaits {
       }
     }
 
-    val namer = new ConsulNamer(
+    val namer = ConsulNamer.untagged(
       Path.read("/test"),
       new TestApi(),
       new TestAgentApi("acme.co"),
-      includeTag = false,
       setHost = false
     )
     @volatile var state: Activity.State[NameTree[Name]] = Activity.Pending
@@ -248,11 +246,10 @@ class ConsulNamerTest extends FunSuite with Awaits {
       }
     }
 
-    val namer = new ConsulNamer(
+    val namer = ConsulNamer.untagged(
       Path.read("/test"),
       new TestApi(),
       new TestAgentApi("acme.co"),
-      includeTag = false,
       setHost = false
     )
     @volatile var state: Activity.State[NameTree[Name]] = Activity.Pending
@@ -298,11 +295,10 @@ class ConsulNamerTest extends FunSuite with Awaits {
       }
     }
 
-    val namer = new ConsulNamer(
+    val namer = ConsulNamer.tagged(
       Path.read("/test"),
       new TestApi(),
       new TestAgentApi("acme.co"),
-      includeTag = true,
       setHost = false
     )
     @volatile var state: Activity.State[NameTree[Name]] = Activity.Pending
@@ -340,7 +336,7 @@ class ConsulNamerTest extends FunSuite with Awaits {
       }
     }
 
-    val namer = new ConsulNamer(
+    val namer = ConsulNamer.untagged(
       Path.read("/test"),
       new TestApi(),
       new TestAgentApi("consul.acme.co"),
@@ -384,11 +380,10 @@ class ConsulNamerTest extends FunSuite with Awaits {
       }
     }
 
-    val namer = new ConsulNamer(
+    val namer = ConsulNamer.tagged(
       Path.read("/test"),
       new TestApi(),
       new TestAgentApi("consul.acme.co"),
-      includeTag = true,
       setHost = true
     )
     @volatile var state: Activity.State[NameTree[Name]] = Activity.Pending


### PR DESCRIPTION
* Split ConsulNamer into several separate classes.  It was a lot in one file, especially the caching layers.
* Fix cache `index` thread safety
* Eliminate redundant `localAgent()` lookups; use retries for localAgent lookups.
* Eliminate lookup-time checks for tag naming.  Instead, choose the appropriate namer at configuration-time.
* Use the most restrictive access modifiers to help reason about scope.
* Reduce allocations where possible.

This change is staged in several commits.  It may be more helpful to review them in order:
```
commit 25cbb6849aeb4c5dc09e33b3cb79a1ec55b98e74
Author: Oliver Gould <ver@buoyant.io>
Date:   Wed Sep 7 03:05:48 2016 +0000

    Move SvcCache and DcCache into their own files.
    
    The consul namer is a little difficult to reason about as one big intermingled
    class. We begin to simplify this by moving DcCache and SvcCache into their own
    package-local classes.
```

```
commit 4b86b9dd69dc673716a2320696c8b53b2c587fb2
Author: Oliver Gould <ver@buoyant.io>
Date:   Wed Sep 7 04:28:21 2016 +0000

    Stop issuing redundant local agent requests.
    
    Previously, the domain was resolved from consul on every service addition.
    Instead, this should be modeled as a single activity that is
    
    Furthermore, on DcCache updates, the dc cache was updated for each individual
    service addition and removal.  Instead, we batch the DC update to be only once
    per API response.
    
    Furthermore, access & update of `index` variables was not thread safe for
    visibility. `index` should ve volatile.
    
    Finally, some minor allocation improvements were made:
    - val'ing some anonymous functions, where convenient
    - Only build address metadata for bound addresses
```

```
commit 495af8bcc885b8daeba88a812e7f55f89f4ee7d8
Author: Oliver Gould <ver@buoyant.io>
Date:   Wed Sep 7 05:27:57 2016 +0000

    Split ConsulNamer into Tagged, Untagged, and Base.
    
    The ConsulNamer doesn't need to determine whether a tag should be included on
    each and every lookup. Instead, we can determine this once at
    configuration-time and construct a Namer that is statically configured to
    produce service keys.
    
    ConsulNamer.Base has all of the common logic shared between namer
    implementations.
```

```
commit 6c24defcfdc74b0e9ea51b88b0871a98d67f8b8a
Author: Oliver Gould <ver@buoyant.io>
Date:   Wed Sep 7 06:26:23 2016 +0000

    ConsulNamer.Base => LookupCache
```