### PR TITLE
Log more info on retry within Consul API

### DIFF
--- a/consul/src/main/scala/io/buoyant/consul/v1/BaseApi.scala
+++ b/consul/src/main/scala/io/buoyant/consul/v1/BaseApi.scala
@@ -29,8 +29,8 @@ trait BaseApi extends Closable {
       case (_, Return(rep)) => rep.status.code >= 500 && rep.status.code < 600
       // Don't retry on interruption
       case (_, Throw(e: Failure)) if e.isFlagged(Failure.Interrupted) => false
-      case (_, Throw(NonFatal(ex))) =>
-        log.error(s"retrying consul request on error $ex")
+      case (req, Throw(NonFatal(ex))) =>
+        log.error(s"retrying consul request ${req.method} ${req.uri} on error $ex")
         true
     },
     HighResTimer.Default,


### PR DESCRIPTION
Transforms:
```
retrying consul request on error UnexpectedResponse(500: rpc error: No path to datacenter)
```
(and not only :) ) into
```
retrying consul request 'GET /v1/health/service/foobar?index=3497381&dc=wrong-dc&tag=&passing=true' on error UnexpectedResponse(500: rpc error: No path to datacenter)
```

which makes debugging much more efficient