### PR TITLE
Support the CI_TERRIBLENESS envvar when waiting for async results

### DIFF
--- a/circle.yml
+++ b/circle.yml
@@ -5,6 +5,8 @@ machine:
     version: 6.1.0
   services:
     - docker
+  environment:
+    CI_TERRIBLENESS: 30.seconds
 
 dependencies:
   cache_directories:

--- a/linkerd/protocol/http/src/e2e/scala/io/buoyant/linkerd/protocol/HttpEndToEndTest.scala
+++ b/linkerd/protocol/http/src/e2e/scala/io/buoyant/linkerd/protocol/HttpEndToEndTest.scala
@@ -17,8 +17,6 @@ import org.scalatest.FunSuite
 
 class HttpEndToEndTest extends FunSuite with Awaits {
 
-  override val defaultWait = 5.seconds
-
   case class Downstream(name: String, server: ListeningServer) {
     val address = server.boundAddress.asInstanceOf[InetSocketAddress]
     val port = address.getPort

--- a/router/core/src/e2e/scala/io/buoyant/router/EchoEndToEndTest.scala
+++ b/router/core/src/e2e/scala/io/buoyant/router/EchoEndToEndTest.scala
@@ -17,8 +17,6 @@ import org.scalatest.FunSuite
 
 class EchoEndToEndTest extends FunSuite with Awaits {
 
-  override val defaultWait = 5.seconds
-
   case class Downstream(name: String, server: ListeningServer) {
     val address = server.boundAddress.asInstanceOf[InetSocketAddress]
     val port = address.getPort

--- a/router/http/src/e2e/scala/io/buoyant/router/HttpEndToEndTest.scala
+++ b/router/http/src/e2e/scala/io/buoyant/router/HttpEndToEndTest.scala
@@ -14,8 +14,6 @@ import org.scalatest.FunSuite
 
 class HttpEndToEndTest extends FunSuite with Awaits {
 
-  override val defaultWait = 5.seconds
-
   case class Downstream(name: String, server: ListeningServer) {
     val address = server.boundAddress.asInstanceOf[InetSocketAddress]
     val port = address.getPort

--- a/router/mux/src/e2e/scala/io/buoyant/router/MuxEndToEndTest.scala
+++ b/router/mux/src/e2e/scala/io/buoyant/router/MuxEndToEndTest.scala
@@ -12,19 +12,15 @@ import org.scalatest.FunSuite
 
 class MuxEndToEndTest extends FunSuite with Awaits {
 
-  // since this is dealing with open sockets we need to be somewhat
-  // tolerant to slow test environments (cough circleci).
-  override val defaultWait = 5.seconds
-
   /*
    * A bunch of utility/setup.  The test is configured as follows:
    *
    * - Downstreams are created. these are target services that serve
    *   requests.
-   * 
+   *
    * - A Router is created that is configured with a dtab that routes
    *   certain requests by name.
-   * 
+   *
    * - An Upstream is created connected to the router (or directly to
    *   the downstream).  As it is issued names, they are used to
    *   resolve a downstream through the router.

--- a/router/thrift/src/e2e/scala/io/buoyant/router/ThriftEndToEndTest.scala
+++ b/router/thrift/src/e2e/scala/io/buoyant/router/ThriftEndToEndTest.scala
@@ -13,8 +13,6 @@ import org.scalatest.FunSuite
 
 class ThriftEndToEndTest extends FunSuite with Awaits {
 
-  override val defaultWait = 5.seconds
-
   case class Downstream(name: String, server: ListeningServer) {
     val address = server.boundAddress.asInstanceOf[InetSocketAddress]
     val port = address.getPort

--- a/test-util/src/main/scala/io/buoyant/test/Awaits.scala
+++ b/test-util/src/main/scala/io/buoyant/test/Awaits.scala
@@ -6,7 +6,9 @@ import org.scalatest.exceptions.TestFailedException
 
 trait Awaits {
 
-  def defaultWait: Duration = 2.seconds
+  def defaultWait: Duration =
+    sys.env.get("CI_TERRIBLENESS").map(Duration.parse(_)).getOrElse(2.seconds)
+
   def awaitStackDepth: Int = 4
 
   def await[T](t: Duration)(f: => Future[T]): T =


### PR DESCRIPTION
Our CI fails constantly because the sleep timeouts are too low. We can support low timeouts for local development but high timeouts for CI by introducing the `CI_TERRIBLENESS` variable.