### PR TITLE
Improve admin and Namerd initialization

### DIFF
--- a/admin/src/main/scala/io/buoyant/admin/Admin.scala
+++ b/admin/src/main/scala/io/buoyant/admin/Admin.scala
@@ -58,7 +58,7 @@ class Admin(app: TApp) {
   def adminMuxer = {
     allRoutes.foldLeft(new HttpMuxer) {
       case (muxer, (path, handler)) =>
-        log.info(s"$path => ${handler.getClass.getName}")
+        log.debug(s"admin: $path => ${handler.getClass.getName}")
         muxer.withHandler(path, handler)
     }
   }

--- a/admin/src/main/scala/io/buoyant/admin/AdminInitializer.scala
+++ b/admin/src/main/scala/io/buoyant/admin/AdminInitializer.scala
@@ -9,7 +9,7 @@ import com.twitter.server.view.NotFoundView
 import com.twitter.util.{Awaitable, Closable, Monitor}
 import java.net.InetSocketAddress
 
-object AdminInitializer {
+private[buoyant] object AdminInitializer {
   private[this] val label = "adminhttp"
 
   private[this] val log = Logger(label)
@@ -26,7 +26,7 @@ object AdminInitializer {
     .withStatsReceiver(NullStatsReceiver)
     .withTracer(NullTracer)
 
-  def run(config: AdminConfig, service: Service[Request, Response]): Closable with Awaitable[Unit] = {
+  def run(config: AdminConfig, service: Service[Request, Response]): ListeningServer = {
     val addr = new InetSocketAddress(config.port.port)
     val svc = new NotFoundView().andThen(service)
     server.serve(addr, svc)

--- a/admin/src/main/scala/io/buoyant/admin/AdminInitializer.scala
+++ b/admin/src/main/scala/io/buoyant/admin/AdminInitializer.scala
@@ -11,8 +11,8 @@ import java.net.InetSocketAddress
 
 object AdminInitializer {
   private[this] val label = "adminhttp"
-  private[this] val log = Logger(label)
 
+  private[this] val log = Logger(label)
   private[this] val loggingMonitor = new Monitor {
     def handle(exc: Throwable): Boolean = {
       log.error(exc, label)

--- a/admin/src/main/scala/io/buoyant/admin/AdminInitializer.scala
+++ b/admin/src/main/scala/io/buoyant/admin/AdminInitializer.scala
@@ -28,7 +28,7 @@ object AdminInitializer {
 
   def run(config: AdminConfig, service: Service[Request, Response]): Closable with Awaitable[Unit] = {
     val addr = new InetSocketAddress(config.port.port)
-    val svc = new NotFoundView().andThen(servce)
+    val svc = new NotFoundView().andThen(service)
     server.serve(addr, svc)
   }
 }

--- a/admin/src/main/scala/io/buoyant/admin/AdminInitializer.scala
+++ b/admin/src/main/scala/io/buoyant/admin/AdminInitializer.scala
@@ -4,35 +4,27 @@ import com.twitter.finagle._
 import com.twitter.finagle.http.{Request, Response}
 import com.twitter.finagle.stats.NullStatsReceiver
 import com.twitter.finagle.tracing.NullTracer
-import com.twitter.logging.{Level, Logger}
+import com.twitter.logging.Logger
 import com.twitter.server.view.NotFoundView
-import com.twitter.util.Monitor
+import com.twitter.util.{Awaitable, Closable, Monitor}
 import java.net.InetSocketAddress
-import scala.util.Properties
 
-class AdminInitializer(admin: AdminConfig, svc: Service[Request, Response]) {
+object AdminInitializer {
+  private[this] val label = "adminhttp"
+  private[this] val log = Logger(label)
 
-  private[this] val log = Logger()
-
-  @volatile protected var _adminHttpServer: ListeningServer = NullServer
-  def adminHttpServer: ListeningServer = _adminHttpServer
-
-  def startServer(): Unit = {
-    val loggingMonitor = new Monitor {
-      def handle(exc: Throwable): Boolean = {
-        log.log(Level.ERROR, s"Caught exception in AdminInitializer: $exc", exc)
-        log.log(Level.ERROR, exc.getStackTrace.mkString("", Properties.lineSeparator,
-          Properties.lineSeparator))
-        false
-      }
+  private[this] val loggingMonitor = new Monitor {
+    def handle(exc: Throwable): Boolean = {
+      log.error(exc, label)
+      false
     }
-    val port = admin.port.port
-    log.info(s"Serving admin http on $port")
-    _adminHttpServer = Http.server
-      .configured(param.Stats(NullStatsReceiver))
-      .configured(param.Tracer(NullTracer))
-      .configured(param.Monitor(loggingMonitor))
-      .configured(param.Label("adminhttp"))
-      .serve(new InetSocketAddress(port), new NotFoundView andThen svc)
   }
+
+  def run(admin: AdminConfig, svc: Service[Request, Response]): Closable with Awaitable[Unit] =
+    Http.server
+      .withLabel(label)
+      .withMonitor(loggingMonitor)
+      .withStatsReceiver(NullStatsReceiver)
+      .withTracer(NullTracer)
+      .serve(new InetSocketAddress(admin.port.port), new NotFoundView().andThen(svc))
 }

--- a/admin/src/main/scala/io/buoyant/admin/AdminInitializer.scala
+++ b/admin/src/main/scala/io/buoyant/admin/AdminInitializer.scala
@@ -1,19 +1,19 @@
 package io.buoyant.admin
 
-import com.twitter.finagle._
+import com.twitter.finagle.{Http, ListeningServer, Service}
 import com.twitter.finagle.http.{Request, Response}
 import com.twitter.finagle.stats.NullStatsReceiver
 import com.twitter.finagle.tracing.NullTracer
 import com.twitter.logging.Logger
 import com.twitter.server.view.NotFoundView
-import com.twitter.util.{Awaitable, Closable, Monitor}
+import com.twitter.util.Monitor
 import java.net.InetSocketAddress
 
 private[buoyant] object AdminInitializer {
   private[this] val label = "adminhttp"
 
-  private[this] val log = Logger(label)
   private[this] val loggingMonitor = new Monitor {
+    val log = Logger(label)
     def handle(exc: Throwable): Boolean = {
       log.error(exc, label)
       false

--- a/admin/src/main/scala/io/buoyant/admin/AdminInitializer.scala
+++ b/admin/src/main/scala/io/buoyant/admin/AdminInitializer.scala
@@ -20,11 +20,15 @@ object AdminInitializer {
     }
   }
 
-  def run(admin: AdminConfig, svc: Service[Request, Response]): Closable with Awaitable[Unit] =
-    Http.server
-      .withLabel(label)
-      .withMonitor(loggingMonitor)
-      .withStatsReceiver(NullStatsReceiver)
-      .withTracer(NullTracer)
-      .serve(new InetSocketAddress(admin.port.port), new NotFoundView().andThen(svc))
+  private[this] val server = Http.server
+    .withLabel(label)
+    .withMonitor(loggingMonitor)
+    .withStatsReceiver(NullStatsReceiver)
+    .withTracer(NullTracer)
+
+  def run(config: AdminConfig, service: Service[Request, Response]): Closable with Awaitable[Unit] = {
+    val addr = new InetSocketAddress(config.port.port)
+    val svc = new NotFoundView().andThen(servce)
+    server.serve(addr, svc)
+  }
 }

--- a/linkerd/main/src/main/scala/io/buoyant/Linkerd.scala
+++ b/linkerd/main/src/main/scala/io/buoyant/Linkerd.scala
@@ -57,9 +57,8 @@ object Linkerd extends App {
 
   private def initAdmin(linker: Linker, linkerConfig: LinkerConfig): Closable with Awaitable[Unit] = {
     val linkerdAdmin = new LinkerdAdmin(this, linker, linkerConfig)
-    val adminInitializer = new AdminInitializer(linker.admin, linkerdAdmin.adminMuxer)
-    adminInitializer.startServer()
-    adminInitializer.adminHttpServer
+    log.info(s"serving http admin on %s", linker.admin.port.port)
+    AdminInitializer.run(linker.admin, linkerdAdmin.adminMuxer)
   }
 
   private def initRouter(config: Router): Closable with Awaitable[Unit] = {


### PR DESCRIPTION
Admin server initialization is far too verbose. Tidy up admin server
initialization, reducing log level on admin endpoint logging.