### PR TITLE
Use built-in resolver for local Maven repository

### DIFF
--- a/project/Base.scala
+++ b/project/Base.scala
@@ -42,7 +42,7 @@ class Base extends Build {
     //conflictManager := ConflictManager.strict,
     resolvers ++= Seq(
       "twitter-repo" at "https://maven.twttr.com",
-      "local-m2" at s"file:${Path.userHome.absolutePath}/.m2/repository",
+      Resolver.mavenLocal,
       "typesafe" at "https://repo.typesafe.com/typesafe/releases"
     ),
     aggregate in assembly := false,


### PR DESCRIPTION
I ran into some issues building the project on my Windows machine, which I traced back to the way the "local-m2" resolver is defined. Replacing the fixed repository path with the built-in `Resolver.mavenLocal` fixed these issues for me.

This is my first contribution to the project, so please let me know if you would like me to make any changes.