### PR TITLE
Convert namerd docs to use tables.

### DIFF
--- a/namerd/docs/config.md
+++ b/namerd/docs/config.md
@@ -37,7 +37,7 @@ Key | Required | Description
 [admin](#administrative-interface) | no | Configures namerd's administrative interface. namerd admin has the same options as linkerd admin.
 [interfaces](#interfaces) | no | Configures namerd's published network interfaces.
 [storage](#storage) | yes | Configures namerd's storage backend.
-[namers](https://linkerd.io/config/latest/linkerd#namers) | no | Configures namerd's integration with various service discovery backends. namerd uses the same namers as linkerd.
+[namers](https://linkerd.io/config/head/linkerd#namers) | no | Configures namerd's integration with various service discovery backends. namerd uses the same namers as linkerd.
 
 ### Administrative interface
 

--- a/namerd/docs/config.md
+++ b/namerd/docs/config.md
@@ -1,13 +1,6 @@
-# Configuration
+# Introduction
 
-namerd's configuration is controlled via config file, which must be provided
-as a command-line argument. It may be a local file path or `-` to
-indicate that the configuration should be read from the standard input.
-
-## File Format
-
-The configuration may be specified as a JSON or YAML object, as described
-below.
+> A namerd config example
 
 ```yaml
 storage:
@@ -29,21 +22,32 @@ interfaces:
   port: 4321
 ```
 
-<a name="storage"></a>
-## Storage
+Welcome to the Configuration Reference for namerd!
 
-All configurations must define a **storage** key which must be a
-[storage](storage.md) object.
+namerd's configuration is controlled via config file, which must be provided
+as a command-line argument. It may be a local file path or `-` to
+indicate that the configuration should be read from the standard input.
 
-<a name="namers"></a>
-## Namers
+#### File Format
 
-Naming and service discovery are configured via the `namers` section of the
-configuration file. In this file, `namers` is an array of objects each of which
-must be a [namer](../../linkerd/docs/namer.md).
+The configuration may be specified as a JSON or YAML object.
 
-<a name="interfaces"></a>
-## Interfaces
+Key | Required | Description
+--- | -------- | -----------
+[admin](#administrative-interface) | no | Configures namerd's administrative interface. namerd admin has the same options as linkerd admin.
+[interfaces](#interfaces) | no | Configures namerd's published network interfaces.
+[storage](#storage) | yes | Configures namerd's storage backend.
+[namers](https://linkerd.io/config/latest/linkerd#namers) | no | Configures namerd's integration with various service discovery backends. namerd uses the same namers as linkerd.
 
-A top-level `interfaces` section controls the published network interfaces to
-namerd. It is an array of [interface](interface.md) objects.
+### Administrative interface
+
+```yaml
+admin:
+  port: 9991
+```
+
+namerd supports an administrative interface. The exposed admin port is configurable via a top-level `admin` section.
+
+Key | Default Value | Description
+--- | ------------- | -----------
+port | `9991` | Port for the admin interface.

--- a/namerd/docs/interface.md
+++ b/namerd/docs/interface.md
@@ -1,44 +1,48 @@
 # Interfaces
 
-*(for the [interfaces](config.md#interfaces) key)*
+An interface is a published network interface to namerd.
 
-An interface is a published network interface to namerd.  An interface config
-block supports the following params:
+<aside class="notice">
+These parameters are available to the interface regardless of kind. Interfaces may also have kind-specific parameters.
+</aside>
 
-* *kind* -- Required. One of the supported interface plugins.
-* *ip* -- Optional.  The local IP address on which to serve the namer interface
-(defaults may be provided by plugins)
-* *port* -- Optional.  The port number on which to server the namer interface.
-(defaults may be provided by plugins)
+Key | Default Value | Description
+--- | ------------- | -----------
+kind | _required_ | Either `io.l5d.thriftNameInterpreter` or `io.l5d.httpController`.
+ip | interface dependent | The local IP address on which to serve the namer interface.
+port | interface dependent | The port number on which to server the namer interface.
 
 ## Thrift Name Interpreter
 
-`io.l5d.thriftNameInterpreter`
+kind: `io.l5d.thriftNameInterpreter`
 
 A read-only interface providing `NameInterpreter` functionality over the ThriftMux protocol.
 
-* default *ip*: 0.0.0.0 (wildcard)
-* default *port*: 4100
-* *retryBaseSecs* -- Optional. Base number of seconds to tell clients to wait
-before retrying after an error.  (default: 600)
-* *retryJitterSecs* -- Optional.  Maximum number of seconds to jitter retry
-time by.  (default: 60)
-* *cache* -- Optional.  Configure the size of the binding and address caches.
-It must be an object containing keys:
-  * *bindingCacheActive* -- Optional.  The size of the binding active cache.
-  (default: 1000)
-  * *bindingCacheInactive* -- Optional.  The size of the binding inactive cache.
-  (default: 100)
-  * *addrCacheActive* -- Optional.  The size of the address active cache.
-  (default: 1000)
-  * *addrCacheInactive* -- Optional.  The size of the address inactive cache.
-  (default: 100)
+Key | Default Value | Description
+--- | ------------- | -----------
+ip | `0.0.0.0` | The local IP address on which to serve the namer interface.
+port | `4100` | The port number on which to server the namer interface.
+retryBaseSecs | `600` | Base number of seconds to tell clients to wait before retrying after an error.
+retryJitterSecs | `60` | Maximum number of seconds to jitter retry time by.
+cache | see [cache](#cache) | Binding and address cache size configuration.
+
+### Cache
+
+Key | Default Value | Description
+-------------- | -------------- | --------------
+bindingCacheActive | `1000` | The size of the binding active cache.
+bindingCacheInactive | `100` | The size of the binding inactive cache.
+addrCacheActive | `1000` | The size of the address active cache.
+addrCacheInactive | `100` | The size of the address inactive cache.
+
 
 ## Http Controller
 
-`io.l5d.httpController`
+kind: `io.l5d.httpController`
 
-A read-write HTTP interface to the `storage`.
+A read-write HTTP interface to the [storage](#storage).
 
-* default *ip*: loopback
-* default *port*: 4180
+Key | Default Value | Description
+--- | ------------- | -----------
+ip | loopback | The local IP address on which to serve the namer interface.
+port | `4180` | The port number on which to server the namer interface.

--- a/namerd/docs/interface.md
+++ b/namerd/docs/interface.md
@@ -45,4 +45,4 @@ A read-write HTTP interface to the [storage](#storage).
 Key | Default Value | Description
 --- | ------------- | -----------
 ip | loopback | The local IP address on which to serve the namer interface.
-port | `4180` | The port number on which to server the namer interface.
+port | `4180` | The port number on which to serve the namer interface.

--- a/namerd/docs/storage.md
+++ b/namerd/docs/storage.md
@@ -11,7 +11,6 @@ Key | Default Value | Description
 --- | ------------- | -----------
 kind | _required_ | Either `io.l5d.inMemory`, `io.l5d.k8s`, `io.l5d.zk`, `io.l5d.etcd` or `io.l5d.consul`.
 experimental | `false` | Set this to `true` to enable the storage if it is experimental.
-port | interface dependent | The port number on which to server the namer interface.
 
 ## In Memory
 

--- a/namerd/docs/storage.md
+++ b/namerd/docs/storage.md
@@ -1,89 +1,99 @@
 # Storage
 
-*(for the [storage](config.md#storage) key)*
-
 A storage object configures the namerd dtabStore which stores and retrieves
 dtabs. This object supports the following params:
 
-* *kind* -- The name of the storage plugin.
-* *experimental* -- Set this to `true` to enable the storage if it is experimental.
-* *sotrage-specific parameters*.
+<aside class="notice">
+These parameters are available to the storage regardless of kind. Storage may also have kind-specific parameters.
+</aside>
+
+Key | Default Value | Description
+--- | ------------- | -----------
+kind | _required_ | Either `io.l5d.inMemory`, `io.l5d.k8s`, `io.l5d.zk`, `io.l5d.etcd` or `io.l5d.consul`.
+experimental | `false` | Set this to `true` to enable the storage if it is experimental.
+port | interface dependent | The port number on which to server the namer interface.
 
 ## In Memory
 
-`io.l5d.inMemory`
+kind: `io.l5d.inMemory`
 
 Stores the dtab in memory.  Not suitable for production use.
 
-* *namespaces* -- Optional.  A map of namespaces to corresponding dtabs.
+Key | Default Value | Description
+--- | ------------- | -----------
+namespaces | empty map | A map of namespaces to corresponding dtabs.
 
 ## Kubernetes
 
-`io.l5d.k8s`
-
-*experimental*
+kind: `io.l5d.k8s`
 
 Stores the dtab with the Kubernetes master via the ThirdPartyResource APIs. Requires a cluster
 running Kubernetes 1.2+ with the ThirdPartyResource feature enabled.
 
-* *host* -- Optional. The location of the Kubernetes API. (default: "kubernetes.default.svc.cluster.local")
-* *port* -- Optional. The port used to connect to the Kubernetes API. (default: 443)
-* *tls*  -- Optional. Whether to connect to the Kubernetes API using TLS. (default: true)
-* *tlsWithoutValidation* -- Optional. Whether to disable certificate checking against the Kubernetes
-  API. Meaningless if *tls* is false. (default: false)
-* *authTokenFile* -- Optional. The location of the token used to authenticate against the Kubernetes
-  API, if any. (default: no authentication)
-* *namespace* The Kubernetes namespace in which dtabs will be stored. This should usually be the
-  same namespace in which namerd is running. (default: "default")
+Key | Default Value | Description
+--- | ------------- | -----------
+experimental | _required_ | Because this storage is still considered experimental, you must set this to `true` to use it.
+host | `kubernetes.default.svc.cluster.local` | The location of the Kubernetes API.
+port | `443` | The port used to connect to the Kubernetes API.
+tls | `true` | Whether to connect to the Kubernetes API using TLS.
+tlsWithoutValidation | `false` | Whether to disable certificate checking against the Kubernetes API. Meaningless if `tls` is false.
+authTokenFile | no auth | The location of the token used to authenticate against the Kubernetes API, if any.
+namespace | `default` | The Kubernetes namespace in which dtabs will be stored. This should usually be the same namespace in which namerd is running.
 
 ## ZooKeeper
 
-`io.l5d.zk`
+kind: `io.l5d.zk`
 
-*experimental*
+Stores the dtab in ZooKeeper.
 
-Stores the dtab in ZooKeeper.  Supports the following options
+Key | Default Value | Description
+--- | ------------- | -----------
+experimental | _required_ | Because this storage is still considered experimental, you must set this to `true` to use it.
+zkAddrs | _required_ | A list of ZooKeeper addresses, each of which have `host` and `port` parameters.
+pathPrefix | `/dtabs` | The ZooKeeper path under which dtabs should be stored.
+sessionTimeoutMs | `10000` | ZooKeeper session timeout in milliseconds.
+authInfo | no auth when logging | Configures the authentication information to use when logging. See [authInfo](#authInfo).
+acls | an empty list | A list of ACLs to set on each dtab znode created. See [acls](#acls).
 
-* *zkAddrs* -- list of ZooKeeper addresses:
-  * *host* --  the ZooKeeper host.
-  * *port* --  the ZooKeeper port.
-* *pathPrefix* -- Optional.  The ZooKeeper path under which dtabs should be stored.  (default:
-"/dtabs")
-* *sessionTimeoutMs* -- Optional.  ZooKeeper session timeout in milliseconds.
-(default: 10000)
-* *authInfo* -- Optional.  An object containing the authentication information to use when logging
-in ZooKeeper:
-  * *scheme* -- Required.  The ZooKeeper auth scheme to use.
-  * *auth* -- Required.  The ZooKeeper auth value to use.
-* *acls* -- Optional.  A list of ACLs to set on each dtab znode created.  Each ACL is an object
-containing:
-  * *scheme* -- Required.  The ACL auth scheme to use.
-  * *id* -- Required.  The ACL id to use.
-  * *perms* -- Required.  A subset of the string "crwda" representing the permissions of this ACL.
-  The characters represent create, read, write, delete, and admin, respectively.
+### authInfo
+
+Key | Default Value | Description
+--- | ------------- | -----------
+scheme | _required_ | The ZooKeeper auth scheme to use.
+auth | _required_ | The ZooKeeper auth value to use.
+
+### acls
+
+Key | Default Value | Description
+--- | ------------- | -----------
+scheme | _required_ | The ACL auth scheme to use.
+id | _required_ | The ACL id to use.
+perms | _required_ | A subset of the string "crwda" representing the permissions of this ACL. The characters represent create, read, write, delete, and admin, respectively.
 
 ## Etcd
 
-`io.l5d.etcd`
+kind: `io.l5d.etcd`
 
-*experimental*
+Stores the dtab in Etcd.
 
-Stores the dtab in Etcd.  Supports the following options
-
-* *host* -- Optional. The location of the etcd API.  (default: localhost)
-* *port* -- Optional. The port used to connect to the etcd API.  (default: 2379)
-* *pathPrefix* -- Optional.  The key path under which dtabs should be stored.  (default: "/namerd/dtabs")
+Key | Default Value | Description
+--- | ------------- | -----------
+experimental | _required_ | Because this storage is still considered experimental, you must set this to `true` to use it.
+host | `localhost` | The location of the etcd API.
+port | `2379` | The port used to connect to the etcd API.
+pathPrefix | `/namerd/dtabs` | The key path under which dtabs should be stored.
 
 ## Consul
 
-`io.l5d.consul`
+kind: `io.l5d.consul`
 
-*experimental*
+Stores the dtab in Consul KV storage.
 
-Stores the dtab in Consul KV storage.  Supports the following options
-
-* *host* -- Optional. The location of the etcd API.  (default: localhost)
-* *port* -- Optional. The port used to connect to the consul API.  (default: 8500)
-* *pathPrefix* -- Optional. The key path under which dtabs should be stored. (default: "/namerd/dtabs")
-* *token* -- Optional. The auth token to use when making API calls.
-* *datacenter* -- Optional. The datacenter to forward requests to. (default: not set, use agent's datacenter)
+Key | Default Value | Description
+--- | ------------- | -----------
+experimental | _required_ | Because this storage is still considered experimental, you must set this to `true` to use it.
+host | `localhost` | The location of the consul API.
+port | `8500` | The port used to connect to the consul API.
+pathPrefix | `/namerd/dtabs` | The key path under which dtabs should be stored.
+token | no auth | The auth token to use when making API calls.
+datacenter | uses agent's datacenter | The datacenter to forward requests to.


### PR DESCRIPTION
Problem: namerd docs are not as well formatted as linkerd docs.
Solution: format them.

For future work I'd really like to see more examples in this documentation, as well
as documentation of the interface apis themselves.

I also have a pie-in-the-sky dream that all the configs standardize on
milliseconds, and be suffixed with "Ms". :)