### PR TITLE
Add tests to validate linkerd and namerd example configs

### DIFF
--- a/linkerd/examples/marathon-leader.yaml
+++ b/linkerd/examples/marathon-leader.yaml
@@ -1,3 +1,4 @@
+#notest
 namers:
 - kind:         io.l5d.marathon
   experimental: true

--- a/linkerd/examples/namerd.yaml
+++ b/linkerd/examples/namerd.yaml
@@ -1,0 +1,9 @@
+routers:
+- protocol: http
+  interpreter:
+    kind: io.l5d.namerd
+    dst: /$/inet/localhost/4100
+    namespace: default
+  servers:
+  - port: 4140
+    ip: 0.0.0.0

--- a/linkerd/examples/perhost.yaml
+++ b/linkerd/examples/perhost.yaml
@@ -28,4 +28,3 @@ routers:
     /http/1.1/* => /host;
   servers:
   - port: 4141
-    ip: 192.168.1.54

--- a/linkerd/examples/src/test/scala/io/buoyant/linkerd/examples/ExamplesTest.scala
+++ b/linkerd/examples/src/test/scala/io/buoyant/linkerd/examples/ExamplesTest.scala
@@ -1,0 +1,30 @@
+package io.buoyant.linkerd.examples
+
+import io.buoyant.linkerd.Linker
+import java.io.{FilenameFilter, File}
+import org.scalatest.FunSuite
+import scala.io.Source
+
+class ExamplesTest extends FunSuite {
+
+  val examplesDir = new File("linkerd/examples")
+  val files = examplesDir.listFiles(new FilenameFilter {
+    override def accept(dir: File, name: String): Boolean = name.endsWith(".yaml")
+  })
+
+  for (file <- files) {
+    test(file.getName) {
+      val source = Source.fromFile(file)
+      try {
+        val lines = source.getLines().toSeq
+        val firstLine = lines.headOption
+        if (!firstLine.contains("#notest")) {
+          val config = lines.mkString("\n")
+          val _ = Linker.load(config)
+        }
+      } finally {
+        source.close()
+      }
+    }
+  }
+}

--- a/linkerd/examples/thrift.yaml
+++ b/linkerd/examples/thrift.yaml
@@ -4,7 +4,7 @@
 namers:
 - kind: io.l5d.fs
   prefix: /thrift
-  rootDir: ./examples/io.l5d.fs
+  rootDir: linkerd/examples/io.l5d.fs
 
 # A simple thrift router that looks up each thrift method in io.l5d.fs.
 routers:

--- a/linkerd/examples/zipkin.yaml
+++ b/linkerd/examples/zipkin.yaml
@@ -1,0 +1,15 @@
+namers:
+- kind: io.l5d.fs
+  rootDir: linkerd/examples/io.l5d.fs
+
+routers:
+- protocol: http
+  baseDtab: |
+    /http/1.1/* => /#/io.l5d.fs
+  servers:
+  - port: 4140
+    ip: 0.0.0.0
+
+tracers:
+- kind: io.l5d.zipkin
+  sampleRate: 1.0

--- a/linkerd/examples/zk.yaml
+++ b/linkerd/examples/zk.yaml
@@ -1,0 +1,17 @@
+admin:
+  port: 15545
+namers:
+- kind: io.l5d.serversets
+  zkAddrs:
+  - host: localhost
+    port: 2181
+routers:
+- protocol: http
+  identifier:
+    kind: io.l5d.methodAndHost
+    httpUriInDst: true
+  baseDtab: |
+    /http/1.1/*/*=>/#/io.l5d.serversets/twitter/service
+  servers:
+  - port: 15724
+    ip: 0.0.0.0

--- a/namerd/examples/consul.yaml
+++ b/namerd/examples/consul.yaml
@@ -1,0 +1,12 @@
+namers:
+- kind: io.l5d.consul
+  experimental: true
+  prefix: /consul
+admin:
+  port: 9991
+storage:
+  kind: io.l5d.consul
+  experimental: true
+interfaces:
+- kind: io.l5d.thriftNameInterpreter
+- kind: io.l5d.httpController

--- a/namerd/examples/etcd.yaml
+++ b/namerd/examples/etcd.yaml
@@ -2,7 +2,7 @@ admin:
   port: 9991
 storage:
   kind: io.l5d.etcd
-  key: /dtabs
+  pathPrefix: /dtabs
 namers: []
 interfaces:
 - kind: io.l5d.thriftNameInterpreter

--- a/namerd/examples/src/test/scala/io/buoyant/namerd/examples/ExamplesTest.scala
+++ b/namerd/examples/src/test/scala/io/buoyant/namerd/examples/ExamplesTest.scala
@@ -1,0 +1,31 @@
+package io.buoyant.namerd.examples
+
+import io.buoyant.namerd.NamerdConfig
+import java.io.{File, FilenameFilter}
+import org.scalatest.FunSuite
+import scala.io.Source
+
+class ExamplesTest extends FunSuite {
+
+  val examplesDir = new File("namerd/examples")
+  val files = examplesDir.listFiles(new FilenameFilter {
+    override def accept(dir: File, name: String): Boolean = name.endsWith(".yaml")
+  })
+
+  for (file <- files) {
+    test(file.getName) {
+      val source = Source.fromFile(file)
+      try {
+        val lines = source.getLines().toSeq
+        val firstLine = lines.headOption
+        if (!firstLine.contains("#notest")) {
+          val config = lines.mkString("\n")
+          val _ = NamerdConfig.loadNamerd(config)
+        }
+      } finally {
+        source.close()
+      }
+    }
+  }
+}
+

--- a/namerd/examples/static.yaml
+++ b/namerd/examples/static.yaml
@@ -4,10 +4,8 @@ storage:
   kind: io.l5d.inMemory
   namespaces:
     default: |
-      /http/1.1/GET => /#/io.l5d.fs;
-namers:
-- kind: io.l5d.fs
-  rootDir: namerd/examples/disco
+      /http/1.1/GET/* => /$/inet/localhost/8080
+namers: []
 interfaces:
 - kind: io.l5d.thriftNameInterpreter
 - kind: io.l5d.httpController

--- a/project/LinkerdBuild.scala
+++ b/project/LinkerdBuild.scala
@@ -489,6 +489,16 @@ object LinkerdBuild extends Base {
       dockerTag := version.value
     )
 
+    val PluginBundle: Seq[ProjectReference] = Seq(
+      Namer.consul, Namer.k8s, Namer.marathon, Namer.serversets, Namer.zkLeader,
+      Interpreter.namerd, Interpreter.fs, Interpreter.perHost, Interpreter.k8s,
+      Protocol.mux, Protocol.thrift,
+      Announcer.serversets,
+      Telemetry.core, Telemetry.tracelog,
+      Tracer.zipkin,
+      tls
+    )
+
     val all = projectDir("linkerd")
       .settings(aggregateSettings)
       .aggregate(admin, core, main, configCore, Namer.all, Protocol.all, Tracer.all, Announcer.all, tls)
@@ -499,14 +509,7 @@ object LinkerdBuild extends Base {
       .settings(inConfig(Minimal)(MinimalSettings))
       .withTwitterLib(Deps.finagle("stats") % Minimal)
       // Bundle is includes all of the supported features:
-      .configDependsOn(Bundle)(
-        Namer.consul, Namer.k8s, Namer.marathon, Namer.serversets, Namer.zkLeader,
-        Interpreter.namerd, Interpreter.fs, Interpreter.perHost, Interpreter.k8s,
-        Protocol.mux, Protocol.thrift,
-        Announcer.serversets,
-        Telemetry.core, Telemetry.tracelog,
-        Tracer.zipkin,
-        tls)
+      .configDependsOn(Bundle)(PluginBundle: _*)
       .settings(inConfig(Bundle)(BundleSettings))
       .settings(
         assembly <<= assembly in Bundle,
@@ -526,6 +529,7 @@ object LinkerdBuild extends Base {
 
     val examples = projectDir("linkerd/examples")
       .withExamples(Linkerd.all, exampleConfigs)
+      .withTests()
   }
 
   val validateAssembled = taskKey[Unit]("run validation against assembled artifacts")

--- a/project/LinkerdBuild.scala
+++ b/project/LinkerdBuild.scala
@@ -636,8 +636,10 @@ object LinkerdBuild extends Base {
       testUtil,
       Interpreter.all,
       Linkerd.all,
+      Linkerd.examples,
       Namer.all,
       Namerd.all,
+      Namerd.examples,
       Router.all,
       Telemetry.all
     )


### PR DESCRIPTION
Add tests that validate that the example configs in linkerd/examples and namerd/examples can be successfully parsed.

Also added a few missing examples.