### PR TITLE
Add an `ip` option to admin configuration

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,6 +1,7 @@
 ## 0.x.y
 
 * Removed unused TLS options from the k8s storage plugin config
+* Add an `ip` option to admin configuration so that access to the admin server may be constrained
 
 ## 0.8.1
 

--- a/admin/src/main/scala/io/buoyant/admin/AdminConfig.scala
+++ b/admin/src/main/scala/io/buoyant/admin/AdminConfig.scala
@@ -1,15 +1,18 @@
 package io.buoyant.admin
 
 import io.buoyant.config.types.Port
-import java.net.InetSocketAddress
+import java.net.{InetAddress, InetSocketAddress}
 
 case class AdminConfig(
-  port: Option[Port],
-  shutdownGraceMs: Option[Int]
+  ip: Option[InetAddress] = None,
+  port: Option[Port] = None,
+  shutdownGraceMs: Option[Int] = None
 ) {
 
-  def mk(defaultPort: Port): Admin = {
-    val addr = new InetSocketAddress(port.getOrElse(defaultPort).port)
+  def mk(defaultAddr: InetSocketAddress): Admin = {
+    val adminIp = ip.getOrElse(defaultAddr.getAddress)
+    val adminPort = port.map(_.port).getOrElse(defaultAddr.getPort)
+    val addr = new InetSocketAddress(adminIp, adminPort)
     new Admin(addr)
   }
 }

--- a/linkerd/core/src/main/scala/io/buoyant/linkerd/Linker.scala
+++ b/linkerd/core/src/main/scala/io/buoyant/linkerd/Linker.scala
@@ -1,19 +1,18 @@
 package io.buoyant.linkerd
 
-import com.twitter.finagle.{Service, http}
 import com.twitter.finagle.buoyant.DstBindingFactory
 import com.twitter.finagle.naming.NameInterpreter
-import com.twitter.finagle.{param, Path, Namer, Stack}
 import com.twitter.finagle.stats.{BroadcastStatsReceiver, LoadedStatsReceiver}
-import com.twitter.finagle.tracing.{DefaultTracer, BroadcastTracer, Tracer}
+import com.twitter.finagle.tracing.{BroadcastTracer, DefaultTracer, Tracer}
 import com.twitter.finagle.util.LoadService
+import com.twitter.finagle.{Namer, Path, Stack, param}
 import com.twitter.logging.Logger
-import io.buoyant.admin.{AdminConfig, Admin}
+import io.buoyant.admin.{Admin, AdminConfig}
 import io.buoyant.config._
-import io.buoyant.config.types.Port
 import io.buoyant.namer.Param.Namers
 import io.buoyant.namer._
 import io.buoyant.telemetry._
+import java.net.InetSocketAddress
 import scala.util.control.NoStackTrace
 
 /**
@@ -31,8 +30,8 @@ trait Linker {
 object Linker {
   private[this] val log = Logger()
 
-  private[this] val DefaultAdminPort = Port(9990)
-  private[this] val DefaultAdminConfig = AdminConfig(Some(DefaultAdminPort), None)
+  private[this] val DefaultAdminAddress = new InetSocketAddress(9990)
+  private[this] val DefaultAdminConfig = AdminConfig()
 
   private[linkerd] case class Initializers(
     protocol: Seq[ProtocolInitializer] = Nil,
@@ -121,7 +120,7 @@ object Linker {
 
       val routerImpls = mkRouters(params + Namers(namersByPrefix) + param.Stats(stats.scope("rt")))
 
-      val adminImpl = admin.getOrElse(DefaultAdminConfig).mk(DefaultAdminPort)
+      val adminImpl = admin.getOrElse(DefaultAdminConfig).mk(DefaultAdminAddress)
 
       Impl(routerImpls, namersByPrefix, tracer, telemeters, adminImpl)
     }

--- a/linkerd/core/src/test/scala/io/buoyant/linkerd/LinkerTest.scala
+++ b/linkerd/core/src/test/scala/io/buoyant/linkerd/LinkerTest.scala
@@ -1,12 +1,11 @@
 package io.buoyant.linkerd
 
-import com.twitter.finagle.buoyant.DstBindingFactory
 import com.twitter.finagle.param
 import com.twitter.finagle.stats.InMemoryStatsReceiver
 import com.twitter.finagle.tracing._
 import io.buoyant.config.{ConflictingLabels, ConflictingPorts, ConflictingSubtypes}
 import io.buoyant.namer.Param.Namers
-import io.buoyant.namer.{NamerInitializer, ConflictingNamerInitializer, TestNamerInitializer, TestNamer}
+import io.buoyant.namer.{ConflictingNamerInitializer, NamerInitializer, TestNamer, TestNamerInitializer}
 import io.buoyant.telemetry._
 import io.buoyant.test.Exceptions
 import java.net.{InetAddress, InetSocketAddress}
@@ -250,14 +249,28 @@ class LinkerTest extends FunSuite with Exceptions {
   test("with admin") {
     val yaml =
       """|admin:
-         |  port: 9991
+         |  ip: 127.0.0.1
+         |  port: 42000
          |routers:
          |- protocol: plain
          |  servers:
          |  - port: 1
          |""".stripMargin
     val linker = parse(yaml)
-    assert(linker.admin.address.asInstanceOf[InetSocketAddress].getPort == 9991)
+    assert(linker.admin.address.asInstanceOf[InetSocketAddress].getHostString == "127.0.0.1")
+    assert(linker.admin.address.asInstanceOf[InetSocketAddress].getPort == 42000)
+  }
+
+  test("with admin default") {
+    val yaml =
+      """|routers:
+        |- protocol: plain
+        |  servers:
+        |  - port: 1
+        |""".stripMargin
+    val linker = parse(yaml)
+    assert(linker.admin.address.asInstanceOf[InetSocketAddress].getHostString == "0.0.0.0")
+    assert(linker.admin.address.asInstanceOf[InetSocketAddress].getPort == 9990)
   }
 
   test("conflicting subtypes") {

--- a/linkerd/docs/config.md
+++ b/linkerd/docs/config.md
@@ -63,15 +63,17 @@ Key | Required | Description
 
 ```yaml
 admin:
+  ip: 127.0.0.1
   port: 9990
 ```
 
 linkerd supports an administrative interface, both as a web ui and a collection
-of json endpoints. The exposed admin port is configurable via a top-level
-`admin` section.
+of json endpoints. The exposed admin port and ip to listen on are configurable
+via a top-level `admin` section.
 
 Key | Default Value | Description
 --- | ------------- | -----------
+ip | `0.0.0.0` | IP for the admin interface.
 port | `9990` | Port for the admin interface.
 
 ### Routers

--- a/namerd/docs/config.md
+++ b/namerd/docs/config.md
@@ -43,11 +43,14 @@ Key | Required | Description
 
 ```yaml
 admin:
+  ip: 127.0.0.1
   port: 9991
 ```
 
-namerd supports an administrative interface. The exposed admin port is configurable via a top-level `admin` section.
+namerd supports an administrative interface. The exposed admin port and
+IP are configurable via a top-level `admin` section.
 
 Key | Default Value | Description
 --- | ------------- | -----------
+ip | `0.0.0.0` | IP for the admin interface.
 port | `9991` | Port for the admin interface.

--- a/namerd/docs/storage.md
+++ b/namerd/docs/storage.md
@@ -112,6 +112,7 @@ metadata:
 data:
   config.yml: |-
     admin:
+      ip: 127.0.0.1
       port: 9991
     storage:
       kind: io.l5d.k8s


### PR DESCRIPTION
Allow users to limit admin access to i.e. localhost.