### PR TITLE
Lowercase Host header value in HTTP identifier

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -8,6 +8,7 @@
 * Require tracer configuration instead of falling back to
   defaults, reducing logging noise.
 * Add `io.l5d.header` identifier for naming requests based on an HTTP header
+* Lowercase `Host` header value in `io.l5d.methodAndHost` identifier
 
 ## 0.7.5
 

--- a/linkerd/docs/protocol-http.md
+++ b/linkerd/docs/protocol-http.md
@@ -81,7 +81,8 @@ kind | _required_ | Either [`io.l5d.methodAndHost`](#method-and-host-identifier)
 kind: `io.l5d.methodAndHost`.
 
 With this identifier, HTTP requests are turned into logical names using a
-combination of Host header, method, and (optionally) URI.
+combination of `Host` header, method, and (optionally) URI. `Host`
+header value is lower-cased as per `RFC 2616`.
 
 #### Namer Configuration:
 

--- a/router/http/src/main/scala/io/buoyant/router/http/MethodAndHostIdentifier.scala
+++ b/router/http/src/main/scala/io/buoyant/router/http/MethodAndHostIdentifier.scala
@@ -34,7 +34,7 @@ case class MethodAndHostIdentifier(
     case Version.Http11 =>
       req.host match {
         case Some(host) if host.nonEmpty =>
-          val dst = mkPath(Path.Utf8("1.1", req.method.toString, host) ++ suffix(req))
+          val dst = mkPath(Path.Utf8("1.1", req.method.toString, host.toLowerCase) ++ suffix(req))
           Future.value(new IdentifiedRequest(dst, req))
         case _ =>
           Future.value(

--- a/router/http/src/test/scala/io/buoyant/router/http/MethodAndHostIdentifierTest.scala
+++ b/router/http/src/test/scala/io/buoyant/router/http/MethodAndHostIdentifierTest.scala
@@ -3,10 +3,8 @@ package io.buoyant.router.http
 import com.twitter.finagle.Path
 import com.twitter.finagle.buoyant.Dst
 import com.twitter.finagle.http.{Method, Request, Version}
-import com.twitter.util._
 import io.buoyant.router.RoutingFactory.{IdentifiedRequest, UnidentifiedRequest}
-import io.buoyant.test.{Exceptions, Awaits}
-import java.net.SocketAddress
+import io.buoyant.test.{Awaits, Exceptions}
 import org.scalatest.FunSuite
 
 class MethodAndHostIdentifierTest extends FunSuite with Awaits with Exceptions {
@@ -22,7 +20,7 @@ class MethodAndHostIdentifierTest extends FunSuite with Awaits with Exceptions {
     val identifier = MethodAndHostIdentifier(Path.Utf8("https"), false)
     val req = Request()
     req.uri = "/some/path?other=stuff"
-    req.host = "domain"
+    req.host = "DoMaiN" // should be lowercased as per RFC 2616
     assert(
       await(identifier(req)).asInstanceOf[IdentifiedRequest[Request]].dst ==
         Dst.Path(Path.read("/https/1.1/GET/domain"))


### PR DESCRIPTION
In accordance to RFC 2616. Handles #106