### PR TITLE
Provide a default log4j configurations with linkerd and namerd

### DIFF
--- a/linkerd/main/src/main/resources/log4j.properties
+++ b/linkerd/main/src/main/resources/log4j.properties
@@ -1,0 +1,5 @@
+log4j.rootLogger=INFO, stderr
+log4j.appender.stderr=org.apache.log4j.ConsoleAppender
+log4j.appender.stderr.Target=System.err
+log4j.appender.stderr.layout=org.apache.log4j.PatternLayout
+log4j.appender.stderr.layout.ConversionPattern=%p %d{MMdd HH:mm:ss.SSS} %t: %m%n

--- a/linkerd/main/src/main/scala/io/buoyant/linkerd/Main.scala
+++ b/linkerd/main/src/main/scala/io/buoyant/linkerd/Main.scala
@@ -35,7 +35,7 @@ object Main extends App {
         val telemeters = linker.telemeters.map(_.run())
         val routers = linker.routers.map(initRouter(_))
 
-        log.info("linkerd initialized.")
+        log.info("initialized")
         registerTerminationSignalHandler(config.admin.flatMap(_.shutdownGraceMs))
         closeOnExit(Closable.sequence(
           Closable.all(routers: _*),

--- a/namerd/main/src/main/resources/log4j.properties
+++ b/namerd/main/src/main/resources/log4j.properties
@@ -1,0 +1,5 @@
+log4j.rootLogger=INFO, stderr
+log4j.appender.stderr=org.apache.log4j.ConsoleAppender
+log4j.appender.stderr.Target=System.err
+log4j.appender.stderr.layout=org.apache.log4j.PatternLayout
+log4j.appender.stderr.layout.ConversionPattern=%p %d{MMdd HH:mm:ss.SSS} %t: %m%n

--- a/project/LinkerdBuild.scala
+++ b/project/LinkerdBuild.scala
@@ -155,7 +155,9 @@ object LinkerdBuild extends Base {
        |   -XX:+UseCMSInitiatingOccupancyOnly                \
        |   -XX:CMSInitiatingOccupancyFraction=70             \
        |   -XX:-TieredCompilation                            \
-       |   -XX:+UseStringDeduplication                       "
+       |   -XX:+UseStringDeduplication                       \
+       |   -Dcom.twitter.util.events.sinkEnabled=false       \
+       |   ${LOCAL_JVM_OPTIONS:-}                            "
        |""".stripMargin
 
   object Namerd {


### PR DESCRIPTION
Currently, no log4j configuration is provided, and so linkerd emits a warning
at startup about the missing configuration.

We now provide a default log4j configuration that emits logs on the standard
error stream of linkerd and namerd.

Furthermore, init scripts now support a LOCAL_JVM_OPTIONS environment variable
to support extending JVM parameters (i.e. to specify an external
log4j.properties file).

Outputs in the format:
> DEBUG 1003 23:18:50.068 main: -Dio.netty.processId: 71323 (auto-detected)
> DEBUG 1003 23:18:50.076 main: Loopback interface: lo0 (lo0, 127.0.0.1)
> DEBUG 1003 23:18:50.077 main: /proc/sys/net/core/somaxconn: 128 (non-existent)

which isn't _quite_ the same as that of finagle, but it's close enough given the effort needed to make them identical.