### PR TITLE
Disable endpoint probation by default

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -4,6 +4,9 @@
   retryable when it has a chunked request body.
 * Add `useHealthCheck` parameter to Consul Namer #589
 * Configured namers are now available to other plugins
+* `enableProbation` is now disabled by default on clients. It leads to
+  unexpected behavior in environments that reuse IP:PORT pairs across
+  services in a close time proximity.
 
 ## 0.7.4
 

--- a/linkerd/core/src/main/scala/io/buoyant/linkerd/LoadBalancerConfig.scala
+++ b/linkerd/core/src/main/scala/io/buoyant/linkerd/LoadBalancerConfig.scala
@@ -21,7 +21,7 @@ trait LoadBalancerConfig {
 
   @JsonIgnore
   def clientParams = Stack.Params.empty + LoadBalancerFactory.Param(factory) +
-    LoadBalancerFactory.EnableProbation(enableProbation.getOrElse(true))
+    LoadBalancerFactory.EnableProbation(enableProbation.getOrElse(false))
 }
 
 case class P2C(maxEffort: Option[Int]) extends LoadBalancerConfig {

--- a/linkerd/core/src/test/scala/io/buoyant/linkerd/LoadBalancerTest.scala
+++ b/linkerd/core/src/test/scala/io/buoyant/linkerd/LoadBalancerTest.scala
@@ -15,7 +15,6 @@ class LoadBalancerTest extends FunSuite {
       |  client:
       |    loadBalancer:
       |      kind: $balancer
-      |      enableProbation: false
       |  servers:
       |  - {}
       |""".stripMargin
@@ -26,6 +25,26 @@ class LoadBalancerTest extends FunSuite {
 
       val enableProbation = linker.routers.head.params[LoadBalancerFactory.EnableProbation]
       assert(enableProbation == LoadBalancerFactory.EnableProbation(false))
+    }
+
+    test(balancer + " + enableProbation") {
+      val config = s"""
+      |routers:
+      |- protocol: plain
+      |  client:
+      |    loadBalancer:
+      |      kind: $balancer
+      |      enableProbation: true
+      |  servers:
+      |  - {}
+      |""".stripMargin
+
+      val linker = Linker.load(config, Linker.Initializers(protocol = Seq(TestProtocol.Plain)))
+      val factory = linker.routers.head.params[LoadBalancerFactory.Param]
+      assert(factory.loadBalancerFactory != DefaultBalancerFactory)
+
+      val enableProbation = linker.routers.head.params[LoadBalancerFactory.EnableProbation]
+      assert(enableProbation == LoadBalancerFactory.EnableProbation(true))
     }
   }
 }

--- a/linkerd/docs/load_balancer.md
+++ b/linkerd/docs/load_balancer.md
@@ -19,7 +19,7 @@ These parameters are available to the loadbalancer regardless of kind. The loadb
 Key | Default Value | Description
 --- | ------------- | -----------
 kind | `p2c` | Either `p2c`, `ewma`, `aperture`, or `heap`.
-enableProbation | `true` | If `true`, endpoints are eagerly evicted from service discovery. See Finagle's [LoadBalancerFactory.EnableProbation](https://github.com/twitter/finagle/blob/develop/finagle-core/src/main/scala/com/twitter/finagle/loadbalancer/LoadBalancerFactory.scala#L28).
+enableProbation | `false` | If `true`, endpoints are eagerly evicted from service discovery. See Finagle's [LoadBalancerFactory.EnableProbation](https://github.com/twitter/finagle/blob/develop/finagle-core/src/main/scala/com/twitter/finagle/loadbalancer/LoadBalancerFactory.scala#L28).
 
 [p2c]: https://twitter.github.io/finagle/guide/Clients.html#power-of-two-choices-p2c-least-loaded
 [ewma]: https://twitter.github.io/finagle/guide/Clients.html#power-of-two-choices-p2c-peak-ewma


### PR DESCRIPTION
Probation can be hard to debug in environments like kubernetes and mesos.  Disable it by default to reduce unexpected behavior.