### PR TITLE
Add header identifier

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,6 +1,11 @@
 ## 0.x.y
 
+* Allow routers to be configured with a list of identifiers.  If an identifier
+  cannot assign a dest to a request, it falls back to the next one in the list.
+  * **Breaking Change**: Identifier plugins must now return a
+    `RequestIdentification` object.
 * Improve shutdown ordering to facilitate graceful shutdown.
+* Add `io.l5d.header` identifier for naming requests based on an HTTP header
 
 ## 0.7.5
 
@@ -16,10 +21,6 @@
 * `enableProbation` is now disabled by default on clients. It leads to
   unexpected behavior in environments that reuse IP:PORT pairs across
   services in a close time proximity.
-* Allow routers to be configured with a list of identifiers.  If an identifier
-  cannot assign a dest to a request, it falls back to the next one in the list.
-  * **Breaking Change**: Identifier plugins must now return a
-    `RequestIdentification` object.
 
 ## 0.7.4
 

--- a/linkerd/docs/protocol-http.md
+++ b/linkerd/docs/protocol-http.md
@@ -191,7 +191,7 @@ routers:
 
 Key | Default Value | Description
 --- | ------------- | -----------
-header | `l5d-dst-concrete` | The name of the HTTP header to use
+header | `l5d-name` | The name of the HTTP header to use
 
 #### Namer Path Parameters:
 
@@ -204,7 +204,7 @@ header | `l5d-dst-concrete` | The name of the HTTP header to use
 Key | Default Value | Description
 --- | ------------- | -----------
 dstPrefix | `http` | The `dstPrefix` as set in the routers block.
-headerValue | N/A | The value of the HTTP header as a path, if it is a valid path.  The value of the HTTP header as a single path segment, otherwise.
+headerValue | N/A | The value of the HTTP header as a path.
 
 <a name="http-engines"></a>
 ## HTTP Engines

--- a/linkerd/docs/protocol-http.md
+++ b/linkerd/docs/protocol-http.md
@@ -165,6 +165,47 @@ Key | Default Value | Description
 dstPrefix | `http` | The `dstPrefix` as set in the routers block.
 urlPath | N/A | A path from the URL whose number of segments is set in the identifier block.
 
+<a name="header-identifier"></a>
+### Header Identifier
+
+kind: `io.l5d.header`
+
+With this identifier, HTTP requests are turned into names based only on the
+value of an HTTP header.  If the header value is a valid path, that path is
+used.  Otherwise, the header value is converted to a path with one path segment.
+
+#### Namer Configuration:
+
+> With this configuration, the value of the `my-header` HTTP header will be used
+as the logical name.
+
+```yaml
+routers:
+- protocol: http
+  identifier:
+    kind: io.l5d.header
+    header: my-header
+  servers:
+  - port: 5000
+```
+
+Key | Default Value | Description
+--- | ------------- | -----------
+header | `l5d-dst-concrete` | The name of the HTTP header to use
+
+#### Namer Path Parameters:
+
+> Dtab Path Format
+
+```
+  / dstPrefix [/ *headerValue ]
+```
+
+Key | Default Value | Description
+--- | ------------- | -----------
+dstPrefix | `http` | The `dstPrefix` as set in the routers block.
+headerValue | N/A | The value of the HTTP header as a path, if it is a valid path.  The value of the HTTP header as a single path segment, otherwise.
+
 <a name="http-engines"></a>
 ## HTTP Engines
 

--- a/linkerd/protocol/http/src/main/resources/META-INF/services/io.buoyant.linkerd.IdentifierInitializer
+++ b/linkerd/protocol/http/src/main/resources/META-INF/services/io.buoyant.linkerd.IdentifierInitializer
@@ -1,2 +1,3 @@
 io.buoyant.linkerd.protocol.http.MethodAndHostIdentifierInitializer
 io.buoyant.linkerd.protocol.http.PathIdentifierInitializer
+io.buoyant.linkerd.protocol.http.HeaderIdentifierInitializer

--- a/linkerd/protocol/http/src/main/resources/META-INF/services/io.buoyant.linkerd.IdentifierInitializer
+++ b/linkerd/protocol/http/src/main/resources/META-INF/services/io.buoyant.linkerd.IdentifierInitializer
@@ -1,3 +1,3 @@
+io.buoyant.linkerd.protocol.http.HeaderIdentifierInitializer
 io.buoyant.linkerd.protocol.http.MethodAndHostIdentifierInitializer
 io.buoyant.linkerd.protocol.http.PathIdentifierInitializer
-io.buoyant.linkerd.protocol.http.HeaderIdentifierInitializer

--- a/linkerd/protocol/http/src/main/scala/io/buoyant/linkerd/protocol/http/HeaderIdentifierConfig.scala
+++ b/linkerd/protocol/http/src/main/scala/io/buoyant/linkerd/protocol/http/HeaderIdentifierConfig.scala
@@ -1,0 +1,29 @@
+package io.buoyant.linkerd.protocol.http
+
+import com.fasterxml.jackson.annotation.JsonIgnore
+import com.twitter.finagle.buoyant.linkerd.Headers
+import com.twitter.finagle.{Dtab, Path}
+import io.buoyant.linkerd.IdentifierInitializer
+import io.buoyant.linkerd.protocol.HttpIdentifierConfig
+import io.buoyant.router.http.HeaderIdentifier
+
+class HeaderIdentifierInitializer extends IdentifierInitializer {
+  val configClass = classOf[HeaderIdentifierConfig]
+  override val configId = HeaderIdentifierConfig.kind
+}
+
+object HeaderIdentifierInitializer extends HeaderIdentifierInitializer
+
+object HeaderIdentifierConfig {
+  val kind = "io.l5d.header"
+}
+
+class HeaderIdentifierConfig extends HttpIdentifierConfig {
+  var header: Option[String] = None
+
+  @JsonIgnore
+  override def newIdentifier(
+    prefix: Path,
+    baseDtab: () => Dtab = () => Dtab.base
+  ) = HeaderIdentifier(prefix, header.getOrElse(Headers.Dst.Bound), baseDtab)
+}

--- a/linkerd/protocol/http/src/main/scala/io/buoyant/linkerd/protocol/http/HeaderIdentifierConfig.scala
+++ b/linkerd/protocol/http/src/main/scala/io/buoyant/linkerd/protocol/http/HeaderIdentifierConfig.scala
@@ -16,6 +16,7 @@ object HeaderIdentifierInitializer extends HeaderIdentifierInitializer
 
 object HeaderIdentifierConfig {
   val kind = "io.l5d.header"
+  val defaultHeader = Headers.Prefix + "name"
 }
 
 class HeaderIdentifierConfig extends HttpIdentifierConfig {
@@ -25,5 +26,9 @@ class HeaderIdentifierConfig extends HttpIdentifierConfig {
   override def newIdentifier(
     prefix: Path,
     baseDtab: () => Dtab = () => Dtab.base
-  ) = HeaderIdentifier(prefix, header.getOrElse(Headers.Dst.Bound), baseDtab)
+  ) = HeaderIdentifier(
+    prefix,
+    header.getOrElse(HeaderIdentifierConfig.defaultHeader),
+    baseDtab
+  )
 }

--- a/linkerd/protocol/http/src/test/scala/io/buoyant/linkerd/protocol/http/HeaderIdentifierConfigTest.scala
+++ b/linkerd/protocol/http/src/test/scala/io/buoyant/linkerd/protocol/http/HeaderIdentifierConfigTest.scala
@@ -1,0 +1,31 @@
+package io.buoyant.linkerd.protocol.http
+
+import com.twitter.finagle.Path
+import com.twitter.finagle.util.LoadService
+import io.buoyant.config.Parser
+import io.buoyant.linkerd.IdentifierInitializer
+import io.buoyant.linkerd.protocol.HttpIdentifierConfig
+import org.scalatest.FunSuite
+
+class HeaderIdentifierConfigTest extends FunSuite {
+  test("sanity") {
+    // ensure it doesn't totally blowup
+    val _ = new HeaderIdentifierConfig().newIdentifier(Path.empty)
+  }
+
+  test("service registration") {
+    assert(LoadService[IdentifierInitializer].exists(_.isInstanceOf[HeaderIdentifierInitializer]))
+  }
+
+  test("parse config") {
+    val yaml = s"""
+                  |kind: io.l5d.header
+                  |header: my-header
+      """.stripMargin
+
+    val mapper = Parser.objectMapper(yaml, Iterable(Seq(HeaderIdentifierInitializer)))
+    val config = mapper.readValue[HttpIdentifierConfig](yaml).asInstanceOf[HeaderIdentifierConfig]
+    assert(config.header == Some("my-header"))
+  }
+
+}

--- a/linkerd/protocol/http/src/test/scala/io/buoyant/linkerd/protocol/http/HeaderIdentifierConfigTest.scala
+++ b/linkerd/protocol/http/src/test/scala/io/buoyant/linkerd/protocol/http/HeaderIdentifierConfigTest.scala
@@ -1,13 +1,17 @@
 package io.buoyant.linkerd.protocol.http
 
 import com.twitter.finagle.Path
+import com.twitter.finagle.buoyant.Dst
+import com.twitter.finagle.http.Request
 import com.twitter.finagle.util.LoadService
 import io.buoyant.config.Parser
 import io.buoyant.linkerd.IdentifierInitializer
 import io.buoyant.linkerd.protocol.HttpIdentifierConfig
+import io.buoyant.router.RoutingFactory.IdentifiedRequest
+import io.buoyant.test.Awaits
 import org.scalatest.FunSuite
 
-class HeaderIdentifierConfigTest extends FunSuite {
+class HeaderIdentifierConfigTest extends FunSuite with Awaits {
   test("sanity") {
     // ensure it doesn't totally blowup
     val _ = new HeaderIdentifierConfig().newIdentifier(Path.empty)
@@ -25,7 +29,29 @@ class HeaderIdentifierConfigTest extends FunSuite {
 
     val mapper = Parser.objectMapper(yaml, Iterable(Seq(HeaderIdentifierInitializer)))
     val config = mapper.readValue[HttpIdentifierConfig](yaml).asInstanceOf[HeaderIdentifierConfig]
-    assert(config.header == Some("my-header"))
+    val identifier = config.newIdentifier(Path.empty)
+    val req = Request()
+    req.headerMap.set("my-header", "/one/two/three")
+    assert(
+      await(identifier(req)).asInstanceOf[IdentifiedRequest[Request]].dst ==
+        Dst.Path(Path.read("/one/two/three"))
+    )
+  }
+
+  test("default header") {
+    val yaml = s"""
+                  |kind: io.l5d.header
+      """.stripMargin
+
+    val mapper = Parser.objectMapper(yaml, Iterable(Seq(HeaderIdentifierInitializer)))
+    val config = mapper.readValue[HttpIdentifierConfig](yaml).asInstanceOf[HeaderIdentifierConfig]
+    val identifier = config.newIdentifier(Path.empty)
+    val req = Request()
+    req.headerMap.set("l5d-name", "/one/two/three")
+    assert(
+      await(identifier(req)).asInstanceOf[IdentifiedRequest[Request]].dst ==
+        Dst.Path(Path.read("/one/two/three"))
+    )
   }
 
 }

--- a/router/http/src/main/scala/io/buoyant/router/http/HeaderIdentifier.scala
+++ b/router/http/src/main/scala/io/buoyant/router/http/HeaderIdentifier.scala
@@ -1,0 +1,24 @@
+package io.buoyant.router.http
+
+import com.twitter.finagle.http.Request
+import com.twitter.finagle.{Path, Dtab}
+import com.twitter.finagle.buoyant.Dst
+import com.twitter.util.{Try, Future}
+import io.buoyant.router.RoutingFactory
+
+case class HeaderIdentifier(
+  prefix: Path,
+  header: String,
+  baseDtab: () => Dtab = () => Dtab.base
+) extends RoutingFactory.Identifier[Request] {
+
+  def apply(req: Request): Future[(Dst, Request)] = {
+    req.headerMap.get(header) match {
+      case Some(value) =>
+        val path = Try(Path.read(value)).getOrElse(Path.Utf8(value))
+        Future.value(Dst.Path(prefix ++ path, baseDtab(), Dtab.local), req)
+      case None =>
+        Future.exception(new IllegalArgumentException(s"$header header is absent"))
+    }
+  }
+}

--- a/router/http/src/main/scala/io/buoyant/router/http/HeaderIdentifier.scala
+++ b/router/http/src/main/scala/io/buoyant/router/http/HeaderIdentifier.scala
@@ -16,9 +16,12 @@ case class HeaderIdentifier(
   def apply(req: Request): Future[RequestIdentification[Request]] = {
     req.headerMap.get(header) match {
       case Some(value) =>
-        val path = Try(Path.read(value)).getOrElse(Path.Utf8(value))
-        val dst = Dst.Path(prefix ++ path, baseDtab(), Dtab.local)
-        Future.value(new IdentifiedRequest(dst, req))
+        val identified = Try {
+          val path = Path.read(value)
+          val dst = Dst.Path(prefix ++ path, baseDtab(), Dtab.local)
+          new IdentifiedRequest(dst, req)
+        }
+        Future.const(identified)
       case None =>
         Future.value(new UnidentifiedRequest(s"$header header is absent"))
     }

--- a/router/http/src/test/scala/io/buoyant/router/http/HeaderIdentifierTest.scala
+++ b/router/http/src/test/scala/io/buoyant/router/http/HeaderIdentifierTest.scala
@@ -1,0 +1,32 @@
+package io.buoyant.router.http
+
+import com.twitter.finagle.Path
+import com.twitter.finagle.buoyant.Dst
+import com.twitter.finagle.http.Request
+import io.buoyant.test.{Awaits, Exceptions}
+import org.scalatest.FunSuite
+
+class HeaderIdentifierTest extends FunSuite with Awaits with Exceptions {
+
+  test("use path from header") {
+    val identifier = HeaderIdentifier(Path.Utf8("http"), "my-header")
+    val req = Request()
+    req.headerMap.set("my-header", "/a/b/c")
+    assert(await(identifier(req))._1 == Dst.Path(Path.read("/http/a/b/c")))
+  }
+
+  test("use path segment from header") {
+    val identifier = HeaderIdentifier(Path.Utf8("http"), "my-header")
+    val req = Request()
+    req.headerMap.set("my-header", "hello")
+    assert(await(identifier(req))._1 == Dst.Path(Path.read("/http/hello")))
+  }
+
+  test("header is absent") {
+    val identifier = HeaderIdentifier(Path.Utf8("http"), "my-header")
+    val req = Request()
+    assertThrows[IllegalArgumentException] {
+      await(identifier(req))
+    }
+  }
+}

--- a/router/http/src/test/scala/io/buoyant/router/http/HeaderIdentifierTest.scala
+++ b/router/http/src/test/scala/io/buoyant/router/http/HeaderIdentifierTest.scala
@@ -19,16 +19,6 @@ class HeaderIdentifierTest extends FunSuite with Awaits with Exceptions {
     )
   }
 
-  test("use path segment from header") {
-    val identifier = HeaderIdentifier(Path.Utf8("http"), "my-header")
-    val req = Request()
-    req.headerMap.set("my-header", "hello")
-    assert(
-      await(identifier(req)).asInstanceOf[IdentifiedRequest[Request]].dst ==
-        Dst.Path(Path.read("/http/hello"))
-    )
-  }
-
   test("header is absent") {
     val identifier = HeaderIdentifier(Path.Utf8("http"), "my-header")
     val req = Request()


### PR DESCRIPTION
Fixes #373

With this identifier, HTTP requests are turned into names based only on the value of an HTTP header.  If the header value is a valid path, that path is used.  Otherwise, the header value is converted to a path with one path segment.