### PR TITLE
Add support for experimental protocols.

### DIFF
--- a/linkerd/core/src/main/scala/io/buoyant/linkerd/Linker.scala
+++ b/linkerd/core/src/main/scala/io/buoyant/linkerd/Linker.scala
@@ -155,6 +155,14 @@ object Linker {
       for ((label, rts) <- routers.groupBy(_.label))
         if (rts.size > 1) throw ConflictingLabels(label)
 
+      for (r <- routers) {
+        if (r.disabled) {
+          val msg = s"The ${r.protocol.name} protocol is experimental and must be " +
+            "explicitly enabled by setting the `experimental' parameter to `true' on each router."
+          throw new IllegalArgumentException(msg) with NoStackTrace
+        }
+      }
+
       val impls = routers.map { router =>
         val interpreter = router.interpreter.interpreter(params)
         router.router(params + DstBindingFactory.Namer(interpreter))

--- a/linkerd/core/src/main/scala/io/buoyant/linkerd/ProtocolInitializer.scala
+++ b/linkerd/core/src/main/scala/io/buoyant/linkerd/ProtocolInitializer.scala
@@ -35,6 +35,8 @@ abstract class ProtocolInitializer extends ConfigInitializer { initializer =>
   /** The default protocol-specific router configuration */
   protected def defaultRouter: StackRouter[RouterReq, RouterRsp]
 
+  def experimentalRequired: Boolean = false
+
   protected def configureServer(router: Router, server: Server): Server = {
     val ip = server.ip.getHostAddress
     val port = server.port

--- a/linkerd/core/src/main/scala/io/buoyant/linkerd/Router.scala
+++ b/linkerd/core/src/main/scala/io/buoyant/linkerd/Router.scala
@@ -165,6 +165,20 @@ trait RouterConfig {
   private def defaultBudget: Retries.Budget =
     Retries.Budget(RetryBudget(), Backoff.const(Duration.Zero))
 
+  /**
+   * This property must be set to true in order to use this router if it
+   * is experimental.
+   */
+  @JsonProperty("experimental")
+  var _experimentalEnabled: Option[Boolean] = None
+
+  /**
+   * If this protocol is experimental but has not set the
+   * `experimental` property.
+   */
+  @JsonIgnore
+  def disabled = protocol.experimentalRequired && !_experimentalEnabled.contains(true)
+
   @JsonIgnore
   def routerParams = (Stack.Params.empty + defaultBudget)
     .maybeWith(baseDtab.map(dtab => RoutingFactory.BaseDtab(() => dtab)))

--- a/linkerd/core/src/test/scala/io/buoyant/linkerd/LinkerTest.scala
+++ b/linkerd/core/src/test/scala/io/buoyant/linkerd/LinkerTest.scala
@@ -30,6 +30,7 @@ class LinkerTest extends FunSuite with Exceptions {
          |  servers:
          |  - port: 1
          |- protocol: fancy
+         |  experimental: true
          |  servers:
          |  - port: 2
          |""".stripMargin
@@ -84,6 +85,7 @@ class LinkerTest extends FunSuite with Exceptions {
          |  servers:
          |  - port: 1
          |- protocol: fancy
+         |  experimental: true
          |  servers:
          |  - port: 2
          |""".stripMargin
@@ -153,6 +155,7 @@ class LinkerTest extends FunSuite with Exceptions {
          |  - ip: 127.0.0.2
          |    port: 3
          |- protocol: fancy
+         |  experimental: true
          |  servers:
          |  - port: 3
          |""".stripMargin
@@ -269,5 +272,20 @@ class LinkerTest extends FunSuite with Exceptions {
     assertThrows[ConflictingSubtypes] {
       initializer(namers = Seq(TestNamerInitializer, ConflictingNamerInitializer)).load(yaml)
     }
+  }
+
+  test("experimental required") {
+    val yaml =
+      """|routers:
+         |- protocol: fancy
+         |  servers:
+         |  - port: 1
+         |""".stripMargin
+    val iae = intercept[IllegalArgumentException] {
+      parse(yaml)
+    }
+    assert(iae.getMessage ==
+      "The fancy protocol is experimental and must be explicitly enabled by " +
+      "setting the `experimental' parameter to `true' on each router.")
   }
 }

--- a/linkerd/core/src/test/scala/io/buoyant/linkerd/TestProtocol.scala
+++ b/linkerd/core/src/test/scala/io/buoyant/linkerd/TestProtocol.scala
@@ -147,5 +147,6 @@ object TestProtocol {
 
   object Fancy extends TestProtocol("fancy") {
     val configClass = classOf[Fancy]
+    override def experimentalRequired = true
   }
 }


### PR DESCRIPTION
Problem

Namers and DtabStores may require that they are configured with `experimental:
true`. There's no mechanism for protocols to be explicitly marked as experimental.

Solution

ProtocolInitializers now expose a `experimentalRequired` attribute, indicating
whether routers must be configured with `experimental: true`.