### PR TITLE
Serverside TLS support for Netty4 servers

### DIFF
--- a/ci/test.sh
+++ b/ci/test.sh
@@ -9,7 +9,7 @@ unitTests() {
 # we can't compute coverage on e2e tests because it
 # conflicts/overwrites unit coverage for some modules.
 e2eTests() {
-  ./sbt e2e:test integration:compile
+  ./sbt e2e:test integration:compile linkerd-protocol-http/integration:test
 }
 
 case "${CIRCLE_NODE_TOTAL:-1}" in

--- a/linkerd/protocol/http/src/integration/scala/io/buoyant/linkerd/protocol/TlsBoundPathTest.scala
+++ b/linkerd/protocol/http/src/integration/scala/io/buoyant/linkerd/protocol/TlsBoundPathTest.scala
@@ -282,7 +282,7 @@ class TlsBoundPathTest extends FunSuite with Awaits {
   }
 
   private[this] def withDisco(downstreams: Downstream*)(f: File => Unit): Unit = {
-    val disco = new File("mktemp -d -t disco".!!.stripLineEnd)
+    val disco = new File("mktemp -d -t disco.XXXXX".!!.stripLineEnd)
     try {
       for (ds <- downstreams) {
         val w = new java.io.PrintWriter(new File(disco, ds.name))

--- a/linkerd/protocol/http/src/integration/scala/io/buoyant/linkerd/protocol/TlsTerminationTest.scala
+++ b/linkerd/protocol/http/src/integration/scala/io/buoyant/linkerd/protocol/TlsTerminationTest.scala
@@ -9,7 +9,7 @@ import org.scalatest.FunSuite
 
 class TlsTerminationTest extends FunSuite with Awaits {
 
-  test("tls server + plain backend") {
+  test("netty3 tls server + plain backend") {
     withCerts("linkerd") { certs =>
       val dog = Downstream.const("dogs", "woof")
       try {
@@ -22,6 +22,47 @@ class TlsTerminationTest extends FunSuite with Awaits {
              |    /http/1.1/GET/clifford => /p/dog ;
              |  servers:
              |  - port: 0
+             |    tls:
+             |      certPath: ${certs.serviceCerts("linkerd").cert.getPath}
+             |      keyPath: ${certs.serviceCerts("linkerd").key.getPath}
+             |""".stripMargin
+        val linker = Linker.Initializers(Seq(HttpInitializer)).load(linkerConfig)
+
+        val router = linker.routers.head.initialize()
+        try {
+          val server = router.servers.head.serve()
+          try {
+            val client = upstreamTls(server, "linkerd", certs.caCert)
+            try {
+              val rsp = {
+                val req = Request()
+                req.host = "clifford"
+                await(client(req))
+              }
+              assert(rsp.contentString == "woof")
+
+            } finally await(client.close())
+          } finally await(server.close())
+        } finally await(router.close())
+      } finally await(dog.server.close())
+    }
+  }
+
+  test("netty4 tls server + plain backend") {
+    withCerts("linkerd") { certs =>
+      val dog = Downstream.const("dogs", "woof")
+      try {
+        val linkerConfig =
+          s"""
+             |routers:
+             |- protocol: http
+             |  baseDtab: |
+             |    /p/dog => /$$/inet/127.1/${dog.port} ;
+             |    /http/1.1/GET/clifford => /p/dog ;
+             |  servers:
+             |  - port: 0
+             |    engine:
+             |      kind: netty4
              |    tls:
              |      certPath: ${certs.serviceCerts("linkerd").cert.getPath}
              |      keyPath: ${certs.serviceCerts("linkerd").key.getPath}

--- a/linkerd/protocol/http/src/integration/scala/io/buoyant/linkerd/protocol/TlsUtils.scala
+++ b/linkerd/protocol/http/src/integration/scala/io/buoyant/linkerd/protocol/TlsUtils.scala
@@ -27,7 +27,7 @@ object TlsUtils {
   case class Certs(caCert: File, serviceCerts: Map[String, ServiceCert])
   def withCerts(names: String*)(f: Certs => Unit): Unit = {
     // First, we create a CA and get a cert/key for linker
-    val tmpdir = new File("mktemp -d -t linkerd-tls".!!.stripLineEnd)
+    val tmpdir = new File("mktemp -d -t linkerd-tls.XXXXXX".!!.stripLineEnd)
     try {
       val configFile = mkCaDirs (tmpdir)
 

--- a/linkerd/protocol/http/src/integration/scala/io/buoyant/linkerd/protocol/TlsUtils.scala
+++ b/linkerd/protocol/http/src/integration/scala/io/buoyant/linkerd/protocol/TlsUtils.scala
@@ -31,38 +31,22 @@ object TlsUtils {
     try {
       val configFile = mkCaDirs (tmpdir)
 
-      val caCert = new File (tmpdir, "cacert.pem")
-      val caKey = new File (tmpdir, "private/cakey.pem")
-      assert (run (newKeyAndCert ("/C=US/CN=Test CA", configFile, caKey, caCert) ) == 0)
+      val caCert = new File(tmpdir, "ca+cert.pem")
+      val caKey = new File(tmpdir, "private/ca_key.pem")
+      assertOk(newKeyAndCert("/C=US/CN=Test CA", configFile, caKey, caCert))
 
       val svcCerts = names.map { name =>
-        val routerReq = new File(tmpdir, s"${name}req.pem")
-        val routerCert = new File(tmpdir, s"${name}cert.pem")
-        val routerKey = new File(tmpdir, s"private/${name}key.pem")
-        assert(
-          run(
-            newReq(
-              s"/C=US/CN=$name",
-              configFile,
-              routerReq,
-              routerKey
-            )
-          ) == 0
-        )
+        val routerReq = new File(tmpdir, s"${name}_req.pem")
+        val routerCert = new File(tmpdir, s"${name}_cert.pem")
+        val routerKey = new File(tmpdir, s"private/${name}_key.tmp.pem")
+        val routerPk8 = new File(tmpdir, s"private/${name}_pk8.pem")
 
-        assert(
-          run(
-            signReq(
-              configFile,
-              caKey,
-              caCert,
-              routerReq,
-              routerCert
-            )
-          ) == 0
-        )
+        assertOk(newReq(s"/C=US/CN=$name", configFile, routerReq, routerKey))
+        assertOk(signReq(configFile, caKey, caCert, routerReq, routerCert))
+        assertOk(toPk8(routerKey, routerPk8))
+
         // routerCert has the server's cert, signed by caCert
-        name -> ServiceCert(routerCert, routerKey)
+        name -> ServiceCert(routerCert, routerPk8)
       }.toMap
 
       f(Certs (caCert, svcCerts) )
@@ -70,6 +54,9 @@ object TlsUtils {
       val _ = Seq("rm", "-rf", tmpdir.getPath).!
     }
   }
+
+  def assertOk(cmd: ProcessBuilder): Unit =
+    assert(run(cmd) == 0, s"`$cmd` failed")
 
   def upstreamTls(server: ListeningServer, tlsName: String, caCert: File) = {
     val address = Address(server.boundAddress.asInstanceOf[InetSocketAddress])
@@ -254,4 +241,8 @@ object TlsUtils {
       "-out",     newCert.getPath,
       "-infiles", req.getPath
     )
+
+
+  def toPk8(in: File, out: File): ProcessBuilder  =
+    Seq("openssl", "pkcs8", "-topk8", "-nocrypt", "-in", in.getPath, "-out", out.getPath)
 }

--- a/project/LinkerdBuild.scala
+++ b/project/LinkerdBuild.scala
@@ -391,6 +391,7 @@ object LinkerdBuild extends Base {
 
     val tls = projectDir("linkerd/tls")
       .dependsOn(core)
+      .withLibs("io.netty" % "netty-tcnative-boringssl-static" % "1.1.33.Fork23")
       .withTests()
 
     object Protocol {

--- a/validator/src/main/scala/io/buoyant/namerd/Validator.scala
+++ b/validator/src/main/scala/io/buoyant/namerd/Validator.scala
@@ -268,7 +268,7 @@ object Validator extends TwitterServer {
        |""".stripMargin
 
   def withTmpDir(f: String => Unit): Unit = {
-    val tmpdir = Process("mktemp" :: "-d" :: "-t" :: "v4l1d4t0r" :: Nil).!!.stripLineEnd
+    val tmpdir = Process("mktemp" :: "-d" :: "-t" :: "v4l1d4t0r.XXXXX" :: Nil).!!.stripLineEnd
     try f(tmpdir) finally Process("rm" :: "-rf" :: tmpdir :: Nil).!
   }
 


### PR DESCRIPTION
Netty4 servers cannot be configured with TLS, since server TLS configuration
parameters only configure Netty3's TLS subsystem.

Now, server TLS configuration influences netty4 servers as well as netty3
servers. Furthermore, servers may now be configured with a list of supported
ciphers.

Furthermore, the linkerd-tls package now depends on a static boringssl
implementation so that linkerd ships with a functional cross-platform SSL
provider.

NOTE: netty4 servers require that keys be encoded in the PKCS#8 format.

Reported-by: @moderation