### PR TITLE
Order server and router shutdown to prevent exceptions

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,3 +1,7 @@
+## 0.x.y
+
+* Improve shutdown ordering to facilitate graceful shutdown.
+
 ## 0.7.5
 
 * Beautiful new linkerd docs!!! :heart_eyes: https://linkerd.io/config/0.7.5/linkerd

--- a/linkerd/main/src/main/scala/io/buoyant/Linkerd.scala
+++ b/linkerd/main/src/main/scala/io/buoyant/Linkerd.scala
@@ -73,13 +73,11 @@ object Linkerd extends App {
           }
         }
 
-        closeOnExit(Closable.make { deadline =>
-          Closable.all(routers: _*).close(deadline).before {
-            val telems = Closable.all(telemeters: _*)
-            Closable.sequence(telems, adminInitializer.adminHttpServer).close(deadline)
-          }
-        })
-
+        closeOnExit(Closable.sequence(
+          Closable.all(routers: _*),
+          Closable.all(telemeters: _*),
+          adminInitializer.adminHttpServer
+        ))
         Await.all(routers: _*)
         Await.all(telemeters: _*)
         Await.result(adminInitializer.adminHttpServer)

--- a/linkerd/main/src/main/scala/io/buoyant/Linkerd.scala
+++ b/linkerd/main/src/main/scala/io/buoyant/Linkerd.scala
@@ -125,7 +125,8 @@ object Linkerd extends App {
       case Return(announced) =>
         deadline match {
           case None => closeRef.set(announced)
-          case Some(d) => announced.close(d)
+          case Some(d) =>
+            val _ = announced.close(d)
         }
     }
 

--- a/router/core/src/main/scala/com/twitter/finagle/buoyant/DstBindingFactory.scala
+++ b/router/core/src/main/scala/com/twitter/finagle/buoyant/DstBindingFactory.scala
@@ -20,8 +20,6 @@ trait DstBindingFactory[-Req, +Rsp] extends Closable {
 
 object DstBindingFactory {
 
-  private[this] val log = Logger.get("rpcs")
-
   private[buoyant] class RefCount {
     // If non-None, refcount >= 0, indicating the number of active
     // references.  When None, the reference count may not change.
@@ -211,7 +209,9 @@ object DstBindingFactory {
     private[this] val caches: Seq[Cache[_]] =
       Seq(pathCache, treeCache, boundCache, clientCache)
 
-    def close(deadline: Time) = Closable.all(caches: _*).close(deadline)
+    def close(deadline: Time) =
+      Closable.sequence(caches: _*).close(deadline)
+
     def status = Status.worstOf[Cache[_]](caches, _.status)
   }
 }


### PR DESCRIPTION
Problem

When shutting down linkerd under load, some exceptions are thrown (and requests failed).

Solution

During graceful shutdown, we must close things from the "top" (server) to the
"bottom" (client connections) so that we stop accepting requests from clients
before harvesting a router's resources.

linkerd's Main now has one big closeOnExit block that ensures proper shutdown
ordering: servers, routers, telemeters/admin.

Furthermore, we ensure that the DstBindingFactory tears down its caches in the
proper order: path, tree, bound, client.

Now everything seems copacetic during shutdown.