### PR TITLE
Change Announcer API to return a Closable.

### DIFF
--- a/linkerd/announcer/serversets/src/main/scala/com/twitter/finagle/zookeeper/buoyant/ZkAnnouncer.scala
+++ b/linkerd/announcer/serversets/src/main/scala/com/twitter/finagle/zookeeper/buoyant/ZkAnnouncer.scala
@@ -4,16 +4,16 @@ import com.twitter.finagle.{Path, Announcement}
 import com.twitter.finagle.zookeeper.{ZkAnnouncer => FZkAnnouncer, DefaultZkClientFactory}
 import com.twitter.util.Future
 import io.buoyant.config.types.HostAndPort
-import io.buoyant.linkerd.Announcer
+import io.buoyant.linkerd.FutureAnnouncer
 import java.net.InetSocketAddress
 
-class ZkAnnouncer(zkAddrs: Seq[HostAndPort], pathPrefix: Path) extends Announcer {
-  override val scheme: String = "zk-serversets"
+class ZkAnnouncer(zkAddrs: Seq[HostAndPort], pathPrefix: Path) extends FutureAnnouncer {
+  val scheme: String = "zk-serversets"
 
-  val underlying = new FZkAnnouncer(DefaultZkClientFactory)
+  private[this] val underlying = new FZkAnnouncer(DefaultZkClientFactory)
 
   private[this] val connect = zkAddrs.map(_.toString).mkString(",")
 
-  override def announce(addr: InetSocketAddress, name: Path): Future[Announcement] =
+  protected def announceAsync(addr: InetSocketAddress, name: Path): Future[Announcement] =
     underlying.announce(addr, s"$connect!${(pathPrefix ++ name).show}!0")
 }

--- a/linkerd/core/src/main/scala/io/buoyant/linkerd/Announcer.scala
+++ b/linkerd/core/src/main/scala/io/buoyant/linkerd/Announcer.scala
@@ -1,11 +1,41 @@
 package io.buoyant.linkerd
 
-import com.twitter.finagle.{Announcement, Path}
-import com.twitter.util.Future
+import com.twitter.finagle.{Announcement, Failure, Path}
+import com.twitter.util.{Closable, Future, Return, Throw, Time}
+import java.util.concurrent.atomic.AtomicReference
 import java.net.InetSocketAddress
 
 abstract class Announcer {
-  val scheme: String
+  def scheme: String
+  def announce(addr: InetSocketAddress, name: Path): Closable
+}
 
-  def announce(addr: InetSocketAddress, name: Path): Future[Announcement]
+abstract class FutureAnnouncer extends Announcer {
+
+  protected def announceAsync(addr: InetSocketAddress, name: Path): Future[Announcement]
+
+  final def announce(addr: InetSocketAddress, name: Path): Closable = {
+    val pending = announceAsync(addr, name)
+
+    // If we close before the announcer registers, we
+    // cancel the registration. If we close after
+    // registration, we close it.
+    @volatile var deadline: Option[Time] = None
+    val closeRef = new AtomicReference[Closable](Closable.make { d =>
+      deadline = Some(d)
+      pending.raise(Failure("closed").flagged(Failure.Interrupted))
+      Future.Unit
+    })
+    pending.respond {
+      case Throw(_) => closeRef.set(Closable.nop)
+      case Return(announced) =>
+        deadline match {
+          case None => closeRef.set(announced)
+          case Some(d) =>
+            val _ = announced.close(d)
+        }
+    }
+
+    Closable.ref(closeRef)
+  }
 }

--- a/linkerd/main/src/main/scala/io/buoyant/Linkerd.scala
+++ b/linkerd/main/src/main/scala/io/buoyant/Linkerd.scala
@@ -90,7 +90,7 @@ object Linkerd extends App {
         Closable.nop
 
       case announcers =>
-        val closers = matching.map {
+        val closers = announcers.map {
           case (prefix, announcer) =>
             log.info("announcing %s as %s to %s", server.addr, name.show, announcer.scheme)
             announcer.announce(server.addr, name.drop(prefix.size))

--- a/linkerd/main/src/main/scala/io/buoyant/Linkerd.scala
+++ b/linkerd/main/src/main/scala/io/buoyant/Linkerd.scala
@@ -1,13 +1,12 @@
 package io.buoyant
 
-import com.twitter.finagle.{Failure, Path}
+import com.twitter.finagle.Path
 import com.twitter.util.{Await, Awaitable, Closable, CloseAwaitably, Future, Return, Throw, Time}
 import io.buoyant.admin.{AdminInitializer, App}
 import io.buoyant.linkerd.Linker.LinkerConfig
 import io.buoyant.linkerd.admin.LinkerdAdmin
 import io.buoyant.linkerd.{Announcer, Build, Linker, Router, Server}
 import java.io.File
-import java.util.concurrent.atomic.AtomicReference
 import scala.io.Source
 
 /**
@@ -84,52 +83,20 @@ object Linkerd extends App {
     announcers0: Seq[(Path, Announcer)],
     server: Server.Initializer,
     name: Path
-  ): Closable =
+  ): Closable = {
     announcers0.filter { case (pfx, _) => name.startsWith(pfx) } match {
-      case Seq() =>
+      case Nil =>
         log.warning("no announcer found for %s", name.show)
         Closable.nop
 
       case announcers =>
-        val closers = announcers.map {
-          case (prefix, announcer) => announce(prefix, announcer, server, name)
+        val closers = matching.map {
+          case (prefix, announcer) =>
+            log.info("announcing %s as %s to %s", server.addr, name.show, announcer.scheme)
+            announcer.announce(server.addr, name.drop(prefix.size))
         }
         Closable.all(closers: _*)
     }
-
-  private def announce(
-    prefix: Path,
-    announcer: Announcer,
-    server: Server.Initializer,
-    name: Path
-  ): Closable = {
-    log.info("announcing %s as %s to %s", server.addr, name.show, announcer.scheme)
-    val pending = announcer.announce(server.addr, name.drop(prefix.size))
-
-    // If we close before the announcer registers, we
-    // cancel the registration. If we close after
-    // registration, we close it.
-    //
-    // XXX we should change the announcer API to return
-    // an Announcement synchronously (that may actually
-    // wrap some asynchronous announcement logic).
-    @volatile var deadline: Option[Time] = None
-    val closeRef = new AtomicReference[Closable](Closable.make { d =>
-      deadline = Some(d)
-      pending.raise(Failure("closed").flagged(Failure.Interrupted))
-      Future.Unit
-    })
-    pending.respond {
-      case Throw(_) => closeRef.set(Closable.nop)
-      case Return(announced) =>
-        deadline match {
-          case None => closeRef.set(announced)
-          case Some(d) =>
-            val _ = announced.close(d)
-        }
-    }
-
-    Closable.ref(closeRef)
   }
 
 }


### PR DESCRIPTION
It's more convenient (for the purposes of linkerd's execution) for the
Announcer API to just return a Closable. The FutureAnnouncer helper bridges
Finagle's Future API to linkerd's immediate API.