### PR TITLE
Require configuration for tracing.

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,6 +1,8 @@
 ## 0.x.y
 
 * Improve shutdown ordering to facilitate graceful shutdown.
+* Require tracer configuration instead of falling back to
+  defaults, reducing logging noise.
 
 ## 0.7.5
 

--- a/linkerd/core/src/main/scala/io/buoyant/linkerd/Linker.scala
+++ b/linkerd/core/src/main/scala/io/buoyant/linkerd/Linker.scala
@@ -3,15 +3,15 @@ package io.buoyant.linkerd
 import com.twitter.finagle.buoyant.DstBindingFactory
 import com.twitter.finagle.naming.NameInterpreter
 import com.twitter.finagle.{param, Path, Namer, Stack}
-import com.twitter.finagle.stats.{BroadcastStatsReceiver, DefaultStatsReceiver, NullStatsReceiver}
-import com.twitter.finagle.tracing.{debugTrace => fDebugTrace, NullTracer, DefaultTracer, BroadcastTracer, Tracer}
+import com.twitter.finagle.stats.{BroadcastStatsReceiver, NullStatsReceiver}
+import com.twitter.finagle.tracing.{debugTrace => fDebugTrace, NullTracer, BroadcastTracer, Tracer}
 import com.twitter.finagle.util.LoadService
 import com.twitter.logging.Logger
 import io.buoyant.admin.AdminConfig
 import io.buoyant.config._
 import io.buoyant.namer.Param.Namers
 import io.buoyant.namer._
-import io.buoyant.telemetry.{TelemeterInitializer, TelemeterConfig, Telemeter}
+import io.buoyant.telemetry.{DefaultTelemeter, TelemeterInitializer, TelemeterConfig, Telemeter}
 
 /**
  * Represents the total configuration of a Linkerd process.
@@ -88,44 +88,48 @@ object Linker {
       // At least one router must be specified
       if (routers.isEmpty) throw NoRoutersSpecified
 
-      val telemeters = telemetry.map(_.map(_.mk(Stack.Params.empty)))
+      val telemeters = telemetry match {
+        case None =>
+          // Use the default stats receiver but require explicit
+          // tracer configuration.
+          val default = new DefaultTelemeter(true, false)
+          Seq(default)
+        case Some(telemeters) =>
+          telemeters.map(_.mk(Stack.Params.empty))
+      }
 
       // Telemeters may provide StatsReceivers.  Note that if all
       // telemeters provide implementations that do not use the
       // default Metrics registry, linker stats may be missing from
       // /admin/metrics.json
-      val stats =
-        telemeters.getOrElse(Nil).collect { case t if !t.stats.isNull => t.stats } match {
-          case Nil =>
-            log.info(s"Using default stats receiver")
-            DefaultStatsReceiver
-          case receivers =>
-            for (r <- receivers) log.info(s"Using stats receiver: $r")
-            BroadcastStatsReceiver(receivers)
+      val stats = {
+        val receivers = telemeters.collect { case t if !t.stats.isNull => t.stats } match {
+          case Nil => NullStatsReceiver
+          case receivers => BroadcastStatsReceiver(receivers)
         }
+        for (t <- tracers) log.info("stats: %s", t)
+        receivers
+      }
 
       // Similarly, tracers may be provided by telemeters OR by
       // 'tracers' configuration.
       //
       // TODO the TracerInitializer API should be killed and these
       // modules should be converted to Telemeters.
-      val configuredTracers = tracers.map { tracers =>
-        tracers.map { t =>
-          // override the global {com.twitter.finagle.tracing.debugTrace} flag
-          fDebugTrace.parse(t.debugTrace.toString)
-          t.newTracer()
-        }
+      val configuredTracers = tracers match {
+        case None => Nil
+        case Some(tracers) =>
+          tracers.map { t =>
+            // override the global {com.twitter.finagle.tracing.debugTrace} flag
+            fDebugTrace.parse(t.debugTrace.toString)
+            t.newTracer()
+          }
       }
-      val telemeterTracers = telemeters.map { ts =>
-        ts.collect { case t if !t.tracer.isNull => t.tracer }
-      }
-      val tracer: Tracer = (configuredTracers, telemeterTracers) match {
-        case (None, None) =>
-          log.info(s"Using default tracer")
-          DefaultTracer
-        case (tracers0, tracers1) =>
-          val tracers = (tracers0 ++ tracers1).flatten.toSeq
-          for (t <- tracers) log.info(s"Using tracer: $t")
+      val telemeterTracers = telemeters.collect { case t if !t.tracer.isNull => t.tracer }
+      val tracer = (configuredTracers ++ telemeterTracers) match {
+        case Nil => NullTracer
+        case tracers =>
+          for (t <- tracers) log.info("tracer: %s", t)
           BroadcastTracer(tracers)
       }
 
@@ -163,7 +167,7 @@ object Linker {
         routerImpls,
         namersByPrefix,
         tracer,
-        telemeters.getOrElse(Nil),
+        telemeters,
         admin.getOrElse(AdminConfig())
       )
     }

--- a/linkerd/core/src/main/scala/io/buoyant/linkerd/Linker.scala
+++ b/linkerd/core/src/main/scala/io/buoyant/linkerd/Linker.scala
@@ -102,13 +102,11 @@ object Linker {
       // telemeters provide implementations that do not use the
       // default Metrics registry, linker stats may be missing from
       // /admin/metrics.json
-      val stats = {
-        val receivers = telemeters.collect { case t if !t.stats.isNull => t.stats } match {
-          case Nil => NullStatsReceiver
-          case receivers => BroadcastStatsReceiver(receivers)
-        }
-        for (t <- tracers) log.info("stats: %s", t)
-        receivers
+      val stats = telemeters.collect { case t if !t.stats.isNull => t.stats } match {
+        case Nil => NullStatsReceiver
+        case receivers =>
+          for (r <- receivers) log.info("stats: %s", r)
+          BroadcastStatsReceiver(receivers)
       }
 
       // Similarly, tracers may be provided by telemeters OR by


### PR DESCRIPTION
Problem

Falling back to use DefaultTracer causes log noise for most configurations.

Solution

Do not fall back to DefaultTracer. Instead, if no telemeter is configured, we
provide a default telemeter that has tracing disabled.