### PR TITLE
Measure basic information about the consul namer.

### DIFF
--- a/linkerd/core/src/main/scala/io/buoyant/linkerd/Linker.scala
+++ b/linkerd/core/src/main/scala/io/buoyant/linkerd/Linker.scala
@@ -129,7 +129,8 @@ object Linker {
           BroadcastTracer(tracers)
       }
 
-      val namerParams = Stack.Params.empty + param.Tracer(tracer) + param.Stats(stats)
+      val baseParams = Stack.Params.empty + param.Tracer(tracer) + param.Stats(stats)
+      val namerParams = baseParams + param.Stats(stats.scope("namer"))
       val namersByPrefix = namers.getOrElse(Nil).reverse.map { namer =>
         if (namer.disabled) throw new IllegalArgumentException(
           s"""The ${namer.prefix.show} namer is experimental and must be explicitly enabled by setting the "experimental" parameter to true."""
@@ -143,7 +144,7 @@ object Linker {
       for ((label, rts) <- routers.groupBy(_.label))
         if (rts.size > 1) throw ConflictingLabels(label)
 
-      val routerParams = namerParams +
+      val routerParams = baseParams +
         Namers(namersByPrefix) +
         param.Stats(namerParams[param.Stats].statsReceiver.scope("rt"))
       val routerImpls = routers.map { router =>

--- a/linkerd/core/src/main/scala/io/buoyant/linkerd/Linker.scala
+++ b/linkerd/core/src/main/scala/io/buoyant/linkerd/Linker.scala
@@ -146,7 +146,7 @@ object Linker {
 
       val routerParams = baseParams +
         Namers(namersByPrefix) +
-        param.Stats(namerParams[param.Stats].statsReceiver.scope("rt"))
+        param.Stats(baseParams[param.Stats].statsReceiver.scope("rt"))
       val routerImpls = routers.map { router =>
         val interpreter = router.interpreter.newInterpreter(routerParams)
         router.router(routerParams + DstBindingFactory.Namer(interpreter))

--- a/linkerd/core/src/test/scala/io/buoyant/linkerd/LinkerTest.scala
+++ b/linkerd/core/src/test/scala/io/buoyant/linkerd/LinkerTest.scala
@@ -237,7 +237,7 @@ class LinkerTest extends FunSuite with Exceptions {
     val param.Stats(stats) = linker.routers.head.params[param.Stats]
     stats.counter("rad").incr()
     treceivers.foreach { r =>
-      assert(r.counters(Seq("rt", "rad")) == 1)
+      assert(r.counters == Map(Seq("rt", "rad") -> 1))
     }
 
     val param.Tracer(tracer) = linker.routers.head.params[param.Tracer]

--- a/namer/consul/src/main/scala/io/buoyant/namer/consul/ConsulInitializer.scala
+++ b/namer/consul/src/main/scala/io/buoyant/namer/consul/ConsulInitializer.scala
@@ -69,7 +69,7 @@ case class ConsulConfig(
 
     val service = Http.client
       .withParams(Http.client.params ++ params)
-      .withLabel(prefix.show)
+      .withLabel(prefix.show.stripPrefix("/"))
       .withMonitor(interruptionMonitor)
       .withTracer(NullTracer)
       .filtered(filters)

--- a/namer/consul/src/main/scala/io/buoyant/namer/consul/ConsulInitializer.scala
+++ b/namer/consul/src/main/scala/io/buoyant/namer/consul/ConsulInitializer.scala
@@ -2,7 +2,7 @@ package io.buoyant.namer.consul
 
 import com.fasterxml.jackson.annotation.JsonIgnore
 import com.twitter.finagle.http.{Request, Response}
-import com.twitter.finagle.param.Label
+import com.twitter.finagle.param
 import com.twitter.finagle.tracing.NullTracer
 import com.twitter.finagle.{Failure, Filter, Http, Namer, Path, Stack}
 import com.twitter.util.Monitor
@@ -68,9 +68,9 @@ case class ConsulConfig(
     }
 
     val service = Http.client
-      .withMonitor(interruptionMonitor)
       .withParams(Http.client.params ++ params)
-      .configured(Label("namer" + prefix))
+      .withLabel(prefix.show)
+      .withMonitor(interruptionMonitor)
       .withTracer(NullTracer)
       .filtered(filters)
       .newService(s"/$$/inet/$getHost/$getPort")
@@ -81,11 +81,13 @@ case class ConsulConfig(
     }
     val agent = v1.AgentApi(service)
 
+    val stats = params[param.Stats].statsReceiver.scope(prefix.show.stripPrefix("/"))
+
     includeTag match {
       case Some(true) =>
-        ConsulNamer.tagged(prefix, consul, agent, setHost.getOrElse(false))
+        ConsulNamer.tagged(prefix, consul, agent, setHost.getOrElse(false), stats)
       case _ =>
-        ConsulNamer.untagged(prefix, consul, agent, setHost.getOrElse(false))
+        ConsulNamer.untagged(prefix, consul, agent, setHost.getOrElse(false), stats)
     }
   }
 }

--- a/namer/consul/src/main/scala/io/buoyant/namer/consul/ConsulNamer.scala
+++ b/namer/consul/src/main/scala/io/buoyant/namer/consul/ConsulNamer.scala
@@ -1,6 +1,7 @@
 package io.buoyant.namer.consul
 
 import com.twitter.finagle._
+import com.twitter.finagle.stats.{StatsReceiver, NullStatsReceiver}
 import com.twitter.util._
 import io.buoyant.consul.v1
 
@@ -10,9 +11,10 @@ object ConsulNamer {
     prefix: Path,
     consulApi: v1.ConsulApi,
     agentApi: v1.AgentApi,
-    setHost: Boolean = false
+    setHost: Boolean = false,
+    stats: StatsReceiver = NullStatsReceiver
   ): Namer = {
-    val lookup = new LookupCache(consulApi, agentApi, setHost)
+    val lookup = new LookupCache(consulApi, agentApi, setHost, stats)
     new TaggedNamer(lookup, prefix)
   }
 
@@ -20,9 +22,10 @@ object ConsulNamer {
     prefix: Path,
     consulApi: v1.ConsulApi,
     agentApi: v1.AgentApi,
-    setHost: Boolean = false
+    setHost: Boolean = false,
+    stats: StatsReceiver = NullStatsReceiver
   ): Namer = {
-    val lookup = new LookupCache(consulApi, agentApi, setHost)
+    val lookup = new LookupCache(consulApi, agentApi, setHost, stats)
     new UntaggedNamer(lookup, prefix)
   }
 

--- a/namer/consul/src/main/scala/io/buoyant/namer/consul/DcServices.scala
+++ b/namer/consul/src/main/scala/io/buoyant/namer/consul/DcServices.scala
@@ -12,7 +12,9 @@ private[consul] object DcServices {
    * We use a shared stats object so that counters/stats are not
    * created anew for each DC/service.
    */
-  case class Stats(stats: StatsReceiver) {
+  case class Stats(stats0: StatsReceiver) {
+    val stats = stats0.scope("dc")
+
     val opens = stats.counter("opens")
     val closes = stats.counter("closes")
     val errors = stats.counter("errors")
@@ -20,7 +22,7 @@ private[consul] object DcServices {
     val adds = stats.counter("adds")
     val removes = stats.counter("removes")
 
-    val service = SvcAddr.Stats(stats.scope("service"))
+    val service = SvcAddr.Stats(stats0.scope("service"))
   }
 
   /**

--- a/namer/consul/src/test/scala/io/buoyant/namer/consul/ConsulNamerTest.scala
+++ b/namer/consul/src/test/scala/io/buoyant/namer/consul/ConsulNamerTest.scala
@@ -62,7 +62,8 @@ class ConsulNamerTest extends FunSuite with Awaits {
     namer.lookup(Path.read("/dc1/servicename/residual")).states respond { state = _ }
     assert(state == Activity.Pending)
     assert(stats.counters == Map(
-      Seq("dc", "opens") -> 1
+      Seq("dc", "opens") -> 1,
+      Seq("lookups") -> 1
     ))
   }
 
@@ -83,7 +84,8 @@ class ConsulNamerTest extends FunSuite with Awaits {
     assert(state == Activity.Failed(ChannelWriteException(null)))
     assert(stats.counters == Map(
       Seq("dc", "opens") -> 1,
-      Seq("dc", "errors") -> 1
+      Seq("dc", "errors") -> 1,
+      Seq("lookups") -> 1
     ))
   }
 
@@ -107,7 +109,8 @@ class ConsulNamerTest extends FunSuite with Awaits {
 
     assert(state == Activity.Pending)
     assert(stats.counters == Map(
-      Seq("dc", "opens") -> 1
+      Seq("dc", "opens") -> 1,
+      Seq("lookups") -> 1
     ))
   }
 
@@ -145,7 +148,7 @@ class ConsulNamerTest extends FunSuite with Awaits {
       Seq("dc", "opens") -> 1,
       Seq("dc", "updates") -> 1,
       Seq("dc", "adds") -> 1,
-      Seq("negs") -> 1
+      Seq("lookups") -> 1
     ))
   }
 
@@ -192,8 +195,7 @@ class ConsulNamerTest extends FunSuite with Awaits {
       Seq("dc", "opens") -> 1,
       Seq("dc", "updates") -> 2,
       Seq("dc", "adds") -> 4,
-      Seq("negs") -> 1,
-      Seq("leafs") -> 1
+      Seq("lookups") -> 1
     ))
   }
 
@@ -243,10 +245,10 @@ class ConsulNamerTest extends FunSuite with Awaits {
       Seq("dc", "opens") -> 1,
       Seq("dc", "updates") -> 1,
       Seq("dc", "adds") -> 4,
-      Seq("dc", "service", "opens") -> 1,
-      Seq("dc", "service", "updates") -> 1,
-      Seq("dc", "service", "closes") -> 1,
-      Seq("leafs") -> 1
+      Seq("service", "opens") -> 1,
+      Seq("service", "updates") -> 1,
+      Seq("service", "closes") -> 1,
+      Seq("lookups") -> 1
     ))
   }
 
@@ -304,10 +306,10 @@ class ConsulNamerTest extends FunSuite with Awaits {
       Seq("dc", "opens") -> 1,
       Seq("dc", "updates") -> 1,
       Seq("dc", "adds") -> 4,
-      Seq("dc", "service", "opens") -> 2,
-      Seq("dc", "service", "updates") -> 4,
-      Seq("dc", "service", "closes") -> 2,
-      Seq("leafs") -> 1
+      Seq("service", "opens") -> 2,
+      Seq("service", "updates") -> 4,
+      Seq("service", "closes") -> 2,
+      Seq("lookups") -> 1
     ))
   }
 
@@ -361,10 +363,10 @@ class ConsulNamerTest extends FunSuite with Awaits {
       Seq("dc", "opens") -> 1,
       Seq("dc", "updates") -> 1,
       Seq("dc", "adds") -> 4,
-      Seq("dc", "service", "opens") -> 1,
-      Seq("dc", "service", "updates") -> 1,
-      Seq("dc", "service", "closes") -> 1,
-      Seq("leafs") -> 1
+      Seq("service", "opens") -> 1,
+      Seq("service", "updates") -> 1,
+      Seq("service", "closes") -> 1,
+      Seq("lookups") -> 1
     ))
   }
 
@@ -413,10 +415,10 @@ class ConsulNamerTest extends FunSuite with Awaits {
       Seq("dc", "opens") -> 1,
       Seq("dc", "updates") -> 1,
       Seq("dc", "adds") -> 4,
-      Seq("dc", "service", "opens") -> 1,
-      Seq("dc", "service", "updates") -> 1,
-      Seq("dc", "service", "closes") -> 1,
-      Seq("leafs") -> 1
+      Seq("service", "opens") -> 1,
+      Seq("service", "updates") -> 1,
+      Seq("service", "closes") -> 1,
+      Seq("lookups") -> 1
     ))
   }
 
@@ -473,10 +475,10 @@ class ConsulNamerTest extends FunSuite with Awaits {
       Seq("dc", "opens") -> 1,
       Seq("dc", "updates") -> 1,
       Seq("dc", "adds") -> 4,
-      Seq("dc", "service", "opens") -> 1,
-      Seq("dc", "service", "updates") -> 1,
-      Seq("dc", "service", "closes") -> 1,
-      Seq("leafs") -> 1
+      Seq("service", "opens") -> 1,
+      Seq("service", "updates") -> 1,
+      Seq("service", "closes") -> 1,
+      Seq("lookups") -> 1
     ))
   }
 }


### PR DESCRIPTION
This should help diagnose consul behavior.

Furthermore, fix a malformed consul client naming (was doing Path.toString
instead of Path.show).

Finally, LinkerConfig should scope namer stats explicitly rather than rely on
the namer to do the right scoping.