### PR TITLE
fix ttlMs default in docs to match code

### DIFF
--- a/linkerd/docs/namer.md
+++ b/linkerd/docs/namer.md
@@ -185,8 +185,8 @@ includeTag | `false` | If `true`, read a Consul tag from the path.
 useHealthCheck | `false` | If `true`, rely on Consul health checks.
 token | no authentication | The auth token to use when making API calls.
 setHost | `false` | If `true`, HTTP requests resolved by Consul will have their Host header overwritten to `${serviceName}.service.${datacenter}.${domain}`. `$domain` is fetched from Consul.
-consistencyMode | `default` | Select between [Consul API consistency modes](https://www.consul.io/docs/agent/http.html) such as `default`, `stale` and `consistent`. 
-failFast | `false` | If `false`, disable fail fast and failure accrual for Consul client. Keep it `false` when using a local agent but change it to `true` when talking directly to an HA Consul API 
+consistencyMode | `default` | Select between [Consul API consistency modes](https://www.consul.io/docs/agent/http.html) such as `default`, `stale` and `consistent`.
+failFast | `false` | If `false`, disable fail fast and failure accrual for Consul client. Keep it `false` when using a local agent but change it to `true` when talking directly to an HA Consul API.
 
 ### Consul Path Parameters
 
@@ -282,7 +282,7 @@ namers:
   host:         marathon.mesos
   port:         80
   uriPrefix:    /marathon
-  ttlMs:        500
+  ttlMs:        5000
 ```
 > Then reference the namer in the dtab to use it:
 
@@ -303,7 +303,7 @@ experimental | _required_ | Because this namer is still considered experimental,
 host | `marathon.mesos` | The Marathon master host.
 port | `80` | The Marathon master port.
 uriPrefix | none | The Marathon API prefix. This prefix depends on your Marathon configuration. For example, running Marathon locally, the API is avaiable at `localhost:8080/v2/`, while the default setup on AWS/DCOS is `$(dcos config show core.dcos_url)/marathon/v2/apps`.
-ttlMs | `500` | The polling timeout in milliseconds against the marathon API.
+ttlMs | `5000` | The polling interval in milliseconds against the marathon API.
 
 ### Marathon Path Parameters
 

--- a/namerd/docs/storage.md
+++ b/namerd/docs/storage.md
@@ -41,10 +41,10 @@ The Kubernetes storage plugin does not support TLS.  Instead, you should run `ku
 which will create a local proxy for securely talking to the Kubernetes cluster API. See (the k8s guide)[https://linkerd.io/doc/latest/k8s/] for more information.
 </aside>
 
-**How to check ThirdPartyResource is enabled**  
-    1. Open `extensions/v1beta1` api - `https://<k8s-cluster-host>/apis/extensions/v1beta1`.  
+**How to check ThirdPartyResource is enabled**
+    1. Open `extensions/v1beta1` api - `https://<k8s-cluster-host>/apis/extensions/v1beta1`.
     2. Check that kind `ThirdPartyResource` exists in response:
-    
+
     ```
     {
       "kind": "APIResourceList",
@@ -60,7 +60,7 @@ which will create a local proxy for securely talking to the Kubernetes cluster A
     }
     ```
 
-**Example of configuration for ThirdPartyResource in Kubernetes**  
+**Example of configuration for ThirdPartyResource in Kubernetes**
 
   ```yaml
   metadata:
@@ -71,8 +71,8 @@ which will create a local proxy for securely talking to the Kubernetes cluster A
   versions:
     - name: v1alpha1 # Do not change this value as it hardcoded in Namerd and doesn't work with other value.
   ```
---- 
-*Complete example of `Namerd` configuration with `k8s` storage and exposed 2 services for sync with `Linkerd` and `Namerd API`:*  
+---
+*Complete example of `Namerd` configuration with `k8s` storage and exposed 2 services for sync with `Linkerd` and `Namerd API`:*
 
 ```yaml
 apiVersion: v1
@@ -234,5 +234,5 @@ token | no auth | The auth token to use when making API calls.
 datacenter | uses agent's datacenter | The datacenter to forward requests to.
 readConsistencyMode | `default` | Select between [Consul API consistency modes](https://www.consul.io/docs/agent/http.html) such as `default`, `stale` and `consistent` for reads.
 writeConsistencyMode | `default` | Select between [Consul API consistency modes](https://www.consul.io/docs/agent/http.html) such as `default`, `stale` and `consistent` for writes.
-failFast | `false` | If `false`, disable fail fast and failure accrual for Consul client. Keep it `false` when using a local agent but change it to `true` when talking directly to an HA Consul API
+failFast | `false` | If `false`, disable fail fast and failure accrual for Consul client. Keep it `false` when using a local agent but change it to `true` when talking directly to an HA Consul API.
 


### PR DESCRIPTION
this is not as much a "timeout" as it is an "interval" for polling the marathon api.

default in code:
https://github.com/BuoyantIO/linkerd/blob/master/namer/marathon/src/main/scala/io/buoyant/namer/marathon/MarathonInitializer.scala#L52