### PR TITLE
Refactor HttpControlService

### DIFF
--- a/namerd/iface/control-http/src/main/scala/io/buoyant/namerd/iface/AddrHandler.scala
+++ b/namerd/iface/control-http/src/main/scala/io/buoyant/namerd/iface/AddrHandler.scala
@@ -1,0 +1,42 @@
+package io.buoyant.namerd.iface
+
+import com.twitter.finagle.http.{Request, Response}
+import com.twitter.finagle.{Addr, Path, Service}
+import com.twitter.io.Buf
+import com.twitter.util.Future
+import io.buoyant.admin.names.DelegateApiHandler
+import io.buoyant.admin.names.DelegateApiHandler.{Addr => JsonAddr}
+import io.buoyant.namerd.RichActivity
+
+object AddrUri extends NsPathUri {
+  import HttpControlService._
+
+  val prefix = s"$apiPrefix/addr"
+}
+
+class AddrHandler(cache: NameInterpreterCache) extends Service[Request, Response] {
+  import HttpControlService._
+
+  override def apply(req: Request): Future[Response] = req match {
+    case AddrUri(Some(ns), path) =>
+      get(ns, path, req)
+    case _ => NotFound
+  }
+
+  private[this] def get(ns: String, path: Path, req: Request): Future[Response] = {
+    if (isStreaming(req)) {
+      streamingResp(cache.getAddr(ns, path).values)(AddrHandler.renderAddr)
+    } else {
+      cache.getAddr(ns, path).toFuture.map { addr =>
+        val rsp = Response()
+        rsp.content = AddrHandler.renderAddr(addr)
+        rsp
+      }
+    }
+  }
+}
+
+object AddrHandler {
+  def renderAddr(addr: Addr): Buf =
+    DelegateApiHandler.Codec.writeBuf(JsonAddr.mk(addr)).concat(Buf.Utf8("\n"))
+}

--- a/namerd/iface/control-http/src/main/scala/io/buoyant/namerd/iface/BindHandler.scala
+++ b/namerd/iface/control-http/src/main/scala/io/buoyant/namerd/iface/BindHandler.scala
@@ -1,0 +1,46 @@
+package io.buoyant.namerd.iface
+
+import com.twitter.finagle._
+import com.twitter.finagle.http.{Request, Response}
+import com.twitter.io.Buf
+import com.twitter.util.Future
+import io.buoyant.admin.names.DelegateApiHandler
+import io.buoyant.admin.names.DelegateApiHandler.JsonDelegateTree
+import io.buoyant.namer.DelegateTree
+import io.buoyant.namerd.RichActivity
+
+object BindUri extends NsPathUri {
+  import HttpControlService._
+
+  val prefix = s"$apiPrefix/bind"
+}
+
+class BindHandler(cache: NameInterpreterCache) extends Service[Request, Response] {
+  import HttpControlService._
+
+  override def apply(req: Request): Future[Response] = req match {
+    case BindUri(Some(ns), path) => handleGetBind(ns, path, req)
+    case _ => NotFound
+  }
+
+  private[this] def handleGetBind(ns: String, path: Path, req: Request): Future[Response] = {
+    val extraDtab = req.params.get("dtab")
+    if (isStreaming(req)) {
+      streamingRespF(cache.getBind(ns, path, extraDtab).values)(BindHandler.renderNameTree)
+    } else {
+      val nameTree = cache.getBind(ns, path, extraDtab).toFuture
+      nameTree.flatMap(BindHandler.renderNameTree).map { buf =>
+        val rsp = Response()
+        rsp.content = buf
+        rsp
+      }
+    }
+  }
+}
+
+object BindHandler {
+  def renderNameTree(tree: NameTree[Name.Bound]): Future[Buf] =
+    JsonDelegateTree.mk(
+      DelegateTree.fromNameTree(tree)
+    ).map(DelegateApiHandler.Codec.writeBuf).map(_.concat(Buf.Utf8("\n")))
+}

--- a/namerd/iface/control-http/src/main/scala/io/buoyant/namerd/iface/BoundNamesHandler.scala
+++ b/namerd/iface/control-http/src/main/scala/io/buoyant/namerd/iface/BoundNamesHandler.scala
@@ -1,0 +1,51 @@
+package io.buoyant.namerd.iface
+
+import com.twitter.finagle.http.{MediaType, Method, Request, Response}
+import com.twitter.finagle.{Namer, Path, Service}
+import com.twitter.io.Buf
+import com.twitter.util.{Activity, Future}
+import io.buoyant.namer.EnumeratingNamer
+import io.buoyant.namerd.RichActivity
+
+object BoundNamesUri {
+  import io.buoyant.namerd.iface.HttpControlService._
+
+  def unapply(req: Request): Option[Request] = {
+    if (req.path == s"$apiPrefix/bound-names" && req.method == Method.Get)
+      Some(req)
+    else
+      None
+  }
+}
+
+class BoundNamesHandler(namers: Map[Path, Namer]) extends Service[Request, Response] {
+  import HttpControlService._
+
+  override def apply(req: Request): Future[Response] = req match {
+    case BoundNamesUri(_) => handleGetBoundNames(req)
+    case _ => NotFound
+  }
+
+  private[this] val enumeratingNamers = namers.values.collect {
+    case namer: EnumeratingNamer => namer
+  }.toSeq
+  private[this] val boundNames =
+    Activity.collect(enumeratingNamers.map(_.getAllNames))
+      .map(_.toSet.flatten)
+
+  private[this] def renderBoundNames(names: Set[Path]): Buf =
+    Buf.Utf8(names.map(_.show).mkString("[\"", "\",\"", "\"]\n"))
+
+  private[this] def handleGetBoundNames(req: Request): Future[Response] = {
+    if (isStreaming(req)) {
+      streamingResp(boundNames.values, Some(MediaType.Json))(renderBoundNames)
+    } else {
+      boundNames.toFuture.map { names =>
+        val rsp = Response()
+        rsp.contentType = MediaType.Json
+        rsp.content = renderBoundNames(names)
+        rsp
+      }
+    }
+  }
+}

--- a/namerd/iface/control-http/src/main/scala/io/buoyant/namerd/iface/DelegateHandler.scala
+++ b/namerd/iface/control-http/src/main/scala/io/buoyant/namerd/iface/DelegateHandler.scala
@@ -1,0 +1,44 @@
+package io.buoyant.namerd.iface
+
+import com.twitter.finagle.naming.NameInterpreter
+import com.twitter.finagle.{Namer, Dtab, Path, Service}
+import com.twitter.finagle.http.{Status, Request, Response}
+import com.twitter.util.Future
+import io.buoyant.admin.names.DelegateApiHandler
+import io.buoyant.namer.Delegator
+import io.buoyant.namerd.Ns
+
+object DelegateUri extends NsPathUri {
+  import HttpControlService._
+
+  val prefix = s"$apiPrefix/delegate"
+}
+
+class DelegateHandler(delegate: Ns => NameInterpreter, namers: Map[Path, Namer]) extends Service[Request, Response] {
+  import HttpControlService._
+
+  private[this] val delegateApiHander = new DelegateApiHandler(delegate, namers.toSeq)
+
+  override def apply(req: Request): Future[Response] = req match {
+    case DelegateUri(Some(ns), path) =>
+      get(ns, path, req.params.get("dtab"))
+    case DelegateUri(None, path) =>
+      delegateApiHander(req)
+    case _ => NotFound
+  }
+
+  private[this] def get(ns: String, path: Path, extraDtab: Option[String]): Future[Response] = {
+    delegate(ns) match {
+      case delegator: Delegator =>
+        val fullDtab = extraDtab match {
+          case Some(str) => Dtab.read(str)
+          case None => Dtab.empty
+        }
+        DelegateApiHandler.getDelegateRsp(fullDtab.show, path.show, delegator)
+      case _ =>
+        val rsp = Response(Status.NotImplemented)
+        rsp.contentString = s"Name Interpreter for $ns cannot show delegations"
+        Future.value(rsp)
+    }
+  }
+}

--- a/namerd/iface/control-http/src/main/scala/io/buoyant/namerd/iface/DtabHandler.scala
+++ b/namerd/iface/control-http/src/main/scala/io/buoyant/namerd/iface/DtabHandler.scala
@@ -1,0 +1,162 @@
+package io.buoyant.namerd.iface
+
+import com.twitter.finagle.Service
+import com.twitter.finagle.http._
+import com.twitter.io.Buf
+import com.twitter.util._
+import io.buoyant.namerd.DtabStore.{Forbidden, DtabNamespaceAlreadyExistsException, DtabVersionMismatchException, DtabNamespaceDoesNotExistException}
+import io.buoyant.namerd.{VersionedDtab, DtabStore, Ns, RichActivity}
+
+object DtabUri {
+  import HttpControlService._
+
+  val prefix = s"$apiPrefix/dtabs"
+  val prefixSlash = s"$prefix/"
+
+  def unapply(request: Request): Option[(Method, Option[Ns])] =
+    if (request.path == prefix) Some(request.method, None)
+    else if (!request.path.startsWith(prefixSlash)) None
+    else request.path.stripPrefix(prefixSlash) match {
+      case "" => Some(request.method, None)
+      case ns => Some(request.method, Some(ns))
+    }
+}
+
+class DtabHandler(storage: DtabStore) extends Service[Request, Response] {
+  import HttpControlService._
+
+  override def apply(req: Request): Future[Response] = (req match {
+    case DtabUri(_, None) =>
+      list(req)
+    case DtabUri(Method.Head, Some(ns)) =>
+      head(ns, req)
+    case DtabUri(Method.Get, Some(ns)) =>
+      get(ns, req)
+    case DtabUri(Method.Put, Some(ns)) =>
+      put(ns, req)
+    case DtabUri(Method.Post, Some(ns)) =>
+      post(ns, req)
+    case DtabUri(Method.Delete, Some(ns)) =>
+      delete(ns)
+    case _ => NotFound
+  }).handle {
+    case Forbidden => Response(Status.Forbidden)
+  }
+
+  private[this] def renderList(list: Iterable[Ns]): Buf = Json.write(list).concat(newline)
+
+  private[this] def list(req: Request): Future[Response] =
+    if (isStreaming(req)) {
+      streamingResp(storage.list().values, Some(MediaType.Json))(renderList)
+    } else {
+      storage.list().toFuture.map { namespaces =>
+        val rsp = Response()
+        rsp.contentType = MediaType.Json
+        rsp.content = renderList(namespaces.toSeq.sorted)
+        rsp
+      }
+    }
+
+  private[this] def get(ns: String, req: Request): Future[Response] = {
+    val (contentType, codec) = DtabCodec.accept(req.accept).getOrElse(DtabCodec.default)
+    if (isStreaming(req)) {
+      val dtabs: Event[Try[VersionedDtab]] = storage.observe(ns).values.collect {
+        case Return(Some(dtab)) => Return(dtab)
+        case Throw(e) => Throw(e)
+      }
+      streamingResp(dtabs, Some(contentType)) { dtab =>
+        codec.write(dtab.dtab).concat(newline)
+      }
+    } else {
+      storage.observe(ns).toFuture.map {
+        case Some(dtab) =>
+          val rsp = Response()
+          rsp.contentType = contentType
+          rsp.headerMap.add(Fields.Etag, DtabHandler.versionString(dtab.version))
+          rsp.content = codec.write(dtab.dtab).concat(newline)
+          rsp
+
+        case None => Response(Status.NotFound)
+      }
+    }
+  }
+
+  private[this] def head(ns: String, req: Request): Future[Response] =
+    storage.observe(ns).toFuture.map {
+      case Some(dtab) =>
+        val rsp = Response()
+        rsp.headerMap.add(Fields.Etag, DtabHandler.versionString(dtab.version))
+        rsp
+
+      case None => Response(Status.NotFound)
+    }
+
+  private[this] def put(ns: String, req: Request): Future[Response] =
+    req.contentType.flatMap(DtabCodec.byContentType) match {
+      case Some(codec) =>
+        codec.read(req.content) match {
+          case Return(dtab) =>
+            req.headerMap.get(Fields.IfMatch) match {
+              case Some(stamp) =>
+                val buf = Buf.ByteArray.Owned(Base64StringEncoder.decode(stamp))
+                storage.update(ns, dtab, buf).transform {
+                  case Return(_) =>
+                    Future.value(Response(Status.NoContent))
+                  case Throw(e: DtabNamespaceDoesNotExistException) =>
+                    Future.value(Response(Status.NotFound))
+                  case Throw(e: DtabVersionMismatchException) =>
+                    Future.value(Response(Status.PreconditionFailed))
+                  case Throw(_) =>
+                    Future.value(Response(Status.InternalServerError))
+                }
+              case None =>
+                storage.put(ns, dtab).map { _ =>
+                  Response(Status.NoContent)
+                }
+            }
+
+          // invalid dtab
+          case Throw(_) => Future.value(Response(Status.BadRequest))
+        }
+
+      // invalid content type
+      case None => Future.value(Response(Status.BadRequest))
+    }
+
+  private[this] def post(ns: String, req: Request): Future[Response] =
+    req.contentType.flatMap(DtabCodec.byContentType) match {
+      case Some(codec) =>
+        codec.read(req.content) match {
+          case Return(dtab) =>
+            storage.create(ns, dtab).transform {
+              case Return(_) =>
+                Future.value(Response(Status.NoContent))
+              case Throw(e: DtabNamespaceAlreadyExistsException) =>
+                Future.value(Response(Status.Conflict))
+              case Throw(_) =>
+                Future.value(Response(Status.InternalServerError))
+            }
+
+          // invalid dtab
+          case Throw(_) => Future.value(Response(Status.BadRequest))
+        }
+
+      // invalid content type
+      case None => Future.value(Response(Status.BadRequest))
+    }
+
+  private[this] def delete(ns: String): Future[Response] =
+    storage.delete(ns).transform {
+      case Return(()) => Future.value(Response(Status.NoContent))
+      case Throw(_: DtabNamespaceDoesNotExistException) => Future.value(Response(Status.NotFound))
+      case Throw(_) => Future.value(Response(Status.InternalServerError))
+    }
+}
+
+object DtabHandler {
+  private[iface] def versionString(buf: Buf): String = {
+    val versionBytes = new Array[Byte](buf.length)
+    buf.write(versionBytes, 0)
+    Base64StringEncoder.encode(versionBytes)
+  }
+}

--- a/namerd/iface/control-http/src/main/scala/io/buoyant/namerd/iface/HttpControlService.scala
+++ b/namerd/iface/control-http/src/main/scala/io/buoyant/namerd/iface/HttpControlService.scala
@@ -1,196 +1,75 @@
 package io.buoyant.namerd.iface
 
-import com.fasterxml.jackson.databind._
-import com.fasterxml.jackson.module.scala.DefaultScalaModule
-import com.fasterxml.jackson.module.scala.experimental.ScalaObjectMapper
-import com.google.common.cache.{CacheBuilder, CacheLoader, RemovalListener, RemovalNotification}
 import com.twitter.finagle.http._
 import com.twitter.finagle.naming.NameInterpreter
-import com.twitter.finagle.util.{Drv, Rng}
 import com.twitter.finagle.{Status => _, _}
 import com.twitter.io.Buf
 import com.twitter.util._
-import io.buoyant.admin.names.DelegateApiHandler
-import io.buoyant.admin.names.DelegateApiHandler.{JsonDelegateTree, Addr => JsonAddr}
-import io.buoyant.namer.{DelegateTree, Delegator, EnumeratingNamer}
-import io.buoyant.namerd.DtabStore.{DtabNamespaceDoesNotExistException, DtabVersionMismatchException, Forbidden}
-import io.buoyant.namerd.{DtabStore, Ns, RichActivity, VersionedDtab, DtabCodec => DtabModule}
+import io.buoyant.namerd.iface.HttpControlService.InvalidPathException
+import io.buoyant.namerd.{DtabStore, Ns}
 
-object HttpControlService {
+trait NsPathUri {
+  val prefix: String
+  lazy val prefixSlash = s"$prefix/"
 
-  object Json {
-
-    private[this] val mapper = new ObjectMapper with ScalaObjectMapper
-    mapper.registerModule(DefaultScalaModule)
-    mapper.registerModule(DtabModule.module)
-
-    def read[T: Manifest](buf: Buf): Try[T] = {
-      val Buf.ByteBuffer.Owned(bb) = Buf.ByteBuffer.coerce(buf)
-      Try { mapper.readValue[T](bb.array) }
-    }
-
-    def write[T](t: T): Buf =
-      Buf.ByteArray.Owned(mapper.writeValueAsBytes(t))
-  }
-
-  sealed trait DtabCodec {
-    def contentTypes: Set[String]
-    def write(dtab: Dtab): Buf
-    def read(buf: Buf): Try[Dtab]
-  }
-  object DtabCodec {
-
-    object Json extends DtabCodec {
-      val contentTypes = Set(MediaType.Json)
-      def write(dtab: Dtab) = HttpControlService.Json.write(dtab)
-      def read(buf: Buf) =
-        HttpControlService.Json.read[IndexedSeq[Dentry]](buf).map(Dtab(_))
-    }
-
-    object Text extends DtabCodec {
-      val contentTypes = Set("application/dtab", MediaType.Txt)
-      def write(dtab: Dtab) = Buf.Utf8(dtab.show)
-      def read(buf: Buf) = {
-        val Buf.Utf8(d) = buf
-        Try { Dtab.read(d) }
-      }
-    }
-
-    def accept(types: Seq[String]): Option[(String, DtabCodec)] =
-      types.map(_.toLowerCase).foldLeft[Option[(String, DtabCodec)]](None) {
-        case (None, ct) => byContentType(ct).map(ct -> _)
-        case (t, _) => t
-      }
-
-    def byContentType(ct: String): Option[DtabCodec] =
-      if (Json.contentTypes(ct)) Some(DtabCodec.Json)
-      else if (Text.contentTypes(ct)) Some(DtabCodec.Text)
-      else None
-
-    val default = (MediaType.Json, Json)
-  }
-
-  val apiPrefix = "/api/1"
-
-  object DtabUri {
-    val prefix = s"$apiPrefix/dtabs"
-    val prefixSlash = s"$prefix/"
-
-    def unapply(request: Request): Option[(Method, Option[Ns])] =
-      if (request.path == prefix) Some(request.method, None)
-      else if (!request.path.startsWith(prefixSlash)) None
-      else request.path.stripPrefix(prefixSlash) match {
-        case "" => Some(request.method, None)
-        case ns => Some(request.method, Some(ns))
-      }
-  }
-
-  case class InvalidPathException(path: String, underlying: Exception)
-    extends Exception(s"Invalid path: $path / ${underlying.getMessage}", underlying)
-
-  trait NsPathUri {
-    val prefix: String
-    lazy val prefixSlash = s"$prefix/"
-
-    def unapply(request: Request): Option[(Option[Ns], Path)] = {
-      if (request.path.startsWith(prefix)) {
-        val ns = if (request.path.startsWith(prefixSlash)) {
-          Some(request.path.stripPrefix(prefixSlash))
-        } else {
-          None
-        }
-        val path = try {
-          Path.read(request.getParam("path"))
-        } catch {
-          case e: IllegalArgumentException =>
-            throw InvalidPathException(request.getParam("path"), e)
-        }
-        Some(ns, path)
+  def unapply(request: Request): Option[(Option[Ns], Path)] = {
+    if (request.path.startsWith(prefix)) {
+      val ns = if (request.path.startsWith(prefixSlash)) {
+        Some(request.path.stripPrefix(prefixSlash))
       } else {
         None
       }
+      val path = try {
+        Path.read(request.getParam("path"))
+      } catch {
+        case e: IllegalArgumentException =>
+          throw InvalidPathException(request.getParam("path"), e)
+      }
+      Some(ns, path)
+    } else {
+      None
     }
   }
-
-  object BindUri extends NsPathUri {
-    val prefix = s"$apiPrefix/bind"
-  }
-
-  object AddrUri extends NsPathUri {
-    val prefix = s"$apiPrefix/addr"
-  }
-
-  object ResolveUri extends NsPathUri {
-    val prefix = s"$apiPrefix/resolve"
-  }
-
-  object DelegateUri extends NsPathUri {
-    val prefix = s"$apiPrefix/delegate"
-  }
-
-  def versionString(buf: Buf): String = {
-    val versionBytes = new Array[Byte](buf.length)
-    buf.write(versionBytes, 0)
-    Base64StringEncoder.encode(versionBytes)
-  }
-
-  private[iface] val newline = Buf.Utf8("\n")
-
-  private val DefaultNamer: (Path, Namer) = Path.empty -> Namer.global
 }
 
 class HttpControlService(storage: DtabStore, delegate: Ns => NameInterpreter, namers: Map[Path, Namer])
   extends Service[Request, Response] {
   import HttpControlService._
 
-  // cached activities are not held open so there is very little cost to caching
-  // them forever
-  private[this] val bindingCacheSize = 100000
-  private[this] val addrCacheSize = 100000
+  val cache = new NameInterpreterCache(delegate, namers)
 
-  /** Get the dtab, if it exists. */
-  private[this] def getDtab(ns: String): Future[Option[VersionedDtab]] =
-    storage.observe(ns).toFuture
-
-  private[this] val delegateApiHander = new DelegateApiHandler(delegate, namers.toSeq)
+  val dtabHandler = new DtabHandler(storage)
+  val bindHandler = new BindHandler(cache)
+  val addrHandler = new AddrHandler(cache)
+  val resolveHandler = new ResolveHandler(cache)
+  val delegateHandler = new DelegateHandler(delegate, namers)
+  val boundNamesHandler = new BoundNamesHandler(namers)
 
   def apply(req: Request): Future[Response] = Future(req match {
-    case DtabUri(_, None) =>
-      handleList(req)
-    case DtabUri(Method.Head, Some(ns)) =>
-      handleHeadDtab(ns, req)
-    case DtabUri(Method.Get, Some(ns)) =>
-      handleGetDtab(ns, req)
-    case DtabUri(Method.Put, Some(ns)) =>
-      handlePutDtab(ns, req)
-    case DtabUri(Method.Post, Some(ns)) =>
-      handlePostDtab(ns, req)
-    case DtabUri(Method.Delete, Some(ns)) =>
-      handleDeleteDtab(ns)
-    case BindUri(Some(ns), path) =>
-      handleGetBind(ns, path, req)
-    case AddrUri(Some(ns), path) =>
-      handleGetAddr(ns, path, req)
-    case ResolveUri(Some(ns), path) =>
-      handleGetResolve(ns, path, req)
-    case DelegateUri(Some(ns), path) =>
-      handleGetDelegate(ns, path, req.params.get("dtab"))
-    case DelegateUri(None, path) =>
-      delegateApiHander(req)
-    case _ if req.path == s"$apiPrefix/bound-names" && req.method == Method.Get =>
-      handleGetBoundNames(req)
+    case DtabUri(_, _) => dtabHandler(req)
+    case BindUri(_, _) => bindHandler(req)
+    case AddrUri(_, _) => addrHandler(req)
+    case ResolveUri(_, _) => resolveHandler(req)
+    case DelegateUri(_, _) => delegateHandler(req)
+    case BoundNamesUri(_) => boundNamesHandler(req)
     // invalid uri/method
-    case _ =>
-      Future.value(Response(Status.NotFound))
+    case _ => NotFound
   }).flatten.handle {
-    case Forbidden => Response(Status.Forbidden)
     case ex@InvalidPathException(path, _) =>
       val resp = Response(Status.BadRequest)
       resp.contentString = ex.getMessage
       resp
   }
+}
 
-  private[this] def streamingRespF[T](
+object HttpControlService {
+
+  val apiPrefix = "/api/1"
+
+  case class InvalidPathException(path: String, underlying: Exception)
+    extends Exception(s"Invalid path: $path / ${underlying.getMessage}", underlying)
+
+  private[iface] def streamingRespF[T](
     values: Event[Try[T]],
     contentType: Option[String] = None
   )(render: T => Future[Buf]): Future[Response] = {
@@ -222,7 +101,7 @@ class HttpControlService(storage: DtabStore, delegate: Ns => NameInterpreter, na
     Future.value(resp)
   }
 
-  private[this] def streamingResp[T](
+  private[iface] def streamingResp[T](
     values: Event[Try[T]],
     contentType: Option[String] = None
   )(render: T => Buf): Future[Response] =
@@ -230,286 +109,10 @@ class HttpControlService(storage: DtabStore, delegate: Ns => NameInterpreter, na
       Future.value(render(t))
     }
 
-  private[this] def isStreaming(req: Request): Boolean = req.getBooleanParam("watch")
+  private[iface] def isStreaming(req: Request): Boolean = req.getBooleanParam("watch")
 
-  private[this] def renderList(list: Iterable[Ns]): Buf = Json.write(list).concat(newline)
+  private[iface] val newline = Buf.Utf8("\n")
 
-  private[this] def handleList(req: Request): Future[Response] =
-    if (isStreaming(req)) {
-      streamingResp(storage.list().values, Some(MediaType.Json))(renderList)
-    } else {
-      storage.list().toFuture.map { namespaces =>
-        val rsp = Response()
-        rsp.contentType = MediaType.Json
-        rsp.content = renderList(namespaces.toSeq.sorted)
-        rsp
-      }
-    }
-
-  private[this] def handleGetDtab(ns: String, req: Request): Future[Response] = {
-    val (contentType, codec) = DtabCodec.accept(req.accept).getOrElse(DtabCodec.default)
-    if (isStreaming(req)) {
-      val dtabs: Event[Try[VersionedDtab]] = storage.observe(ns).values.collect {
-        case Return(Some(dtab)) => Return(dtab)
-        case Throw(e) => Throw(e)
-      }
-      streamingResp(dtabs, Some(contentType)) { dtab =>
-        codec.write(dtab.dtab).concat(newline)
-      }
-    } else {
-      storage.observe(ns).toFuture.map {
-        case Some(dtab) =>
-          val rsp = Response()
-          rsp.contentType = contentType
-          rsp.headerMap.add(Fields.Etag, versionString(dtab.version))
-          rsp.content = codec.write(dtab.dtab).concat(newline)
-          rsp
-
-        case None => Response(Status.NotFound)
-      }
-    }
-  }
-
-  private[this] def handleHeadDtab(ns: String, req: Request): Future[Response] =
-    getDtab(ns).map {
-      case Some(dtab) =>
-        val rsp = Response()
-        rsp.headerMap.add(Fields.Etag, versionString(dtab.version))
-        rsp
-
-      case None => Response(Status.NotFound)
-    }
-
-  private[this] def handlePutDtab(ns: String, req: Request): Future[Response] =
-    req.contentType.flatMap(DtabCodec.byContentType) match {
-      case Some(codec) =>
-        codec.read(req.content) match {
-          case Return(dtab) =>
-            req.headerMap.get(Fields.IfMatch) match {
-              case Some(stamp) =>
-                val buf = Buf.ByteArray.Owned(Base64StringEncoder.decode(stamp))
-                storage.update(ns, dtab, buf).transform {
-                  case Return(_) =>
-                    Future.value(Response(Status.NoContent))
-                  case Throw(e: DtabNamespaceDoesNotExistException) =>
-                    Future.value(Response(Status.NotFound))
-                  case Throw(e: DtabVersionMismatchException) =>
-                    Future.value(Response(Status.PreconditionFailed))
-                  case Throw(_) =>
-                    Future.value(Response(Status.InternalServerError))
-                }
-              case None =>
-                storage.put(ns, dtab).map { _ =>
-                  Response(Status.NoContent)
-                }
-            }
-
-          // invalid dtab
-          case Throw(_) => Future.value(Response(Status.BadRequest))
-        }
-
-      // invalid content type
-      case None => Future.value(Response(Status.BadRequest))
-    }
-
-  private[this] def handlePostDtab(ns: String, req: Request): Future[Response] =
-    req.contentType.flatMap(DtabCodec.byContentType) match {
-      case Some(codec) =>
-        codec.read(req.content) match {
-          case Return(dtab) =>
-            storage.create(ns, dtab).transform {
-              case Return(_) => Future.value(Response(Status.NoContent))
-              case Throw(_) => Future.value(Response(Status.InternalServerError))
-            }
-
-          // invalid dtab
-          case Throw(_) => Future.value(Response(Status.BadRequest))
-        }
-
-      // invalid content type
-      case None => Future.value(Response(Status.BadRequest))
-    }
-
-  private[this] def handleDeleteDtab(ns: String): Future[Response] =
-    storage.delete(ns).transform {
-      case Return(()) => Future.value(Response(Status.NoContent))
-      case Throw(_: DtabNamespaceDoesNotExistException) => Future.value(Response(Status.NotFound))
-      case Throw(_) => Future.value(Response(Status.InternalServerError))
-    }
-
-  private[this] def getBind(ns: String, path: Path, extraDtab: Option[String]): Activity[NameTree[Name.Bound]] =
-    extraDtab match {
-      case Some(dtab) => delegate(ns).bind(Dtab.read(dtab), path)
-      case _ => bindingCache.get(NsPath(ns, path)).activity
-    }
-
-  private[this] case class NsPath(ns: Ns, path: Path)
-  private[this] case class NameActClose(activity: Activity[NameTree[Name.Bound]], closable: Closable)
-
-  private[this] val bindingCache = CacheBuilder.newBuilder()
-    .maximumSize(bindingCacheSize)
-    .removalListener(new RemovalListener[NsPath, NameActClose] {
-      override def onRemoval(notification: RemovalNotification[NsPath, NameActClose]): Unit = {
-        val _ = notification.getValue.closable.close()
-      }
-    })
-    .build[NsPath, NameActClose](
-      new CacheLoader[NsPath, NameActClose] {
-        override def load(key: NsPath): NameActClose = {
-          val act = delegate(key.ns).bind(Dtab.empty, key.path)
-          // we want to keep the activity observed as long as it's in the cache
-          val closable = act.run.changes.respond(_ => ())
-          NameActClose(act, closable)
-        }
-      }
-    )
-
-  private[this] def renderNameTree(tree: NameTree[Name.Bound]): Future[Buf] =
-    JsonDelegateTree.mk(
-      DelegateTree.fromNameTree(tree)
-    ).map(DelegateApiHandler.Codec.writeBuf).map(_.concat(Buf.Utf8("\n")))
-
-  private[this] def handleGetBind(ns: String, path: Path, req: Request): Future[Response] = {
-    val extraDtab = req.params.get("dtab")
-    if (isStreaming(req)) {
-      streamingRespF(getBind(ns, path, extraDtab).values)(renderNameTree)
-    } else {
-      getBind(ns, path, extraDtab).toFuture.flatMap(renderNameTree).map { buf =>
-        val rsp = Response()
-        rsp.content = buf
-        rsp
-      }
-    }
-  }
-
-  private[this] case class AddrActClose(activity: Activity[Addr], closable: Closable)
-
-  private[this] val addrCache = CacheBuilder.newBuilder()
-    .maximumSize(addrCacheSize)
-    .removalListener(new RemovalListener[NsPath, AddrActClose] {
-      override def onRemoval(notification: RemovalNotification[NsPath, AddrActClose]): Unit = {
-        val _ = notification.getValue.closable.close()
-      }
-    })
-    .build[NsPath, AddrActClose](
-      new CacheLoader[NsPath, AddrActClose] {
-        override def load(key: NsPath): AddrActClose = {
-          val act = bindAddrId(key.path).flatMap {
-            case NameTree.Leaf(bound) => Activity(bound.addr.map(Activity.Ok(_)))
-            case NameTree.Empty => Activity.value(Addr.Bound())
-            case NameTree.Fail => Activity.exception(new Exception("name tree failed"))
-            case NameTree.Neg => Activity.value(Addr.Neg)
-            case NameTree.Alt(_) | NameTree.Union(_) =>
-              Activity.exception(new Exception(s"${key.path.show} is not a concrete bound id"))
-          }.flatMap {
-            case Addr.Pending => Activity.pending
-            case addr => Activity.value(addr)
-          }
-          // we want to keep the activity observed as long as it's in the cache
-          val closable = act.run.changes.respond(_ => ())
-          AddrActClose(act, closable)
-        }
-      }
-    )
-
-  private[this] def bindAddrId(id: Path): Activity[NameTree[Name.Bound]] = {
-    val (pfx, namer) = namers.find { case (p, _) => id.startsWith(p) }.getOrElse(DefaultNamer)
-    namer.bind(NameTree.Leaf(id.drop(pfx.size)))
-  }
-
-  private[this] def renderAddr(addr: Addr): Buf =
-    DelegateApiHandler.Codec.writeBuf(JsonAddr.mk(addr)).concat(Buf.Utf8("\n"))
-
-  private[this] def handleGetAddr(ns: String, path: Path, req: Request): Future[Response] = {
-    if (isStreaming(req)) {
-      streamingResp(addrCache.get(NsPath(ns, path)).activity.values)(renderAddr)
-    } else {
-      addrCache.get(NsPath(ns, path)).activity.toFuture.map { addr =>
-        val rsp = Response()
-        rsp.content = renderAddr(addr)
-        rsp
-      }
-    }
-  }
-
-  private[this] def handleGetDelegate(ns: String, path: Path, extraDtab: Option[String]): Future[Response] = {
-    delegate(ns) match {
-      case delegator: Delegator =>
-        val fullDtab = extraDtab match {
-          case Some(str) => Dtab.read(str)
-          case None => Dtab.empty
-        }
-        DelegateApiHandler.getDelegateRsp(fullDtab.show, path.show, delegator)
-      case _ =>
-        val rsp = Response(Status.NotImplemented)
-        rsp.contentString = s"Name Interpreter for $ns cannot show delegations"
-        Future.value(rsp)
-    }
-  }
-
-  private[this] def flattenTree(tree: NameTree[Name.Bound], rng: Rng = Rng.threadLocal): Option[Path] = {
-    tree match {
-      case NameTree.Neg | NameTree.Fail | NameTree.Empty | NameTree.Alt() => None
-      case NameTree.Leaf(bound) => bound.id match {
-        case p: Path => Some(p)
-        case _ => None
-      }
-      case NameTree.Union(weightedTrees@_*) =>
-        val (weights, trees) = weightedTrees.unzip { case NameTree.Weighted(w, t) => (w, t) }
-        val drv = Drv.fromWeights(weights)
-        val randomTree = trees(drv(rng))
-        flattenTree(randomTree, rng)
-      case NameTree.Alt(alts@_*) =>
-        flattenTree(alts.head) match {
-          case p: Some[Path] => p
-          case None => flattenTree(NameTree.Alt(alts.tail: _*), rng)
-        }
-    }
-  }
-
-  private[this] def handleGetResolve(ns: String, path: Path, req: Request): Future[Response] = {
-    val extraDtab = req.params.get("dtab")
-
-    val activity = getBind(ns, path, extraDtab).flatMap { tree =>
-      flattenTree(tree) match {
-        case Some(p) => addrCache.get(NsPath(ns, p)).activity
-        case None => Activity.value(Addr.Neg)
-      }
-    }
-
-    if (isStreaming(req)) {
-      streamingResp(activity.values, Some(MediaType.Json))(renderAddr)
-    } else {
-      activity.toFuture.map { addr =>
-        // maybe we should return 404 on Addr.Neg and 302 with Retry-After header on Addr.Pending?..
-        val rsp = Response()
-        rsp.content = renderAddr(addr)
-        rsp.contentType = MediaType.Json
-        rsp
-      }
-    }
-  }
-
-  private[this] val enumeratingNamers = namers.values.collect {
-    case namer: EnumeratingNamer => namer
-  }.toSeq
-  private[this] val boundNames =
-    Activity.collect(enumeratingNamers.map(_.getAllNames))
-      .map(_.toSet.flatten)
-
-  private[this] def renderBoundNames(names: Set[Path]): Buf =
-    Buf.Utf8(names.map(_.show).mkString("[\"", "\",\"", "\"]\n"))
-
-  private[this] def handleGetBoundNames(req: Request): Future[Response] = {
-    if (isStreaming(req)) {
-      streamingResp(boundNames.values, Some(MediaType.Json))(renderBoundNames)
-    } else {
-      boundNames.toFuture.map { names =>
-        val rsp = Response()
-        rsp.contentType = MediaType.Json
-        rsp.content = renderBoundNames(names)
-        rsp
-      }
-    }
-  }
+  private[iface] val NotFound = Future.value(Response(Status.NotFound))
 }
+

--- a/namerd/iface/control-http/src/main/scala/io/buoyant/namerd/iface/Json.scala
+++ b/namerd/iface/control-http/src/main/scala/io/buoyant/namerd/iface/Json.scala
@@ -1,0 +1,63 @@
+package io.buoyant.namerd.iface
+
+import com.fasterxml.jackson.databind._
+import com.fasterxml.jackson.module.scala.DefaultScalaModule
+import com.fasterxml.jackson.module.scala.experimental.ScalaObjectMapper
+import com.twitter.finagle.http._
+import com.twitter.finagle.{Status => _, _}
+import com.twitter.io.Buf
+import com.twitter.util._
+import io.buoyant.namerd.{DtabCodec => DtabModule}
+
+object Json {
+
+  private[this] val mapper = new ObjectMapper with ScalaObjectMapper
+  mapper.registerModule(DefaultScalaModule)
+  mapper.registerModule(DtabModule.module)
+
+  def read[T: Manifest](buf: Buf): Try[T] = {
+    val Buf.ByteBuffer.Owned(bb) = Buf.ByteBuffer.coerce(buf)
+    Try { mapper.readValue[T](bb.array) }
+  }
+
+  def write[T](t: T): Buf =
+    Buf.ByteArray.Owned(mapper.writeValueAsBytes(t))
+}
+
+sealed trait DtabCodec {
+  def contentTypes: Set[String]
+  def write(dtab: Dtab): Buf
+  def read(buf: Buf): Try[Dtab]
+}
+
+object DtabCodec {
+
+  object JsonCodec extends DtabCodec {
+    val contentTypes = Set(MediaType.Json)
+    def write(dtab: Dtab) = Json.write(dtab)
+    def read(buf: Buf) =
+      Json.read[IndexedSeq[Dentry]](buf).map(Dtab(_))
+  }
+
+  object TextCodec extends DtabCodec {
+    val contentTypes = Set("application/dtab", MediaType.Txt)
+    def write(dtab: Dtab) = Buf.Utf8(dtab.show)
+    def read(buf: Buf) = {
+      val Buf.Utf8(d) = buf
+      Try { Dtab.read(d) }
+    }
+  }
+
+  def accept(types: Seq[String]): Option[(String, DtabCodec)] =
+    types.map(_.toLowerCase).foldLeft[Option[(String, DtabCodec)]](None) {
+      case (None, ct) => byContentType(ct).map(ct -> _)
+      case (t, _) => t
+    }
+
+  def byContentType(ct: String): Option[DtabCodec] =
+    if (JsonCodec.contentTypes(ct)) Some(DtabCodec.JsonCodec)
+    else if (TextCodec.contentTypes(ct)) Some(DtabCodec.TextCodec)
+    else None
+
+  val default = (MediaType.Json, JsonCodec)
+}

--- a/namerd/iface/control-http/src/main/scala/io/buoyant/namerd/iface/NameInterpreterCache.scala
+++ b/namerd/iface/control-http/src/main/scala/io/buoyant/namerd/iface/NameInterpreterCache.scala
@@ -1,0 +1,83 @@
+package io.buoyant.namerd.iface
+
+import com.google.common.cache.{CacheLoader, RemovalNotification, RemovalListener, CacheBuilder}
+import com.twitter.finagle.naming.NameInterpreter
+import com.twitter.finagle._
+import com.twitter.util.{Activity, Closable}
+import io.buoyant.namerd.Ns
+
+private[iface] class NameInterpreterCache(delegate: Ns => NameInterpreter, namers: Map[Path, Namer]) {
+
+  private[this] case class NsPath(ns: Ns, path: Path)
+  private[this] case class NameActClose(activity: Activity[NameTree[Name.Bound]], closable: Closable)
+
+  def getBind(ns: String, path: Path, extraDtab: Option[String]): Activity[NameTree[Name.Bound]] =
+    extraDtab match {
+      case Some(dtab) => delegate(ns).bind(Dtab.read(dtab), path)
+      case _ => bindingCache.get(NsPath(ns, path)).activity
+    }
+
+  def getAddr(ns: Ns, path: Path): Activity[Addr] =
+    addrCache.get(NsPath(ns, path)).activity
+
+  // cached activities are not held open so there is very little cost to caching
+  // them forever
+  private[this] val bindingCacheSize = 100000
+  private[this] val addrCacheSize = 100000
+
+  private[this] val bindingCache = CacheBuilder.newBuilder()
+    .maximumSize(bindingCacheSize)
+    .removalListener(new RemovalListener[NsPath, NameActClose] {
+      override def onRemoval(notification: RemovalNotification[NsPath, NameActClose]): Unit = {
+        val _ = notification.getValue.closable.close()
+      }
+    })
+    .build[NsPath, NameActClose](
+      new CacheLoader[NsPath, NameActClose] {
+        override def load(key: NsPath): NameActClose = {
+          val act = delegate(key.ns).bind(Dtab.empty, key.path)
+          // we want to keep the activity observed as long as it's in the cache
+          val closable = act.run.changes.respond(_ => ())
+          NameActClose(act, closable)
+        }
+      }
+    )
+
+  private[this] case class AddrActClose(activity: Activity[Addr], closable: Closable)
+
+  private[this] val DefaultNamer: (Path, Namer) = Path.empty -> Namer.global
+
+  private[this] def bindAddrId(id: Path): Activity[NameTree[Name.Bound]] = {
+    val (pfx, namer) = namers.find { case (p, _) => id.startsWith(p) }.getOrElse(DefaultNamer)
+    namer.bind(NameTree.Leaf(id.drop(pfx.size)))
+  }
+
+  private[this] val addrCache = CacheBuilder.newBuilder()
+    .maximumSize(addrCacheSize)
+    .removalListener(new RemovalListener[NsPath, AddrActClose] {
+      override def onRemoval(notification: RemovalNotification[NsPath, AddrActClose]): Unit = {
+        val _ = notification.getValue.closable.close()
+      }
+    })
+    .build[NsPath, AddrActClose](
+      new CacheLoader[NsPath, AddrActClose] {
+        override def load(key: NsPath): AddrActClose = {
+          val act = bindAddrId(key.path).flatMap {
+            case NameTree.Leaf(bound) => Activity(bound.addr.map(Activity.Ok(_)))
+            case NameTree.Empty => Activity.value(Addr.Bound())
+            case NameTree.Fail => Activity.exception(new Exception("name tree failed"))
+            case NameTree.Neg => Activity.value(Addr.Neg)
+            case NameTree.Alt(_) | NameTree.Union(_) =>
+              Activity.exception(new Exception(s"${key.path.show} is not a concrete bound id"))
+          }.flatMap {
+            case Addr.Pending => Activity.pending
+            case addr => Activity.value(addr)
+          }
+          // we want to keep the activity observed as long as it's in the cache
+          val closable = act.run.changes.respond(_ => ())
+          AddrActClose(act, closable)
+        }
+      }
+    )
+
+}

--- a/namerd/iface/control-http/src/main/scala/io/buoyant/namerd/iface/ResolveHandler.scala
+++ b/namerd/iface/control-http/src/main/scala/io/buoyant/namerd/iface/ResolveHandler.scala
@@ -1,0 +1,66 @@
+package io.buoyant.namerd.iface
+
+import com.twitter.finagle._
+import com.twitter.finagle.http.{MediaType, Request, Response}
+import com.twitter.finagle.util.{Drv, Rng}
+import com.twitter.util.{Activity, Future}
+import io.buoyant.namerd.RichActivity
+
+object ResolveUri extends NsPathUri {
+  import HttpControlService._
+
+  val prefix = s"$apiPrefix/resolve"
+}
+
+class ResolveHandler(cache: NameInterpreterCache) extends Service[Request, Response] {
+  import HttpControlService._
+
+  override def apply(req: Request): Future[Response] = req match {
+    case ResolveUri(Some(ns), path) =>
+      get(ns, path, req)
+    case _ => NotFound
+  }
+
+  private[this] def flattenTree(tree: NameTree[Name.Bound], rng: Rng = Rng.threadLocal): Option[Path] = {
+    tree match {
+      case NameTree.Neg | NameTree.Fail | NameTree.Empty | NameTree.Alt() => None
+      case NameTree.Leaf(bound) => bound.id match {
+        case p: Path => Some(p)
+        case _ => None
+      }
+      case NameTree.Union(weightedTrees@_*) =>
+        val (weights, trees) = weightedTrees.unzip { case NameTree.Weighted(w, t) => (w, t) }
+        val drv = Drv.fromWeights(weights)
+        val randomTree = trees(drv(rng))
+        flattenTree(randomTree, rng)
+      case NameTree.Alt(alts@_*) =>
+        flattenTree(alts.head) match {
+          case p: Some[Path] => p
+          case None => flattenTree(NameTree.Alt(alts.tail: _*), rng)
+        }
+    }
+  }
+
+  private[this] def get(ns: String, path: Path, req: Request): Future[Response] = {
+    val extraDtab = req.params.get("dtab")
+
+    val activity = cache.getBind(ns, path, extraDtab).flatMap { tree =>
+      flattenTree(tree) match {
+        case Some(p) => cache.getAddr(ns, p)
+        case None => Activity.value(Addr.Neg)
+      }
+    }
+
+    if (isStreaming(req)) {
+      streamingResp(activity.values, Some(MediaType.Json))(AddrHandler.renderAddr)
+    } else {
+      activity.toFuture.map { addr =>
+        // maybe we should return 404 on Addr.Neg and 302 with Retry-After header on Addr.Pending?..
+        val rsp = Response()
+        rsp.content = AddrHandler.renderAddr(addr)
+        rsp.contentType = MediaType.Json
+        rsp
+      }
+    }
+  }
+}

--- a/namerd/iface/control-http/src/test/scala/io/buoyant/namerd/iface/HttpControlServiceTest.scala
+++ b/namerd/iface/control-http/src/test/scala/io/buoyant/namerd/iface/HttpControlServiceTest.scala
@@ -22,7 +22,7 @@ class HttpControlServiceTest extends FunSuite with Awaits {
     "tlop" -> Dtab.read("/yeezy => /pablo")
   )
 
-  val v1Stamp = HttpControlService.versionString(InMemoryDtabStore.InitialVersion)
+  val v1Stamp = DtabHandler.versionString(InMemoryDtabStore.InitialVersion)
 
   def newDtabStore(dtabs: Map[String, Dtab] = defaultDtabs): DtabStore =
     new InMemoryDtabStore(dtabs)
@@ -50,8 +50,8 @@ class HttpControlServiceTest extends FunSuite with Awaits {
   test("dtab round-trips through json") {
     val dtab = Dtab.read("/tshirt => /suit")
     val json = Buf.Utf8("""[{"prefix":"/tshirt","dst":"/suit"}]""")
-    assert(HttpControlService.Json.read[Seq[Dentry]](json) == Return(dtab))
-    assert(HttpControlService.Json.write(dtab) == json)
+    assert(Json.read[Seq[Dentry]](json) == Return(dtab))
+    assert(Json.write(dtab) == json)
   }
 
   test("GET /api/1/dtabs") {
@@ -61,7 +61,7 @@ class HttpControlServiceTest extends FunSuite with Awaits {
     val rsp = Await.result(service(req), 1.second)
     assert(rsp.status == Status.Ok)
     assert(rsp.contentType == Some(MediaType.Json))
-    val expected = HttpControlService.Json.write(defaultDtabs.keys.toSeq.sorted).concat(HttpControlService.newline)
+    val expected = Json.write(defaultDtabs.keys.toSeq.sorted).concat(HttpControlService.newline)
     assert(rsp.content == expected)
   }
 
@@ -118,7 +118,7 @@ class HttpControlServiceTest extends FunSuite with Awaits {
     val rsp = Await.result(service(req), 1.second)
     assert(rsp.status == Status.Ok)
     assert(rsp.contentType == Some(MediaType.Json))
-    val expected = HttpControlService.Json.write(defaultDtabs.keys.toSeq.sorted).concat(HttpControlService.newline)
+    val expected = Json.write(defaultDtabs.keys.toSeq.sorted).concat(HttpControlService.newline)
     assert(rsp.content == expected)
   }
 
@@ -138,7 +138,7 @@ class HttpControlServiceTest extends FunSuite with Awaits {
     assert(rsp.status == Status.Ok)
     assert(rsp.contentType == Some(MediaType.Json))
     assert(rsp.headerMap("ETag") == v1Stamp)
-    val expected = HttpControlService.Json.write(defaultDtabs("yeezus")).concat(HttpControlService.newline)
+    val expected = Json.write(defaultDtabs("yeezus")).concat(HttpControlService.newline)
     assert(rsp.content == expected)
   }
 
@@ -150,11 +150,11 @@ class HttpControlServiceTest extends FunSuite with Awaits {
     assert(rsp.status == Status.Ok)
     assert(rsp.contentType == Some(MediaType.Json))
 
-    readAndAssert(rsp.reader, HttpControlService.Json.write(defaultDtabs("yeezus")))
+    readAndAssert(rsp.reader, Json.write(defaultDtabs("yeezus")))
 
     val newDtab = Dtab.read("/yeezy=>/kanye")
     await(store.put("yeezus", newDtab))
-    readAndAssert(rsp.reader, HttpControlService.Json.write(newDtab))
+    readAndAssert(rsp.reader, Json.write(newDtab))
 
     rsp.reader.discard()
   }


### PR DESCRIPTION
HttpControlService.scala was getting really big and difficult to navigate.  I broke it into separate handlers for dtab, bind, addr, resolve, delegate, and boundNames.