### PR TITLE
Add insert rewriting namer

### DIFF
--- a/router/http/src/test/scala/io/buoyant/http/NamerTest.scala
+++ b/router/http/src/test/scala/io/buoyant/http/NamerTest.scala
@@ -80,6 +80,11 @@ class NamerTest extends FunSuite with Awaits {
     assert(lookup(path) == NameTree.Leaf(Name.Path(Path.Utf8("pfx", "io", "buoyant", "foo"))))
   }
 
+  test("insert") {
+    val path = Path.read("/$/io.buoyant.http.insert/2/foo/zero/one/two/three")
+    assert(lookup(path) == NameTree.Leaf(Name.Path(Path.Utf8("zero", "one", "foo", "two", "three"))))
+  }
+
   test("status") {
     val client = Http.newService("/$/io.buoyant.http.status/401/foo/bar.a.b/bah")
     val rsp = await(client(Request()))


### PR DESCRIPTION
Fixes #695 

A rewriting namer that accepts names in the form /<index>/<segment>/<rest*>
and inserts <segment> at position <index> in <rest*>.  For example,
 ```
/2/foo/zero/one/two/three
```
will insert foo at position 2, resulting in:
```
/zero/one/foo/two/three
```

<img width="1276" alt="screen shot 2016-09-23 at 3 25 29 pm" src="https://cloud.githubusercontent.com/assets/3979810/18803191/a493e0a8-81a2-11e6-9395-a6dcf16a6ed8.png">
