### PR TITLE
Bump to 0.8.0

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -8,15 +8,16 @@
   * Improve performance by only watching services as necessary and tearing
     down watches when they are no longer needed.
   * Add `consistencyMode` option to `io.l5d.consul` namer
-  * Add `readConsistencyMode` and `writeConsistencyMode` options to `io.l5d.consul` dtab storage
+  * Add `readConsistencyMode` and `writeConsistencyMode` options to
+    `io.l5d.consul` dtab storage
   * Consul Namerd/DtabStore: `failFast` and `failureAccrual` is now
     disabled by default but can be enabled with the `failFast` option
 * Improve shutdown ordering to facilitate graceful shutdown.
   * Gracefully shutdown on SIGINT and SIGTERM.
 * Require tracer configuration instead of falling back to
   defaults, reducing logging noise.
-* The `debugTrace` tracer configuration flag has been removed in favor
-  of the `io.l5d.tracelog` telemeter.
+* **Breaking Change**: The `debugTrace` tracer configuration flag has been
+  removed in favor of the `io.l5d.tracelog` telemeter.
 * Add `io.l5d.header` identifier for naming requests based on an HTTP header
 * Lowercase `Host` header value in `io.l5d.methodAndHost` identifier
 * Introduce transformers for post-processing the set of addresses returned by

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,10 +1,18 @@
-## 0.x.y
+## 0.8.0
 
 * Allow routers to be configured with a list of identifiers.  If an identifier
   cannot assign a dest to a request, it falls back to the next one in the list.
   * **Breaking Change**: Identifier plugins must now return a
     `RequestIdentification` object.
+* Consul improvements:
+  * Improve performance by only watching services as necessary and tearing
+    down watches when they are no longer needed.
+  * Add `consistencyMode` option to `io.l5d.consul` namer
+  * Add `readConsistencyMode` and `writeConsistencyMode` options to `io.l5d.consul` dtab storage
+  * Consul Namerd/DtabStore: `failFast` and `failureAccrual` is now
+    disabled by default but can be enabled with the `failFast` option
 * Improve shutdown ordering to facilitate graceful shutdown.
+  * Gracefully shutdown on SIGINT and SIGTERM.
 * Require tracer configuration instead of falling back to
   defaults, reducing logging noise.
 * The `debugTrace` tracer configuration flag has been removed in favor
@@ -13,12 +21,10 @@
 * Lowercase `Host` header value in `io.l5d.methodAndHost` identifier
 * Introduce transformers for post-processing the set of addresses returned by
   an interpreter.
-* Add k8s transformers to support linkerd-to-linkerd deployments when linkerd
-  is deployed as a k8s daemonset.
-* Add `consistencyMode` option to `io.l5d.consul` namer
-* Add `readConsistencyMode` and `writeConsistencyMode` options to `io.l5d.consul` dtab storage
-* Consul Namerd/DtabStore: `failFast` and `failureAccrual` is now
-  disabled by default but can be enabled with the `failFast` option
+  * Add k8s transformers to support linkerd-to-linkerd deployments when linkerd
+    is deployed as a k8s daemonset.
+* Remove hop-by-hop headers for better HTTP proxy compliance
+
 
 ## 0.7.5
 

--- a/README.md
+++ b/README.md
@@ -250,7 +250,7 @@ $ docker run -p 4140:4140 -p 9990:9990 -v /absolute/path/to/myapp:/myapp buoyant
 For local testing convenience, we supply a config that routes to a single backend on _localhost:8080_.
 
 ```
-$ docker run -p 4140:4140 -p 9990:9990 -v /path/to/linkerd/linkerd/examples:/config buoyantio/linkerd:0.7.5-SNAPSHOT /config/static_namer.yaml
+$ docker run -p 4140:4140 -p 9990:9990 -v /path/to/linkerd/linkerd/examples:/config buoyantio/linkerd:0.8.0-SNAPSHOT /config/static_namer.yaml
 ```
 
 The list of image names may be changed with a command like:
@@ -285,14 +285,14 @@ The assembly script executes two commands serially:
 
 ```bash
 $ ./sbt namerd/dcos:assembly
-$ namerd/target/scala-2.11/namerd-0.7.5-SNAPSHOT-dcos-exec namerd/examples/zk.yaml
+$ namerd/target/scala-2.11/namerd-0.8.0-SNAPSHOT-dcos-exec namerd/examples/zk.yaml
 ```
 
 ##### Run assembly script in docker #####
 
 ```bash
 $ ./sbt namerd/dcos:docker
-$ docker run -p 2181:2181 -p 4180:4180 -v /path/to/repo:/myapp -w /myapp buoyantio/namerd:0.7.5-SNAPSHOT-dcos namerd/examples/zk.yaml
+$ docker run -p 2181:2181 -p 4180:4180 -v /path/to/repo:/myapp -w /myapp buoyantio/namerd:0.8.0-SNAPSHOT-dcos namerd/examples/zk.yaml
 ```
 
 ### Contributing ###

--- a/project/Base.scala
+++ b/project/Base.scala
@@ -17,7 +17,7 @@ import scoverage.ScoverageSbtPlugin
  * Base project configuration.
  */
 class Base extends Build {
-  val headVersion = "0.7.5"
+  val headVersion = "0.8.0"
 
   object Git {
     def git(arg: String, args: String*) = Process("git" +: arg +: args)


### PR DESCRIPTION
## 0.8.0

* Allow routers to be configured with a list of identifiers.  If an identifier
  cannot assign a dest to a request, it falls back to the next one in the list.
  * **Breaking Change**: Identifier plugins must now return a
    `RequestIdentification` object.
* Consul improvements:
  * Improve performance by only watching services as necessary and tearing
    down watches when they are no longer needed.
  * Add `consistencyMode` option to `io.l5d.consul` namer
  * Add `readConsistencyMode` and `writeConsistencyMode` options to `io.l5d.consul` dtab storage
  * Consul Namerd/DtabStore: `failFast` and `failureAccrual` is now
    disabled by default but can be enabled with the `failFast` option
* Improve shutdown ordering to facilitate graceful shutdown.
  * Gracefully shutdown on SIGINT and SIGTERM.
* Require tracer configuration instead of falling back to
  defaults, reducing logging noise.
* The `debugTrace` tracer configuration flag has been removed in favor
  of the `io.l5d.tracelog` telemeter.
* Add `io.l5d.header` identifier for naming requests based on an HTTP header
* Lowercase `Host` header value in `io.l5d.methodAndHost` identifier
* Introduce transformers for post-processing the set of addresses returned by
  an interpreter.
  * Add k8s transformers to support linkerd-to-linkerd deployments when linkerd
    is deployed as a k8s daemonset.
* Remove hop-by-hop headers for better HTTP proxy compliance