### PR TITLE
Allow routers to be configured with a list of identifiers

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -7,6 +7,8 @@
 * `enableProbation` is now disabled by default on clients. It leads to
   unexpected behavior in environments that reuse IP:PORT pairs across
   services in a close time proximity.
+* Allow routers to be configured with a list of identifiers.  If an identifier
+  cannot assign a dest to a request, it falls back to the next one in the list.
 
 ## 0.7.4
 

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -9,6 +9,8 @@
   services in a close time proximity.
 * Allow routers to be configured with a list of identifiers.  If an identifier
   cannot assign a dest to a request, it falls back to the next one in the list.
+  * **Breaking Change**: Identifier plugins must now return a
+    `RequestIdentification` object.
 
 ## 0.7.4
 

--- a/linkerd/core/src/test/scala/io/buoyant/linkerd/TestProtocol.scala
+++ b/linkerd/core/src/test/scala/io/buoyant/linkerd/TestProtocol.scala
@@ -10,6 +10,7 @@ import com.twitter.finagle.stack.Endpoint
 import com.twitter.util.Future
 import io.buoyant.linkerd.TestProtocol.FancyParam
 import io.buoyant.config.Parser
+import io.buoyant.router.RoutingFactory.IdentifiedRequest
 import io.buoyant.router.{RoutingFactory, StackRouter, StdStackRouter}
 import java.net.SocketAddress
 
@@ -76,7 +77,7 @@ abstract class TestProtocol(val name: String) extends ProtocolInitializer.Simple
       val RoutingFactory.BaseDtab(dtab) = params[RoutingFactory.BaseDtab]
       val RoutingFactory.DstPrefix(pfx) = params[RoutingFactory.DstPrefix]
       val path = pfx ++ Path.read(req)
-      Future.value((Dst.Path(path, dtab(), Dtab.local), req))
+      Future.value(new IdentifiedRequest[String](Dst.Path(path, dtab(), Dtab.local), req))
     }
   }
 

--- a/linkerd/docs/protocol-http.md
+++ b/linkerd/docs/protocol-http.md
@@ -46,7 +46,7 @@ Key | Default Value | Description
 --- | ------------- | -----------
 dstPrefix | `http` | A path prefix used by [Http-specific identifiers](#http-1-1-identifiers).
 httpAccessLog | none | Sets the access log path.  If not specified, no access log is written.
-identifier | `io.l5d.methodAndHost` | See [Http-specific identifiers](#http-1-1-identifiers).
+identifier | The `methodAndHost` identifier | An identifier or list of identifiers.  See [Http-specific identifiers](#http-1-1-identifiers).
 maxChunkKB | 8KB | The maximum size of an HTTP chunk.
 maxHeadersKB | 8KB | The maximum size of all headers in an HTTP message.
 maxInitialLineKB | 4KB | The maximum size of an initial HTTP message line.
@@ -66,7 +66,9 @@ significantly alter linkerd's performance characteristics.
 Identifiers are responsible for creating logical *names* from an incoming
 request; these names are then matched against the dtab. (See the [linkerd
 routing overview](https://linkerd.io/doc/latest/routing/) for more details on
-this.) All HTTP/1.1 identifiers have a `kind`.
+this.) All HTTP/1.1 identifiers have a `kind`.  If a list of identifiers is
+provided, each identifier is tried in turn until one successfully assigns a
+logical *name* to the request.
 
 Key | Default Value | Description
 --- | ------------- | -----------

--- a/linkerd/protocol/http/src/main/scala/io/buoyant/linkerd/protocol/HttpConfig.scala
+++ b/linkerd/protocol/http/src/main/scala/io/buoyant/linkerd/protocol/HttpConfig.scala
@@ -169,6 +169,6 @@ case class HttpConfig(
 }
 
 object HttpConfig {
-  val NilIdentification: Future[RequestIdentification[Request]] =
+  private val NilIdentification: Future[RequestIdentification[Request]] =
     Future.value(new UnidentifiedRequest("no identifiers"))
 }

--- a/linkerd/protocol/http/src/main/scala/io/buoyant/linkerd/protocol/HttpConfig.scala
+++ b/linkerd/protocol/http/src/main/scala/io/buoyant/linkerd/protocol/HttpConfig.scala
@@ -89,6 +89,7 @@ case class HttpServerConfig(
   }
 }
 
+// Cribbed from https://gist.github.com/Aivean/6bb90e3942f3bf966608
 class HttpIdentifierConfigDeserializer extends JsonDeserializer[Option[Seq[HttpIdentifierConfig]]] {
   override def deserialize(p: JsonParser, ctxt: DeserializationContext): Option[Seq[HttpIdentifierConfig]] = {
     val codec = p.getCodec

--- a/linkerd/protocol/http/src/test/scala/io/buoyant/linkerd/protocol/http/ErrorResponderTest.scala
+++ b/linkerd/protocol/http/src/test/scala/io/buoyant/linkerd/protocol/http/ErrorResponderTest.scala
@@ -13,7 +13,7 @@ import org.scalatest.FunSuite
 class ErrorResponderTest extends FunSuite with Awaits {
 
   val svc = Service.mk[Request, Response] { _ =>
-    Future.exception(RoutingFactory.UnknownDst(Request(), new Exception(s"foo\nbar")))
+    Future.exception(RoutingFactory.UnknownDst(Request(), s"foo\nbar"))
   }
   val stk = ErrorResponder.module.toStack(
     Stack.Leaf(Stack.Role("endpoint"), ServiceFactory.const(svc))

--- a/linkerd/protocol/http/src/test/scala/io/buoyant/linkerd/protocol/http/HttpConfigTest.scala
+++ b/linkerd/protocol/http/src/test/scala/io/buoyant/linkerd/protocol/http/HttpConfigTest.scala
@@ -6,6 +6,7 @@ import io.buoyant.config.Parser
 import io.buoyant.linkerd.RouterConfig
 import io.buoyant.linkerd.protocol.{HttpConfig, HttpInitializer}
 import io.buoyant.router.Http
+import io.buoyant.router.RoutingFactory.IdentifiedRequest
 import io.buoyant.test.Awaits
 import org.scalatest.FunSuite
 
@@ -44,7 +45,10 @@ class HttpConfigTest extends FunSuite with Awaits {
       .id(Path.read("/http"), () => Dtab.empty)
     val req = Request(Method.Get, "/one/two/three")
     req.host = "host.com"
-    assert(await(identifier(req))._1.path == Path.read("/http/1.1/GET/host.com"))
+    assert(
+      await(identifier(req)).asInstanceOf[IdentifiedRequest[Request]].dst.path ==
+        Path.read("/http/1.1/GET/host.com")
+    )
   }
 
   test("single identifier") {
@@ -60,7 +64,10 @@ class HttpConfigTest extends FunSuite with Awaits {
       .id(Path.read("/http"), () => Dtab.empty)
     val req = Request(Method.Get, "/one/two/three")
     req.host = "host.com"
-    assert(await(identifier(req))._1.path == Path.read("/http/1.1/GET/host.com"))
+    assert(
+      await(identifier(req)).asInstanceOf[IdentifiedRequest[Request]].dst.path ==
+        Path.read("/http/1.1/GET/host.com")
+    )
   }
 
   test("identifier list") {
@@ -77,7 +84,10 @@ class HttpConfigTest extends FunSuite with Awaits {
       .id(Path.read("/http"), () => Dtab.empty)
     val req = Request(Method.Get, "/one/two/three")
     req.host = "host.com"
-    assert(await(identifier(req))._1.path == Path.read("/http/1.1/GET/host.com"))
+    assert(
+      await(identifier(req)).asInstanceOf[IdentifiedRequest[Request]].dst.path ==
+        Path.read("/http/1.1/GET/host.com")
+    )
   }
 
   test("identifier list with fallback") {
@@ -93,6 +103,9 @@ class HttpConfigTest extends FunSuite with Awaits {
     val identifier = config.routerParams[Http.param.HttpIdentifier]
       .id(Path.read("/http"), () => Dtab.empty)
     val req = Request(Method.Get, "/one/two/three")
-    assert(await(identifier(req))._1.path == Path.read("/http/one"))
+    assert(
+      await(identifier(req)).asInstanceOf[IdentifiedRequest[Request]].dst.path ==
+        Path.read("/http/one")
+    )
   }
 }

--- a/linkerd/protocol/http/src/test/scala/io/buoyant/linkerd/protocol/http/HttpConfigTest.scala
+++ b/linkerd/protocol/http/src/test/scala/io/buoyant/linkerd/protocol/http/HttpConfigTest.scala
@@ -1,0 +1,98 @@
+package io.buoyant.linkerd.protocol.http
+
+import com.twitter.finagle.http.{Method, Request}
+import com.twitter.finagle.{Dtab, Path}
+import io.buoyant.config.Parser
+import io.buoyant.linkerd.RouterConfig
+import io.buoyant.linkerd.protocol.{HttpConfig, HttpInitializer}
+import io.buoyant.router.Http
+import io.buoyant.test.Awaits
+import org.scalatest.FunSuite
+
+class HttpConfigTest extends FunSuite with Awaits {
+
+  def parse(yaml: String): HttpConfig = {
+    val mapper = Parser.objectMapper(yaml, Iterable(Seq(HttpInitializer), Seq(MethodAndHostIdentifierInitializer, PathIdentifierInitializer)))
+    mapper.readValue[RouterConfig](yaml).asInstanceOf[HttpConfig]
+  }
+
+  test("parse config") {
+    val yaml = s"""
+                  |protocol: http
+                  |httpAccessLog: access.log
+                  |identifier:
+                  |  kind: io.l5d.methodAndHost
+                  |maxChunkKB: 8KB
+                  |maxHeadersKB: 8KB
+                  |maxInitialLineKB: 4KB
+                  |maxRequestKB: 5MB
+                  |maxResponseKB: 5MB
+                  |servers:
+                  |- port: 5000
+      """.stripMargin
+    val _ = parse(yaml)
+  }
+
+  test("default to methodAndHost identifier") {
+    val yaml = s"""
+                  |protocol: http
+                  |servers:
+                  |- port: 5000
+      """.stripMargin
+    val config = parse(yaml)
+    val identifier = config.routerParams[Http.param.HttpIdentifier]
+      .id(Path.read("/http"), () => Dtab.empty)
+    val req = Request(Method.Get, "/one/two/three")
+    req.host = "host.com"
+    assert(await(identifier(req))._1.path == Path.read("/http/1.1/GET/host.com"))
+  }
+
+  test("single identifier") {
+    val yaml = s"""
+                  |protocol: http
+                  |identifier:
+                  |  kind: io.l5d.methodAndHost
+                  |servers:
+                  |- port: 5000
+      """.stripMargin
+    val config = parse(yaml)
+    val identifier = config.routerParams[Http.param.HttpIdentifier]
+      .id(Path.read("/http"), () => Dtab.empty)
+    val req = Request(Method.Get, "/one/two/three")
+    req.host = "host.com"
+    assert(await(identifier(req))._1.path == Path.read("/http/1.1/GET/host.com"))
+  }
+
+  test("identifier list") {
+    val yaml = s"""
+                  |protocol: http
+                  |identifier:
+                  |- kind: io.l5d.methodAndHost
+                  |- kind: io.l5d.path
+                  |servers:
+                  |- port: 5000
+      """.stripMargin
+    val config = parse(yaml)
+    val identifier = config.routerParams[Http.param.HttpIdentifier]
+      .id(Path.read("/http"), () => Dtab.empty)
+    val req = Request(Method.Get, "/one/two/three")
+    req.host = "host.com"
+    assert(await(identifier(req))._1.path == Path.read("/http/1.1/GET/host.com"))
+  }
+
+  test("identifier list with fallback") {
+    val yaml = s"""
+                  |protocol: http
+                  |identifier:
+                  |- kind: io.l5d.methodAndHost
+                  |- kind: io.l5d.path
+                  |servers:
+                  |- port: 5000
+      """.stripMargin
+    val config = parse(yaml)
+    val identifier = config.routerParams[Http.param.HttpIdentifier]
+      .id(Path.read("/http"), () => Dtab.empty)
+    val req = Request(Method.Get, "/one/two/three")
+    assert(await(identifier(req))._1.path == Path.read("/http/one"))
+  }
+}

--- a/router/core/src/e2e/scala/io/buoyant/router/EchoEndToEndTest.scala
+++ b/router/core/src/e2e/scala/io/buoyant/router/EchoEndToEndTest.scala
@@ -10,6 +10,7 @@ import com.twitter.finagle.stack.nilStack
 import com.twitter.finagle.stats.NullStatsReceiver
 import com.twitter.finagle.tracing.{Annotation, BufferingTracer, Trace, NullTracer}
 import com.twitter.util._
+import io.buoyant.router.RoutingFactory.{IdentifiedRequest, RequestIdentification}
 import io.buoyant.test.Awaits
 import java.net.{InetSocketAddress, SocketAddress}
 import org.scalatest.FunSuite
@@ -174,9 +175,11 @@ object Echo extends Router[String, String] with Server[String, String] {
     case class Identifier(prefix: Path = Path.empty, dtab: () => Dtab = () => Dtab.base)
         extends RoutingFactory.Identifier[String] {
 
-      def apply(req: String): Future[(Dst, String)] = {
+      def apply(req: String): Future[RequestIdentification[String]] = {
         val path = Path.read(if (req startsWith "/") req else s"/$req")
-        Future.value((Dst.Path(prefix ++ path, dtab(), Dtab.local), req))
+        Future.value(
+          new IdentifiedRequest(Dst.Path(prefix ++ path, dtab(), Dtab.local), req)
+        )
       }
     }
 

--- a/router/core/src/main/scala/io/buoyant/router/RoutingFactory.scala
+++ b/router/core/src/main/scala/io/buoyant/router/RoutingFactory.scala
@@ -18,6 +18,7 @@ object RoutingFactory {
 
   /** The result of attempting to identify a request. */
   sealed trait RequestIdentification[Req]
+
   /**
    * This indicates that a destination was successfully assigned.  The attached
    * request should be sent to the destination.
@@ -30,7 +31,7 @@ object RoutingFactory {
 
   object IdentifiedRequest {
     def unapply[Req](identified: IdentifiedRequest[Req]): Option[(Dst, Req)] =
-      Some(identified.dst, identified.request)
+      Some((identified.dst, identified.request))
   }
 
   /**

--- a/router/core/src/test/scala/io/buoyant/router/RouterTest.scala
+++ b/router/core/src/test/scala/io/buoyant/router/RouterTest.scala
@@ -9,6 +9,7 @@ import com.twitter.finagle.stack.{Endpoint, nilStack}
 import com.twitter.finagle.stats.InMemoryStatsReceiver
 import com.twitter.finagle.transport.Transport
 import com.twitter.util.{Activity, Duration, Future, MockTimer, Return, Throw, Time, Try, Var}
+import io.buoyant.router.RoutingFactory.IdentifiedRequest
 import io.buoyant.test.{Exceptions, Awaits}
 import java.util.concurrent.atomic.AtomicInteger
 import org.scalatest.FunSuite
@@ -56,7 +57,7 @@ class RouterTest extends FunSuite with Awaits with Exceptions {
       val RoutingFactory.DstPrefix(pfx) = params[RoutingFactory.DstPrefix]
       val RoutingFactory.BaseDtab(baseDtab) = params[RoutingFactory.BaseDtab]
       in => Future.value(
-        (Dst.Path(pfx ++ Path.Utf8(in), baseDtab(), Dtab.local), in)
+        new IdentifiedRequest[String](Dst.Path(pfx ++ Path.Utf8(in), baseDtab(), Dtab.local), in)
       )
     }
   }

--- a/router/core/src/test/scala/io/buoyant/router/RoutingFactoryTest.scala
+++ b/router/core/src/test/scala/io/buoyant/router/RoutingFactoryTest.scala
@@ -5,6 +5,7 @@ import com.twitter.finagle.buoyant._
 import com.twitter.finagle.tracing.Annotation.{BinaryAnnotation, Rpc}
 import com.twitter.finagle.tracing._
 import com.twitter.util.{Future, Time}
+import io.buoyant.router.RoutingFactory.IdentifiedRequest
 import io.buoyant.test.{Exceptions, Awaits}
 import org.scalatest.FunSuite
 
@@ -39,7 +40,8 @@ class RoutingFactoryTest extends FunSuite with Awaits with Exceptions {
     }
 
   def mkService(
-    pathMk: RoutingFactory.Identifier[Request] = (req: Request) => Future.value((Dst.Path.empty, req)),
+    pathMk: RoutingFactory.Identifier[Request] = (req: Request) =>
+      Future.value(new IdentifiedRequest[Request](Dst.Path.empty, req)),
     cache: DstBindingFactory[Request, Response] = mkClientFactory(),
     label: String = ""
   ) = new RoutingFactory(pathMk, cache, label).toService

--- a/router/http/src/main/scala/io/buoyant/router/http/MethodAndHostIdentifier.scala
+++ b/router/http/src/main/scala/io/buoyant/router/http/MethodAndHostIdentifier.scala
@@ -1,37 +1,37 @@
 package io.buoyant.router.http
 
-import com.twitter.finagle.http.Request
-import com.twitter.finagle.{Dtab, Path, http}
 import com.twitter.finagle.buoyant.Dst
+import com.twitter.finagle.http.{Request, Version}
+import com.twitter.finagle.{Dtab, Path}
 import com.twitter.util.Future
 import io.buoyant.router.RoutingFactory
-import io.buoyant.router.RoutingFactory.{RequestIdentification, UnidentifiedRequest, IdentifiedRequest}
+import io.buoyant.router.RoutingFactory.{IdentifiedRequest, RequestIdentification, UnidentifiedRequest}
 
 object MethodAndHostIdentifier {
   def mk(
     prefix: Path,
     baseDtab: () => Dtab = () => Dtab.base
-  ): RoutingFactory.Identifier[http.Request] = MethodAndHostIdentifier(prefix, false, baseDtab)
+  ): RoutingFactory.Identifier[Request] = MethodAndHostIdentifier(prefix, false, baseDtab)
 }
 
 case class MethodAndHostIdentifier(
   prefix: Path,
   uris: Boolean = false,
   baseDtab: () => Dtab = () => Dtab.base
-) extends RoutingFactory.Identifier[http.Request] {
+) extends RoutingFactory.Identifier[Request] {
 
-  private[this] def suffix(req: http.Request): Path =
+  private[this] def suffix(req: Request): Path =
     if (uris) Path.read(req.path) else Path.empty
 
   private[this] def mkPath(path: Path): Dst.Path =
     Dst.Path(prefix ++ path, baseDtab(), Dtab.local)
 
-  def apply(req: http.Request): Future[RequestIdentification[Request]] = req.version match {
-    case http.Version.Http10 =>
+  def apply(req: Request): Future[RequestIdentification[Request]] = req.version match {
+    case Version.Http10 =>
       val dst = mkPath(Path.Utf8("1.0", req.method.toString) ++ suffix(req))
       Future.value(new IdentifiedRequest(dst, req))
 
-    case http.Version.Http11 =>
+    case Version.Http11 =>
       req.host match {
         case Some(host) if host.nonEmpty =>
           val dst = mkPath(Path.Utf8("1.1", req.method.toString, host) ++ suffix(req))
@@ -39,7 +39,7 @@ case class MethodAndHostIdentifier(
         case _ =>
           Future.value(
             new UnidentifiedRequest(
-              s"${http.Version.Http11} request missing hostname"
+              s"${Version.Http11} request missing hostname"
             )
           )
       }

--- a/router/http/src/main/scala/io/buoyant/router/http/MethodAndHostIdentifier.scala
+++ b/router/http/src/main/scala/io/buoyant/router/http/MethodAndHostIdentifier.scala
@@ -35,17 +35,12 @@ case class MethodAndHostIdentifier(
     case http.Version.Http11 =>
       req.host match {
         case Some(host) if host.nonEmpty =>
-          Future.value(
-            new IdentifiedRequest[Request](
-              mkPath(Path.Utf8("1.1", req.method.toString, host) ++ suffix(req)),
-              req
-            )
-          )
+          val dst = mkPath(Path.Utf8("1.1", req.method.toString, host) ++ suffix(req))
+          Future.value(new IdentifiedRequest(dst, req))
         case _ =>
           Future.value(
             new UnidentifiedRequest[Request](
-              s"${http.Version.Http11} request missing hostname",
-              req
+              s"${http.Version.Http11} request missing hostname"
             )
           )
       }

--- a/router/http/src/main/scala/io/buoyant/router/http/MethodAndHostIdentifier.scala
+++ b/router/http/src/main/scala/io/buoyant/router/http/MethodAndHostIdentifier.scala
@@ -37,7 +37,7 @@ case class MethodAndHostIdentifier(
             (mkPath(Path.Utf8("1.1", req.method.toString, host) ++ suffix(req)), req)
           )
         case _ =>
-          Future.exception(new IllegalArgumentException(s"${http.Version.Http11} request missing hostname: $req"))
+          Future.exception(UnidentifiableRequestException(req, s"${http.Version.Http11} request missing hostname"))
       }
   }
 

--- a/router/http/src/main/scala/io/buoyant/router/http/MethodAndHostIdentifier.scala
+++ b/router/http/src/main/scala/io/buoyant/router/http/MethodAndHostIdentifier.scala
@@ -39,7 +39,7 @@ case class MethodAndHostIdentifier(
           Future.value(new IdentifiedRequest(dst, req))
         case _ =>
           Future.value(
-            new UnidentifiedRequest[Request](
+            new UnidentifiedRequest(
               s"${http.Version.Http11} request missing hostname"
             )
           )

--- a/router/http/src/main/scala/io/buoyant/router/http/MethodAndHostIdentifier.scala
+++ b/router/http/src/main/scala/io/buoyant/router/http/MethodAndHostIdentifier.scala
@@ -28,9 +28,8 @@ case class MethodAndHostIdentifier(
 
   def apply(req: http.Request): Future[RequestIdentification[Request]] = req.version match {
     case http.Version.Http10 =>
-      Future.value(
-        new IdentifiedRequest[Request](mkPath(Path.Utf8("1.0", req.method.toString) ++ suffix(req)), req)
-      )
+      val dst = mkPath(Path.Utf8("1.0", req.method.toString) ++ suffix(req))
+      Future.value(new IdentifiedRequest(dst, req))
 
     case http.Version.Http11 =>
       req.host match {

--- a/router/http/src/main/scala/io/buoyant/router/http/PathIdentifier.scala
+++ b/router/http/src/main/scala/io/buoyant/router/http/PathIdentifier.scala
@@ -24,7 +24,7 @@ case class PathIdentifier(
         Future.value(new IdentifiedRequest[Request](dst, req))
       case _ =>
         Future.value(
-          new UnidentifiedRequest[Request]("not enough segments in path")
+          new UnidentifiedRequest("not enough segments in path")
         )
     }
 }

--- a/router/http/src/main/scala/io/buoyant/router/http/PathIdentifier.scala
+++ b/router/http/src/main/scala/io/buoyant/router/http/PathIdentifier.scala
@@ -1,20 +1,23 @@
 package io.buoyant.router.http
 
-import com.twitter.finagle.http.Request
-import com.twitter.finagle.{Dtab, Path, http}
 import com.twitter.finagle.buoyant.Dst
+import com.twitter.finagle.http.Request
+import com.twitter.finagle.{Dtab, Path}
 import com.twitter.util.Future
 import io.buoyant.router.RoutingFactory
-import io.buoyant.router.RoutingFactory.{UnidentifiedRequest, IdentifiedRequest, RequestIdentification}
+import io.buoyant.router.RoutingFactory.{IdentifiedRequest, RequestIdentification, UnidentifiedRequest}
 
 case class PathIdentifier(
   prefix: Path,
   segments: Int = 1,
   consume: Boolean = false,
   baseDtab: () => Dtab = () => Dtab.base
-) extends RoutingFactory.Identifier[http.Request] {
+) extends RoutingFactory.Identifier[Request] {
 
-  def apply(req: http.Request): Future[RequestIdentification[Request]] =
+  private[this] val TooFewSegments =
+    Future.value(new UnidentifiedRequest[Request]("not enough segments in path"))
+
+  def apply(req: Request): Future[RequestIdentification[Request]] =
     req.path.split("/").drop(1) match {
       case path if path.size >= segments =>
         if (consume) {
@@ -23,8 +26,6 @@ case class PathIdentifier(
         val dst = Dst.Path(prefix ++ Path.Utf8(path.take(segments): _*), baseDtab(), Dtab.local)
         Future.value(new IdentifiedRequest[Request](dst, req))
       case _ =>
-        Future.value(
-          new UnidentifiedRequest("not enough segments in path")
-        )
+        TooFewSegments
     }
 }

--- a/router/http/src/main/scala/io/buoyant/router/http/PathIdentifier.scala
+++ b/router/http/src/main/scala/io/buoyant/router/http/PathIdentifier.scala
@@ -22,6 +22,6 @@ case class PathIdentifier(
           (Dst.Path(prefix ++ Path.Utf8(path.take(segments): _*), baseDtab(), Dtab.local), req)
         )
       case _ =>
-        Future.exception(new IllegalArgumentException(s"not enough segments in path ${req.path}"))
+        Future.exception(UnidentifiableRequestException(req, "not enough segments in path"))
     }
 }

--- a/router/http/src/main/scala/io/buoyant/router/http/PathIdentifier.scala
+++ b/router/http/src/main/scala/io/buoyant/router/http/PathIdentifier.scala
@@ -20,15 +20,11 @@ case class PathIdentifier(
         if (consume) {
           req.uri = req.uri.split("/").drop(segments + 1).mkString("/", "/", "")
         }
-        Future.value(
-          new IdentifiedRequest[Request](
-            Dst.Path(prefix ++ Path.Utf8(path.take(segments): _*), baseDtab(), Dtab.local),
-            req
-          )
-        )
+        val dst = Dst.Path(prefix ++ Path.Utf8(path.take(segments): _*), baseDtab(), Dtab.local)
+        Future.value(new IdentifiedRequest[Request](dst, req))
       case _ =>
         Future.value(
-          new UnidentifiedRequest[Request]("not enough segments in path", req)
+          new UnidentifiedRequest[Request]("not enough segments in path")
         )
     }
 }

--- a/router/http/src/main/scala/io/buoyant/router/http/PathIdentifier.scala
+++ b/router/http/src/main/scala/io/buoyant/router/http/PathIdentifier.scala
@@ -1,9 +1,11 @@
 package io.buoyant.router.http
 
+import com.twitter.finagle.http.Request
 import com.twitter.finagle.{Dtab, Path, http}
 import com.twitter.finagle.buoyant.Dst
 import com.twitter.util.Future
 import io.buoyant.router.RoutingFactory
+import io.buoyant.router.RoutingFactory.{UnidentifiedRequest, IdentifiedRequest, RequestIdentification}
 
 case class PathIdentifier(
   prefix: Path,
@@ -12,16 +14,21 @@ case class PathIdentifier(
   baseDtab: () => Dtab = () => Dtab.base
 ) extends RoutingFactory.Identifier[http.Request] {
 
-  def apply(req: http.Request): Future[(Dst, http.Request)] =
+  def apply(req: http.Request): Future[RequestIdentification[Request]] =
     req.path.split("/").drop(1) match {
       case path if path.size >= segments =>
         if (consume) {
           req.uri = req.uri.split("/").drop(segments + 1).mkString("/", "/", "")
         }
         Future.value(
-          (Dst.Path(prefix ++ Path.Utf8(path.take(segments): _*), baseDtab(), Dtab.local), req)
+          new IdentifiedRequest[Request](
+            Dst.Path(prefix ++ Path.Utf8(path.take(segments): _*), baseDtab(), Dtab.local),
+            req
+          )
         )
       case _ =>
-        Future.exception(UnidentifiableRequestException(req, "not enough segments in path"))
+        Future.value(
+          new UnidentifiedRequest[Request]("not enough segments in path", req)
+        )
     }
 }

--- a/router/http/src/main/scala/io/buoyant/router/http/UnidentifiableRequestException.scala
+++ b/router/http/src/main/scala/io/buoyant/router/http/UnidentifiableRequestException.scala
@@ -1,8 +1,0 @@
-package io.buoyant.router.http
-
-import com.twitter.finagle.http.Request
-import scala.util.control.NoStackTrace
-
-case class UnidentifiableRequestException(req: Request, reason: String)
-  extends Exception(s"Could not identify $req because $reason")
-  with NoStackTrace

--- a/router/http/src/main/scala/io/buoyant/router/http/UnidentifiableRequestException.scala
+++ b/router/http/src/main/scala/io/buoyant/router/http/UnidentifiableRequestException.scala
@@ -1,0 +1,8 @@
+package io.buoyant.router.http
+
+import com.twitter.finagle.http.Request
+import scala.util.control.NoStackTrace
+
+case class UnidentifiableRequestException(req: Request, reason: String)
+  extends Exception(s"Could not identify $req because $reason")
+  with NoStackTrace

--- a/router/http/src/test/scala/io/buoyant/router/http/MethodAndHostIdentifierTest.scala
+++ b/router/http/src/test/scala/io/buoyant/router/http/MethodAndHostIdentifierTest.scala
@@ -4,6 +4,7 @@ import com.twitter.finagle.Path
 import com.twitter.finagle.buoyant.Dst
 import com.twitter.finagle.http.{Method, Request, Version}
 import com.twitter.util._
+import io.buoyant.router.RoutingFactory.{IdentifiedRequest, UnidentifiedRequest}
 import io.buoyant.test.{Exceptions, Awaits}
 import java.net.SocketAddress
 import org.scalatest.FunSuite
@@ -14,9 +15,7 @@ class MethodAndHostIdentifierTest extends FunSuite with Awaits with Exceptions {
     val identifier = MethodAndHostIdentifier(Path.Utf8("https"), false)
     val req = Request()
     req.uri = "/some/path?other=stuff"
-    assertThrows[UnidentifiableRequestException] {
-      await(identifier(req))
-    }
+    assert(await(identifier(req)).isInstanceOf[UnidentifiedRequest[Request]])
   }
 
   test("http/1.1 request with a host header") {
@@ -24,7 +23,10 @@ class MethodAndHostIdentifierTest extends FunSuite with Awaits with Exceptions {
     val req = Request()
     req.uri = "/some/path?other=stuff"
     req.host = "domain"
-    assert(await(identifier(req))._1 == Dst.Path(Path.read("/https/1.1/GET/domain")))
+    assert(
+      await(identifier(req)).asInstanceOf[IdentifiedRequest[Request]].dst ==
+        Dst.Path(Path.read("/https/1.1/GET/domain"))
+    )
   }
 
   test("http/1.1 with URIs") {
@@ -32,20 +34,29 @@ class MethodAndHostIdentifierTest extends FunSuite with Awaits with Exceptions {
     val req = Request()
     req.uri = "/some/path?other=stuff"
     req.host = "domain"
-    assert(await(identifier(req))._1 == Dst.Path(Path.read("/https/1.1/GET/domain/some/path")))
+    assert(
+      await(identifier(req)).asInstanceOf[IdentifiedRequest[Request]].dst ==
+        Dst.Path(Path.read("/https/1.1/GET/domain/some/path"))
+    )
   }
 
   test("http/1.0") {
     val identifier = MethodAndHostIdentifier(Path.Utf8("prefix"), false)
     val req = Request(Method.Post, "/drum/bass")
     req.version = Version.Http10
-    assert(await(identifier(req))._1 == Dst.Path(Path.read("/prefix/1.0/POST")))
+    assert(
+      await(identifier(req)).asInstanceOf[IdentifiedRequest[Request]].dst ==
+        Dst.Path(Path.read("/prefix/1.0/POST"))
+    )
   }
 
   test("http/1.0 with uri") {
     val identifier = MethodAndHostIdentifier(Path.Utf8("prefix"), true)
     val req = Request(Method.Post, "/drum/bass")
     req.version = Version.Http10
-    assert(await(identifier(req))._1 == Dst.Path(Path.read("/prefix/1.0/POST/drum/bass")))
+    assert(
+      await(identifier(req)).asInstanceOf[IdentifiedRequest[Request]].dst ==
+        Dst.Path(Path.read("/prefix/1.0/POST/drum/bass"))
+    )
   }
 }

--- a/router/http/src/test/scala/io/buoyant/router/http/MethodAndHostIdentifierTest.scala
+++ b/router/http/src/test/scala/io/buoyant/router/http/MethodAndHostIdentifierTest.scala
@@ -14,7 +14,7 @@ class MethodAndHostIdentifierTest extends FunSuite with Awaits with Exceptions {
     val identifier = MethodAndHostIdentifier(Path.Utf8("https"), false)
     val req = Request()
     req.uri = "/some/path?other=stuff"
-    assertThrows[IllegalArgumentException] {
+    assertThrows[UnidentifiableRequestException] {
       await(identifier(req))
     }
   }

--- a/router/http/src/test/scala/io/buoyant/router/http/PathIdentifierTest.scala
+++ b/router/http/src/test/scala/io/buoyant/router/http/PathIdentifierTest.scala
@@ -26,7 +26,7 @@ class PathIdentifierTest extends FunSuite with Awaits with Exceptions {
     val identifier = PathIdentifier(Path.Utf8("http"), 2)
     val req = Request()
     req.uri = "/mysvc?other=stuff"
-    assertThrows[IllegalArgumentException] {
+    assertThrows[UnidentifiableRequestException] {
       await(identifier(req))
     }
   }

--- a/router/http/src/test/scala/io/buoyant/router/http/PathIdentifierTest.scala
+++ b/router/http/src/test/scala/io/buoyant/router/http/PathIdentifierTest.scala
@@ -3,6 +3,7 @@ package io.buoyant.router.http
 import com.twitter.finagle.Path
 import com.twitter.finagle.buoyant.Dst
 import com.twitter.finagle.http.Request
+import io.buoyant.router.RoutingFactory.{UnidentifiedRequest, IdentifiedRequest}
 import io.buoyant.test.{Awaits, Exceptions}
 import org.scalatest.FunSuite
 
@@ -12,47 +13,54 @@ class PathIdentifierTest extends FunSuite with Awaits with Exceptions {
     val identifier = PathIdentifier(Path.Utf8("http"), 2)
     val req = Request()
     req.uri = "/mysvc/subsvc"
-    assert(await(identifier(req))._1 == Dst.Path(Path.read("/http/mysvc/subsvc")))
+    assert(
+      await(identifier(req)).asInstanceOf[IdentifiedRequest[Request]].dst ==
+        Dst.Path(Path.read("/http/mysvc/subsvc"))
+    )
   }
 
   test("request with more segments than requested") {
     val identifier = PathIdentifier(Path.Utf8("http"), 2)
     val req = Request()
     req.uri = "/mysvc/subsvc/some/path?other=stuff"
-    assert(await(identifier(req))._1 == Dst.Path(Path.read("/http/mysvc/subsvc")))
+    assert(
+      await(identifier(req)).asInstanceOf[IdentifiedRequest[Request]].dst ==
+        Dst.Path(Path.read("/http/mysvc/subsvc"))
+    )
   }
 
   test("request with fewer segments than requested") {
     val identifier = PathIdentifier(Path.Utf8("http"), 2)
     val req = Request()
     req.uri = "/mysvc?other=stuff"
-    assertThrows[UnidentifiableRequestException] {
-      await(identifier(req))
-    }
+    assert(await(identifier(req)).isInstanceOf[UnidentifiedRequest[Request]])
   }
 
   test("consumes path segments") {
     val identifier = PathIdentifier(Path.Utf8("http"), 2, consume = true)
     val req0 = Request()
     req0.uri = "/mysvc/subsvc/some/path?other=stuff"
-    val (dst, req1) = await(identifier(req0))
-    assert(dst == Dst.Path(Path.read("/http/mysvc/subsvc")))
-    assert(req1.uri == "/some/path?other=stuff")
+    val identified = await(identifier(req0)).asInstanceOf[IdentifiedRequest[Request]]
+    assert(identified.dst == Dst.Path(Path.read("/http/mysvc/subsvc")))
+    assert(identified.request.uri == "/some/path?other=stuff")
   }
 
   test("consumes entire path") {
     val identifier = PathIdentifier(Path.Utf8("http"), 2, consume = true)
     val req0 = Request()
     req0.uri = "/mysvc/subsvc"
-    val (dst, req1) = await(identifier(req0))
-    assert(dst == Dst.Path(Path.read("/http/mysvc/subsvc")))
-    assert(req1.uri == "/")
+    val identified = await(identifier(req0)).asInstanceOf[IdentifiedRequest[Request]]
+    assert(identified.dst == Dst.Path(Path.read("/http/mysvc/subsvc")))
+    assert(identified.request.uri == "/")
   }
 
   test("does not parse more segments than requested") {
     val identifier = PathIdentifier(Path.Utf8("http"), 2)
     val req = Request()
     req.uri = "/mysvc/subsvc/!"
-    assert(await(identifier(req))._1 == Dst.Path(Path.read("/http/mysvc/subsvc")))
+    assert(
+      await(identifier(req)).asInstanceOf[IdentifiedRequest[Request]].dst ==
+        Dst.Path(Path.read("/http/mysvc/subsvc"))
+    )
   }
 }

--- a/router/mux/src/main/scala/io/buoyant/router/Mux.scala
+++ b/router/mux/src/main/scala/io/buoyant/router/Mux.scala
@@ -32,10 +32,10 @@ object Mux extends Router[Request, Response] with Server[Request, Response] {
       prefix: Path = Path.empty,
       dtab: () => Dtab = () => Dtab.base
     ) extends RoutingFactory.Identifier[Request] {
-      def apply(req: Request): Future[RequestIdentification[Request]] =
-        Future.value(
-          new IdentifiedRequest[Request](Dst.Path(prefix ++ req.destination, dtab(), Dtab.local), req)
-        )
+      def apply(req: Request): Future[RequestIdentification[Request]] = {
+        val dst = Dst.Path(prefix ++ req.destination, dtab(), Dtab.local)
+        Future.value(new IdentifiedRequest(dst, req))
+      }
     }
 
   }

--- a/router/mux/src/main/scala/io/buoyant/router/Mux.scala
+++ b/router/mux/src/main/scala/io/buoyant/router/Mux.scala
@@ -7,6 +7,7 @@ import com.twitter.finagle.mux.{Request, Response}
 import com.twitter.finagle.param.ProtocolLibrary
 import com.twitter.finagle.server.StackServer
 import com.twitter.util._
+import io.buoyant.router.RoutingFactory.{RequestIdentification, IdentifiedRequest}
 import java.net.SocketAddress
 
 object Mux extends Router[Request, Response] with Server[Request, Response] {
@@ -31,9 +32,9 @@ object Mux extends Router[Request, Response] with Server[Request, Response] {
       prefix: Path = Path.empty,
       dtab: () => Dtab = () => Dtab.base
     ) extends RoutingFactory.Identifier[Request] {
-      def apply(req: Request): Future[(Dst, Request)] =
+      def apply(req: Request): Future[RequestIdentification[Request]] =
         Future.value(
-          (Dst.Path(prefix ++ req.destination, dtab(), Dtab.local), req)
+          new IdentifiedRequest[Request](Dst.Path(prefix ++ req.destination, dtab(), Dtab.local), req)
         )
     }
 

--- a/router/thrift/src/main/scala/io/buoyant/router/thrift/Identifier.scala
+++ b/router/thrift/src/main/scala/io/buoyant/router/thrift/Identifier.scala
@@ -27,8 +27,8 @@ case class Identifier(
     }
   }
 
-  def apply(req: ThriftClientRequest): Future[RequestIdentification[ThriftClientRequest]] =
-    Future.value(
-      new IdentifiedRequest[ThriftClientRequest](Dst.Path(name ++ suffix(req), dtab(), Dtab.local), req)
-    )
+  def apply(req: ThriftClientRequest): Future[RequestIdentification[ThriftClientRequest]] = {
+    val dst = Dst.Path(name ++ suffix(req), dtab(), Dtab.local)
+    Future.value(new IdentifiedRequest[ThriftClientRequest](dst, req))
+  }
 }

--- a/router/thrift/src/main/scala/io/buoyant/router/thrift/Identifier.scala
+++ b/router/thrift/src/main/scala/io/buoyant/router/thrift/Identifier.scala
@@ -5,6 +5,7 @@ import com.twitter.finagle.thrift.{Protocols, ThriftClientRequest}
 import com.twitter.finagle.{Dtab, Path}
 import com.twitter.util.Future
 import io.buoyant.router.RoutingFactory
+import io.buoyant.router.RoutingFactory.{IdentifiedRequest, RequestIdentification}
 import org.apache.thrift.protocol.TProtocolFactory
 import org.apache.thrift.transport.TMemoryInputTransport
 
@@ -26,8 +27,8 @@ case class Identifier(
     }
   }
 
-  def apply(req: ThriftClientRequest): Future[(Dst, ThriftClientRequest)] =
+  def apply(req: ThriftClientRequest): Future[RequestIdentification[ThriftClientRequest]] =
     Future.value(
-      (Dst.Path(name ++ suffix(req), dtab(), Dtab.local), req)
+      new IdentifiedRequest[ThriftClientRequest](Dst.Path(name ++ suffix(req), dtab(), Dtab.local), req)
     )
 }

--- a/router/thrift/src/test/scala/io/buoyant/router/thrift/IdentifierTest.scala
+++ b/router/thrift/src/test/scala/io/buoyant/router/thrift/IdentifierTest.scala
@@ -6,6 +6,7 @@ import com.twitter.finagle.thrift.{Protocols, ThriftClientRequest, ThriftService
 import com.twitter.finagle.{Path, Service}
 import com.twitter.scrooge.ThriftMethod
 import com.twitter.util.{Await, Future, Throw}
+import io.buoyant.router.RoutingFactory.IdentifiedRequest
 import io.buoyant.router.thriftscala.PingService
 import io.buoyant.test.Awaits
 import org.scalatest.FunSuite
@@ -29,12 +30,18 @@ class IdentifierTest extends FunSuite with Awaits {
   test("thrift request") {
     val identifier = Identifier(Path.Utf8("thrift"))
     val req = encodeRequest(PingService.Ping)(PingService.Ping.Args("hi"))
-    assert(await(identifier(req))._1 == Dst.Path(Path.read("/thrift")))
+    assert(
+      await(identifier(req)).asInstanceOf[IdentifiedRequest[ThriftClientRequest]].dst ==
+        Dst.Path(Path.read("/thrift"))
+    )
   }
 
   test("thrift request with method") {
     val identifier = Identifier(Path.Utf8("thrift"), methodInDst = true)
     val req = encodeRequest(PingService.Ping)(PingService.Ping.Args("hi"))
-    assert(await(identifier(req))._1 == Dst.Path(Path.read("/thrift/ping")))
+    assert(
+      await(identifier(req)).asInstanceOf[IdentifiedRequest[ThriftClientRequest]].dst ==
+        Dst.Path(Path.read("/thrift/ping"))
+    )
   }
 }


### PR DESCRIPTION
Allow routers to be configured with a list of identifiers.  If an identifier cannot assign a dest to a request, it falls back to the next one in the list.