### PR TITLE
Remove `debugTrace` from tracer configuration.

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -7,6 +7,8 @@
 * Improve shutdown ordering to facilitate graceful shutdown.
 * Require tracer configuration instead of falling back to
   defaults, reducing logging noise.
+* The `debugTrace` tracer configuration flag has been removed in favor
+  of the `io.l5d.tracelog` telemeter.<<<<<<< HEAD
 * Add `io.l5d.header` identifier for naming requests based on an HTTP header
 
 ## 0.7.5

--- a/linkerd/core/src/main/scala/io/buoyant/linkerd/TracerInitializer.scala
+++ b/linkerd/core/src/main/scala/io/buoyant/linkerd/TracerInitializer.scala
@@ -1,20 +1,11 @@
 package io.buoyant.linkerd
 
-import com.fasterxml.jackson.annotation.JsonAutoDetect.Visibility
-import com.fasterxml.jackson.annotation.{JsonAutoDetect, JsonIgnore, JsonProperty, JsonTypeInfo}
-import com.twitter.finagle.tracing.{debugTrace => fDebugTrace, Tracer}
+import com.fasterxml.jackson.annotation.{JsonIgnore, JsonProperty, JsonTypeInfo}
+import com.twitter.finagle.tracing.Tracer
 import io.buoyant.config.ConfigInitializer
 
 @JsonTypeInfo(use = JsonTypeInfo.Id.NAME, include = JsonTypeInfo.As.PROPERTY, property = "kind")
-@JsonAutoDetect(fieldVisibility = Visibility.ANY)
 trait TracerConfig {
-
-  @JsonProperty("debugTrace")
-  var _debugTrace: Option[Boolean] = None
-
-  // default to {com.twitter.finagle.tracing.debugTrace} if not set
-  @JsonIgnore
-  def debugTrace: Boolean = _debugTrace.getOrElse(fDebugTrace())
 
   /**
    * Construct a tracer.

--- a/linkerd/core/src/test/scala/io/buoyant/linkerd/LinkerTest.scala
+++ b/linkerd/core/src/test/scala/io/buoyant/linkerd/LinkerTest.scala
@@ -12,8 +12,6 @@ import io.buoyant.test.Exceptions
 import java.net.{InetAddress, InetSocketAddress}
 import org.scalatest.FunSuite
 
-import com.twitter.finagle.tracing.{debugTrace => fDebugTrace}
-
 class LinkerTest extends FunSuite with Exceptions {
 
   def initializer(
@@ -185,7 +183,6 @@ class LinkerTest extends FunSuite with Exceptions {
     val yaml =
       """|tracers:
          |- kind: test
-         |  debugTrace: true
          |routers:
          |- protocol: plain
          |  servers:
@@ -195,14 +192,12 @@ class LinkerTest extends FunSuite with Exceptions {
     val param.Tracer(tracer) = linker.routers.head.params[param.Tracer]
     assert(tracer != DefaultTracer)
     assert(linker.tracer != DefaultTracer)
-    assert(fDebugTrace())
   }
 
   test("with namers & tracers & telemetry") {
     val yaml =
       """|tracers:
          |- kind: test
-         |  debugTrace: true
          |telemetry:
          |- kind: io.l5d.testTelemeter
          |  metrics: true
@@ -247,8 +242,6 @@ class LinkerTest extends FunSuite with Exceptions {
     ttracers.foreach { t =>
       assert(t.size == 1)
     }
-
-    assert(fDebugTrace())
   }
 
   test("with admin") {

--- a/linkerd/docs/tracer.md
+++ b/linkerd/docs/tracer.md
@@ -10,7 +10,6 @@ These parameters are available to the tracer regardless of kind. Tracers may als
 Key | Default Value | Description
 --- | ------------- | -----------
 kind | _required_ | Only `io.l5d.zipkin` is available at this time.
-debugTrace | `false` | If `true`, print all traces to the console. Note this overrides the global `-com.twitter.finagle.tracing.debugTrace` flag, and will default to that flag if not set here.
 
 
 ## Zipkin
@@ -23,7 +22,6 @@ tracers:
   host: localhost
   port: 9410
   sampleRate: 0.02
-  debugTrace: true
 ```
 
 kind: `io.l5d.zipkin`

--- a/linkerd/tracer/zipkin/src/test/scala/io/buoyant/linkerd/tracer/ZipkinTest.scala
+++ b/linkerd/tracer/zipkin/src/test/scala/io/buoyant/linkerd/tracer/ZipkinTest.scala
@@ -22,7 +22,6 @@ class ZipkinTest extends FunSuite {
                   |host: foo
                   |port: 1234
                   |sampleRate: 0.5
-                  |debugTrace: true
       """.stripMargin
 
     val mapper = Parser.objectMapper(yaml, Iterable(Seq(ZipkinTracerInitializer)))
@@ -30,6 +29,5 @@ class ZipkinTest extends FunSuite {
     assert(zipkin.host == Some("foo"))
     assert(zipkin.port == Some(1234))
     assert(zipkin.sampleRate == Some(0.5))
-    assert(zipkin.debugTrace == true)
   }
 }


### PR DESCRIPTION
With the introduction of the `io.l5d.tracelog` telemeter, there is no longer
any need to support the `debugTrace` flag on tracers.  This flag was a bit of a
wart, behaving differently from all other configuration options by configuring
a global parameter.