### PR TITLE
Add k8s-external namer

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -3,6 +3,7 @@
 * Consul namer can use `.local` to reference local agent's datacenter
 * Removed unused TLS options from the k8s storage plugin config
 * Add an `ip` option to admin configuration so that access to the admin server may be constrained
+* Add k8s-external namer for routing to k8s ingress services
 
 ## 0.8.1
 

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -3,7 +3,7 @@
 * Consul namer can use `.local` to reference local agent's datacenter
 * Removed unused TLS options from the k8s storage plugin config
 * Add an `ip` option to admin configuration so that access to the admin server may be constrained
-* Add k8s-external namer for routing to k8s ingress services
+* Add k8s external namer for routing to k8s ingress services
 
 ## 0.8.1
 

--- a/k8s/src/main/scala/io/buoyant/k8s/Ns.scala
+++ b/k8s/src/main/scala/io/buoyant/k8s/Ns.scala
@@ -1,0 +1,93 @@
+package io.buoyant.k8s
+
+import com.twitter.conversions.time._
+import com.twitter.finagle.service.Backoff
+import com.twitter.finagle.tracing.Trace
+import com.twitter.finagle.util.DefaultTimer
+import com.twitter.util._
+
+abstract class Ns[O <: KubeObject: Manifest, W <: Watch[O]: Manifest, L <: KubeList[O]: Manifest, Cache](
+  backoff: Stream[Duration] = Backoff.exponentialJittered(10.milliseconds, 10.seconds),
+  timer: Timer = DefaultTimer.twitter
+) {
+  // note that caches must be updated with synchronized
+  private[this] val caches = Var[Map[String, Cache]](Map.empty[String, Cache])
+  // XXX once a namespace is watched, it is watched forever.
+  private[this] var _watches = Map.empty[String, Activity[Closable]]
+  def watches = _watches
+
+  /**
+   * Returns an Activity backed by a Future.  The resultant Activity is pending until the
+   * original future is satisfied.  When the Future is successful, the Activity becomes
+   * an Activity.Ok with a fixed value from the Future.  If the Future fails, the Activity
+   * becomes an Activity.Failed and the Future is retried with the given backoff schedule.
+   * Therefore, the legal state transitions are:
+   *
+   * Pending -> Ok
+   * Pending -> Failed
+   * Failed -> Failed
+   * Failed -> Ok
+   */
+  private[this] def retryToActivity[T](go: => Future[T]): Activity[T] = {
+    val state = Var[Activity.State[T]](Activity.Pending)
+    _retryToActivity(backoff, state)(go)
+    Activity(state)
+  }
+
+  private[this] def _retryToActivity[T](
+    remainingBackoff: Stream[Duration],
+    state: Var[Activity.State[T]] with Updatable[Activity.State[T]] = Var[Activity.State[T]](Activity.Pending)
+  )(go: => Future[T]): Unit = {
+    val _ = go.respond {
+      case Return(t) =>
+        state() = Activity.Ok(t)
+      case Throw(e) =>
+        state() = Activity.Failed(e)
+        remainingBackoff match {
+          case delay #:: rest =>
+            val _ = Future.sleep(delay)(timer).onSuccess { _ => _retryToActivity(rest, state)(go) }
+          case Stream.Empty =>
+        }
+    }
+  }
+
+  protected def mkResource(name: String): NsListResource[O, W, L]
+
+  protected def mkCache(name: String): Cache
+
+  protected def initialize(cache: Cache, list: L): Unit
+
+  protected def update(cache: Cache)(event: W): Unit
+
+  def get(name: String): Cache = synchronized {
+    caches.sample.get(name) match {
+      case Some(ns) => ns
+      case None =>
+        val ns = mkCache(name)
+        val closable = retryToActivity { watch(name, ns) }
+        _watches += (name -> closable)
+        caches() = caches.sample + (name -> ns)
+        ns
+    }
+  }
+
+  val namespaces: Var[Set[String]] = caches.map(_.keySet)
+
+  private[this] def watch(namespace: String, cache: Cache): Future[Closable] = {
+    val resource = mkResource(namespace)
+    Trace.letClear {
+      log.info("k8s initializing %s", namespace)
+      resource.get().map { list =>
+        initialize(cache, list)
+        val (updates, closable) = resource.watch(
+          resourceVersion = list.metadata.flatMap(_.resourceVersion)
+        )
+        // fire-and-forget this traversal over an AsyncStream that updates the services state
+        val _ = updates.foreach(update(cache))
+        closable
+      }.onFailure { e =>
+        log.error(e, "k8s failed to list endpoints")
+      }
+    }
+  }
+}

--- a/k8s/src/main/scala/io/buoyant/k8s/ServiceNamer.scala
+++ b/k8s/src/main/scala/io/buoyant/k8s/ServiceNamer.scala
@@ -1,0 +1,167 @@
+package io.buoyant.k8s
+
+import com.twitter.conversions.time._
+import com.twitter.finagle.{Service => _, _}
+import com.twitter.finagle.service.Backoff
+import com.twitter.finagle.util.DefaultTimer
+import com.twitter.util._
+import io.buoyant.k8s.v1._
+import java.net.InetSocketAddress
+
+class ServiceNamer(
+  idPrefix: Path,
+  mkApi: String => NsApi,
+  backoff: Stream[Duration] = Backoff.exponentialJittered(10.milliseconds, 10.seconds)
+)(implicit timer: Timer = DefaultTimer.twitter) extends Namer {
+
+  private[this] val PrefixLen = 3
+
+  override def lookup(path: Path): Activity[NameTree[Name]] = path.take(PrefixLen) match {
+    case id@Path.Utf8(nsName, portName, serviceName) =>
+
+      val nameTree = serviceNs.get(nsName).get(serviceName, portName).map {
+        case Some(address) =>
+          val bound = address.map(Addr.Bound(_))
+          NameTree.Leaf(Name.Bound(bound, idPrefix ++ id, path.drop(PrefixLen)))
+        case None =>
+          NameTree.Neg
+      }
+      Activity(nameTree.map(Activity.Ok(_)))
+
+    case _ =>
+      Activity.value(NameTree.Neg)
+  }
+
+  private[this] def getPort(service: Service, portName: String): Option[Int] =
+    for {
+      spec <- service.spec
+      port <- spec.ports.find(_.name == portName)
+    } yield port.port
+
+  val serviceNs = new Ns[Service, ServiceWatch, ServiceList, ServiceCache](backoff, timer) {
+    override protected def mkResource(name: String): NsListResource[Service, ServiceWatch, ServiceList] =
+      mkApi(name).services
+
+    override protected def mkCache(name: String): ServiceCache =
+      new ServiceCache(name)
+
+    override protected def update(cache: ServiceCache)(event: ServiceWatch): Unit =
+      cache.update(event)
+
+    override protected def initialize(
+      cache: ServiceCache,
+      list: ServiceList
+    ): Unit = cache.initialize(list)
+  }
+}
+
+class ServiceCache(namespace: String) {
+
+  def get(serviceName: String, portName: String): Var[Option[Var[Address]]] = synchronized {
+    // we call this unstable because every change to the Address will cause
+    // the entire Var[Option[Address]] to update.
+    val unstable = cache.get(serviceName) match {
+      case Some(ports) => ports.map(_.get(portName))
+      case None =>
+        val ports = Var(Map.empty[String, Address])
+        cache += serviceName -> ports
+        ports.map(_.get(portName))
+    }
+
+    // We can stabilize this by changing the type to Var[Option[Var[Address]]].
+    // If this service port is created or deleted, the outer Var will update.
+    // If the address of the service port changes, only the inner Var will
+    // update.
+    val init = unstable.sample().map(Var(_))
+    Var.async[Option[VarUp[Address]]](init) { update =>
+      // the current inner Var, null if the outer Var is None
+      @volatile var addr: VarUp[Address] = null
+
+      unstable.changes.respond {
+        case Some(address) if addr == null =>
+          // Address created
+          addr = Var(address)
+          update() = Some(addr)
+        case Some(address) =>
+          // Address modified
+          addr() = address
+        case None =>
+          // Address deleted
+          addr = null
+          update() = None
+      }
+    }
+  }
+
+  private[this]type VarUp[T] = Var[T] with Updatable[T]
+
+  private[this] var cache = Map.empty[String, VarUp[Map[String, Address]]]
+
+  private[this] def extractPorts(service: Service): Map[String, Address] = {
+    val ports = for {
+      meta <- service.metadata.toSeq
+      name <- meta.name.toSeq
+      status <- service.status.toSeq
+      lb <- status.loadBalancer.toSeq
+      ingress <- lb.ingress.toSeq.flatten
+      spec <- service.spec.toSeq
+      port <- spec.ports
+    } yield port.name -> Address(new InetSocketAddress(ingress.ip, port.port))
+    ports.toMap
+  }
+
+  def initialize(list: ServiceList): Unit = synchronized {
+    val services = for {
+      service <- list.items
+      meta <- service.metadata
+      name <- meta.name
+    } yield name -> Var(extractPorts(service))
+    cache = services.toMap
+  }
+
+  def update(watch: ServiceWatch): Unit = synchronized {
+    watch match {
+      case ServiceAdded(service) =>
+        for {
+          meta <- service.metadata
+          name <- meta.name
+        } {
+          log.info("k8s added service: %s", name)
+          cache.get(name) match {
+            case Some(ports) =>
+              ports() = extractPorts(service)
+            case None =>
+              cache += (name -> Var(extractPorts(service)))
+          }
+        }
+      case ServiceModified(service) =>
+        for {
+          meta <- service.metadata
+          name <- meta.name
+        } {
+          cache.get(name) match {
+            case Some(ports) =>
+              log.info("k8s modified service: %s", name)
+              ports() = extractPorts(service)
+            case None =>
+              log.warning("k8s received modified watch for unknown service %s", name)
+          }
+        }
+      case ServiceDeleted(service) =>
+        for {
+          meta <- service.metadata
+          name <- meta.name
+        } {
+          log.debug("k8s deleted service : %s", name)
+          cache.get(name) match {
+            case Some(ports) =>
+              ports() = Map.empty
+            case None =>
+              cache += (name -> Var(Map.empty))
+          }
+        }
+      case ServiceError(status) =>
+        log.error("k8s service port watch error %s", status)
+    }
+  }
+}

--- a/k8s/src/main/scala/io/buoyant/k8s/ServiceNamer.scala
+++ b/k8s/src/main/scala/io/buoyant/k8s/ServiceNamer.scala
@@ -8,6 +8,13 @@ import com.twitter.util._
 import io.buoyant.k8s.v1._
 import java.net.InetSocketAddress
 
+/**
+ * Accepts names in the form:
+ *   /<namespace>/<port-name>/<svc-name>/residual/path
+ *
+ * and attempts to bind an Addr by resolving to the external load balancer
+ * for the given service and port.
+ */
 class ServiceNamer(
   idPrefix: Path,
   mkApi: String => NsApi,

--- a/k8s/src/main/scala/io/buoyant/k8s/v1.scala
+++ b/k8s/src/main/scala/io/buoyant/k8s/v1.scala
@@ -1,12 +1,12 @@
 package io.buoyant.k8s
 
 import com.fasterxml.jackson.annotation.{JsonProperty, JsonSubTypes, JsonTypeInfo}
-import com.twitter.finagle.{Service, http}
+import com.twitter.finagle.{Service => FService, http}
 import io.buoyant.k8s.{KubeObject => BaseObject}
 
 package object v1 {
 
-  type Client = Service[http.Request, http.Response]
+  type Client = FService[http.Request, http.Response]
 
   val group = "api"
   val version = "v1"
@@ -15,31 +15,60 @@ package object v1 {
 
   @JsonTypeInfo(use = JsonTypeInfo.Id.NAME, include = JsonTypeInfo.As.PROPERTY, property = "type")
   @JsonSubTypes(Array(
-    new JsonSubTypes.Type(value = classOf[Added], name = "ADDED"),
-    new JsonSubTypes.Type(value = classOf[Modified], name = "MODIFIED"),
-    new JsonSubTypes.Type(value = classOf[Deleted], name = "DELETED"),
-    new JsonSubTypes.Type(value = classOf[Error], name = "ERROR")
+    new JsonSubTypes.Type(value = classOf[EndpointsAdded], name = "ADDED"),
+    new JsonSubTypes.Type(value = classOf[EndpointsModified], name = "MODIFIED"),
+    new JsonSubTypes.Type(value = classOf[EndpointsDeleted], name = "DELETED"),
+    new JsonSubTypes.Type(value = classOf[EndpointsError], name = "ERROR")
   ))
   sealed trait EndpointsWatch extends Watch[Endpoints]
-  case class Added(
+  case class EndpointsAdded(
     `object`: Endpoints
   ) extends EndpointsWatch with Watch.Added[Endpoints]
 
-  case class Modified(
+  case class EndpointsModified(
     `object`: Endpoints
   ) extends EndpointsWatch with Watch.Modified[Endpoints]
 
-  case class Deleted(
+  case class EndpointsDeleted(
     `object`: Endpoints
   ) extends EndpointsWatch with Watch.Deleted[Endpoints]
 
-  case class Error(
+  case class EndpointsError(
     @JsonProperty(value = "object") status: Status
   ) extends EndpointsWatch with Watch.Error[Endpoints]
 
   implicit object EndpointsDescriptor extends ObjectDescriptor[Endpoints, EndpointsWatch] {
     def listName = "endpoints"
-    def toWatch(e: Endpoints) = Modified(e)
+    def toWatch(e: Endpoints) = EndpointsModified(e)
+  }
+
+  @JsonTypeInfo(use = JsonTypeInfo.Id.NAME, include = JsonTypeInfo.As.PROPERTY, property = "type")
+  @JsonSubTypes(Array(
+    new JsonSubTypes.Type(value = classOf[ServiceAdded], name = "ADDED"),
+    new JsonSubTypes.Type(value = classOf[ServiceModified], name = "MODIFIED"),
+    new JsonSubTypes.Type(value = classOf[ServiceDeleted], name = "DELETED"),
+    new JsonSubTypes.Type(value = classOf[ServiceError], name = "ERROR")
+  ))
+  sealed trait ServiceWatch extends Watch[Service]
+  case class ServiceAdded(
+    `object`: Service
+  ) extends ServiceWatch with Watch.Added[Service]
+
+  case class ServiceModified(
+    `object`: Service
+  ) extends ServiceWatch with Watch.Modified[Service]
+
+  case class ServiceDeleted(
+    `object`: Service
+  ) extends ServiceWatch with Watch.Deleted[Service]
+
+  case class ServiceError(
+    @JsonProperty(value = "object") status: Status
+  ) extends ServiceWatch with Watch.Error[Service]
+
+  implicit object ServiceDescriptor extends ObjectDescriptor[Service, ServiceWatch] {
+    def listName = "services"
+    def toWatch(e: Service) = ServiceModified(e)
   }
 
   case class Api(client: Client) extends Version[Object] {
@@ -47,11 +76,13 @@ package object v1 {
     def version = v1.version
     override def withNamespace(ns: String) = new NsApi(client, ns)
     def endpoints = listResource[Endpoints, EndpointsWatch, EndpointsList]()
+    def services = listResource[Service, ServiceWatch, ServiceList]()
   }
 
   class NsApi(client: Client, ns: String)
     extends NsVersion[Object](client, v1.group, v1.version, ns) {
     def endpoints = listResource[Endpoints, EndpointsWatch, EndpointsList]()
+    def services = listResource[Service, ServiceWatch, ServiceList]()
   }
 
   case class EndpointsList(
@@ -83,5 +114,41 @@ package object v1 {
     port: Int,
     name: Option[String] = None,
     protocol: Option[String] = None
+  )
+
+  case class ServiceList(
+    items: Seq[Service],
+    kind: Option[String] = None,
+    metadata: Option[ObjectMeta] = None,
+    apiVersion: Option[String] = None
+  ) extends KubeList[Service]
+
+  case class Service(
+    status: Option[ServiceStatus] = None,
+    spec: Option[ServiceSpec] = None,
+    kind: Option[String] = None,
+    metadata: Option[ObjectMeta] = None,
+    apiVersion: Option[String] = None
+  ) extends Object
+
+  case class ServiceStatus(
+    loadBalancer: Option[LoadBalancerStatus] = None
+  )
+
+  case class LoadBalancerStatus(
+    ingress: Option[Seq[LoadBalancerIngress]]
+  )
+
+  case class LoadBalancerIngress(
+    ip: String
+  )
+
+  case class ServiceSpec(
+    ports: Seq[ServicePort]
+  )
+
+  case class ServicePort(
+    port: Int,
+    name: String
   )
 }

--- a/k8s/src/test/scala/io/buoyant/k8s/ServiceNamerTest.scala
+++ b/k8s/src/test/scala/io/buoyant/k8s/ServiceNamerTest.scala
@@ -1,0 +1,182 @@
+package io.buoyant.k8s
+
+import com.twitter.conversions.time._
+import com.twitter.finagle._
+import com.twitter.finagle.http.{Request, Response}
+import com.twitter.io.{Writer, Buf}
+import com.twitter.util._
+import io.buoyant.test.Awaits
+import java.net.InetSocketAddress
+import org.scalatest.FunSuite
+
+class ServiceNamerTest extends FunSuite with Awaits {
+
+  object Rsps {
+
+    val Init = Buf.Utf8("""{ "kind": "ServiceList", "apiVersion": "v1", "metadata": { "selfLink": "/api/v1/namespaces/pythonsky/services", "resourceVersion": "11600623" }, "items": [ { "metadata": { "name": "hello", "namespace": "pythonsky", "selfLink": "/api/v1/namespaces/pythonsky/services/hello", "uid": "53b183a0-8c0a-11e6-a2a5-42010af00004", "resourceVersion": "11597405", "creationTimestamp": "2016-10-06T21:17:46Z", "annotations": { "kubectl.kubernetes.io/last-applied-configuration": "{\"kind\":\"Service\",\"apiVersion\":\"v1\",\"metadata\":{\"name\":\"hello\",\"creationTimestamp\":null},\"spec\":{\"ports\":[{\"name\":\"http\",\"port\":7000,\"targetPort\":0}],\"selector\":{\"app\":\"hello\"},\"clusterIP\":\"None\"},\"status\":{\"loadBalancer\":{}}}" } }, "spec": { "ports": [ { "name": "http", "protocol": "TCP", "port": 7000, "targetPort": 7000 } ], "selector": { "app": "hello" }, "clusterIP": "None", "type": "ClusterIP", "sessionAffinity": "None" }, "status": { "loadBalancer": {} } }, { "metadata": { "name": "l5d", "namespace": "pythonsky", "selfLink": "/api/v1/namespaces/pythonsky/services/l5d", "uid": "53fb416f-8c0a-11e6-a2a5-42010af00004", "resourceVersion": "11597494", "creationTimestamp": "2016-10-06T21:17:46Z", "annotations": { "kubectl.kubernetes.io/last-applied-configuration": "{\"kind\":\"Service\",\"apiVersion\":\"v1\",\"metadata\":{\"name\":\"l5d\",\"creationTimestamp\":null},\"spec\":{\"ports\":[{\"name\":\"external\",\"port\":80,\"targetPort\":8080},{\"name\":\"outgoing\",\"port\":4140,\"targetPort\":0},{\"name\":\"incoming\",\"port\":4141,\"targetPort\":0},{\"name\":\"admin\",\"port\":9990,\"targetPort\":0}],\"selector\":{\"app\":\"l5d\"},\"type\":\"LoadBalancer\"},\"status\":{\"loadBalancer\":{}}}" } }, "spec": { "ports": [ { "name": "external", "protocol": "TCP", "port": 80, "targetPort": 8080, "nodePort": 32131 }, { "name": "outgoing", "protocol": "TCP", "port": 4140, "targetPort": 4140, "nodePort": 30735 }, { "name": "incoming", "protocol": "TCP", "port": 4141, "targetPort": 4141, "nodePort": 30261 }, { "name": "admin", "protocol": "TCP", "port": 9990, "targetPort": 9990, "nodePort": 31850 } ], "selector": { "app": "l5d" }, "clusterIP": "10.199.242.33", "type": "LoadBalancer", "sessionAffinity": "None" }, "status": { "loadBalancer": { "ingress": [ { "ip": "104.155.170.94" } ] } } }, { "metadata": { "name": "world", "namespace": "pythonsky", "selfLink": "/api/v1/namespaces/pythonsky/services/world", "uid": "542bfddf-8c0a-11e6-a2a5-42010af00004", "resourceVersion": "11597434", "creationTimestamp": "2016-10-06T21:17:47Z", "annotations": { "kubectl.kubernetes.io/last-applied-configuration": "{\"kind\":\"Service\",\"apiVersion\":\"v1\",\"metadata\":{\"name\":\"world\",\"creationTimestamp\":null},\"spec\":{\"ports\":[{\"name\":\"http\",\"port\":7001,\"targetPort\":0}],\"selector\":{\"app\":\"world\"},\"clusterIP\":\"None\"},\"status\":{\"loadBalancer\":{}}}" } }, "spec": { "ports": [ { "name": "http", "protocol": "TCP", "port": 7001, "targetPort": 7001 } ], "selector": { "app": "world" }, "clusterIP": "None", "type": "ClusterIP", "sessionAffinity": "None" }, "status": { "loadBalancer": {} } }, { "metadata": { "name": "world-v2", "namespace": "pythonsky", "selfLink": "/api/v1/namespaces/pythonsky/services/world-v2", "uid": "545bef68-8c0a-11e6-a2a5-42010af00004", "resourceVersion": "11597443", "creationTimestamp": "2016-10-06T21:17:47Z", "annotations": { "kubectl.kubernetes.io/last-applied-configuration": "{\"kind\":\"Service\",\"apiVersion\":\"v1\",\"metadata\":{\"name\":\"world-v2\",\"creationTimestamp\":null},\"spec\":{\"ports\":[{\"name\":\"http\",\"port\":7001,\"targetPort\":0}],\"selector\":{\"app\":\"world-v2\"},\"clusterIP\":\"None\"},\"status\":{\"loadBalancer\":{}}}" } }, "spec": { "ports": [ { "name": "http", "protocol": "TCP", "port": 7001, "targetPort": 7001 } ], "selector": { "app": "world-v2" }, "clusterIP": "None", "type": "ClusterIP", "sessionAffinity": "None" }, "status": { "loadBalancer": {} } } ] }""")
+    val Modified = Buf.Utf8("""{"type":"MODIFIED","object":{"kind":"Service","apiVersion":"v1","metadata":{"name":"l5d","namespace":"pythonsky","selfLink":"/api/v1/namespaces/pythonsky/services/l5d","uid":"53fb416f-8c0a-11e6-a2a5-42010af00004","resourceVersion":"11624505","creationTimestamp":"2016-10-06T21:17:46Z","annotations":{"kubectl.kubernetes.io/last-applied-configuration":"{\"kind\":\"Service\",\"apiVersion\":\"v1\",\"metadata\":{\"name\":\"l5d\",\"creationTimestamp\":null},\"spec\":{\"ports\":[{\"name\":\"external\",\"port\":80,\"targetPort\":8080},{\"name\":\"outgoing\",\"port\":4140,\"targetPort\":0},{\"name\":\"incoming\",\"port\":4141,\"targetPort\":0},{\"name\":\"admin\",\"port\":9990,\"targetPort\":0},{\"name\":\"admin2\",\"port\":9991,\"targetPort\":0}],\"selector\":{\"app\":\"l5d\"},\"type\":\"LoadBalancer\"},\"status\":{\"loadBalancer\":{}}}"}},"spec":{"ports":[{"name":"external","protocol":"TCP","port":80,"targetPort":8080,"nodePort":32131},{"name":"outgoing","protocol":"TCP","port":4140,"targetPort":4140,"nodePort":30735},{"name":"incoming","protocol":"TCP","port":4141,"targetPort":4141,"nodePort":30261},{"name":"admin","protocol":"TCP","port":9990,"targetPort":9990,"nodePort":31850},{"name":"admin2","protocol":"TCP","port":9991,"targetPort":9991,"nodePort":32561}],"selector":{"app":"l5d"},"clusterIP":"10.199.242.33","type":"LoadBalancer","sessionAffinity":"None"},"status":{"loadBalancer":{"ingress":[{"ip":"104.155.170.95"}]}}}}""")
+    val Deleted = Buf.Utf8("""{"type":"DELETED","object":{"kind":"Service","apiVersion":"v1","metadata":{"name":"l5d","namespace":"pythonsky","selfLink":"/api/v1/namespaces/pythonsky/services/l5d","uid":"53fb416f-8c0a-11e6-a2a5-42010af00004","resourceVersion":"11624505","creationTimestamp":"2016-10-06T21:17:46Z","annotations":{"kubectl.kubernetes.io/last-applied-configuration":"{\"kind\":\"Service\",\"apiVersion\":\"v1\",\"metadata\":{\"name\":\"l5d\",\"creationTimestamp\":null},\"spec\":{\"ports\":[{\"name\":\"external\",\"port\":80,\"targetPort\":8080},{\"name\":\"outgoing\",\"port\":4140,\"targetPort\":0},{\"name\":\"incoming\",\"port\":4141,\"targetPort\":0},{\"name\":\"admin\",\"port\":9990,\"targetPort\":0},{\"name\":\"admin2\",\"port\":9991,\"targetPort\":0}],\"selector\":{\"app\":\"l5d\"},\"type\":\"LoadBalancer\"},\"status\":{\"loadBalancer\":{}}}"}},"spec":{"ports":[{"name":"external","protocol":"TCP","port":80,"targetPort":8080,"nodePort":32131},{"name":"outgoing","protocol":"TCP","port":4140,"targetPort":4140,"nodePort":30735},{"name":"incoming","protocol":"TCP","port":4141,"targetPort":4141,"nodePort":30261},{"name":"admin","protocol":"TCP","port":9990,"targetPort":9990,"nodePort":31850},{"name":"admin2","protocol":"TCP","port":9991,"targetPort":9991,"nodePort":32561}],"selector":{"app":"l5d"},"clusterIP":"10.199.242.33","type":"LoadBalancer","sessionAffinity":"None"},"status":{"loadBalancer":{"ingress":[{"ip":"104.155.170.95"}]}}}}""")
+    val Created = Buf.Utf8("""{"type":"ADDED","object":{"kind":"Service","apiVersion":"v1","metadata":{"name":"foo","namespace":"pythonsky","selfLink":"/api/v1/namespaces/pythonsky/services/foo","uid":"53fb416f-8c0a-11e6-a2a5-42010af00004","resourceVersion":"11624505","creationTimestamp":"2016-10-06T21:17:46Z","annotations":{"kubectl.kubernetes.io/last-applied-configuration":"{\"kind\":\"Service\",\"apiVersion\":\"v1\",\"metadata\":{\"name\":\"foo\",\"creationTimestamp\":null},\"spec\":{\"ports\":[{\"name\":\"external\",\"port\":80,\"targetPort\":8080},{\"name\":\"outgoing\",\"port\":4140,\"targetPort\":0},{\"name\":\"incoming\",\"port\":4141,\"targetPort\":0},{\"name\":\"admin\",\"port\":9990,\"targetPort\":0},{\"name\":\"admin2\",\"port\":9991,\"targetPort\":0}],\"selector\":{\"app\":\"foo\"},\"type\":\"LoadBalancer\"},\"status\":{\"loadBalancer\":{}}}"}},"spec":{"ports":[{"name":"external","protocol":"TCP","port":80,"targetPort":8080,"nodePort":32131},{"name":"outgoing","protocol":"TCP","port":4140,"targetPort":4140,"nodePort":30735},{"name":"incoming","protocol":"TCP","port":4141,"targetPort":4141,"nodePort":30261},{"name":"admin","protocol":"TCP","port":9990,"targetPort":9990,"nodePort":31850},{"name":"admin2","protocol":"TCP","port":9991,"targetPort":9991,"nodePort":32561}],"selector":{"app":"foo"},"clusterIP":"10.199.242.33","type":"LoadBalancer","sessionAffinity":"None"},"status":{"loadBalancer":{"ingress":[{"ip":"104.155.170.95"}]}}}}""")
+    val DeletePort = Buf.Utf8("""{"type":"MODIFIED","object":{"kind":"Service","apiVersion":"v1","metadata":{"name":"l5d","namespace":"pythonsky","selfLink":"/api/v1/namespaces/pythonsky/services/l5d","uid":"53fb416f-8c0a-11e6-a2a5-42010af00004","resourceVersion":"11624505","creationTimestamp":"2016-10-06T21:17:46Z","annotations":{"kubectl.kubernetes.io/last-applied-configuration":"{\"kind\":\"Service\",\"apiVersion\":\"v1\",\"metadata\":{\"name\":\"l5d\",\"creationTimestamp\":null},\"spec\":{\"ports\":[{\"name\":\"external\",\"port\":80,\"targetPort\":8080},{\"name\":\"outgoing\",\"port\":4140,\"targetPort\":0},{\"name\":\"incoming\",\"port\":4141,\"targetPort\":0},{\"name\":\"admin\",\"port\":9990,\"targetPort\":0}],\"selector\":{\"app\":\"l5d\"},\"type\":\"LoadBalancer\"},\"status\":{\"loadBalancer\":{}}}"}},"spec":{"ports":[{"name":"external","protocol":"TCP","port":80,"targetPort":8080,"nodePort":32131},{"name":"outgoing","protocol":"TCP","port":4140,"targetPort":4140,"nodePort":30735},{"name":"incoming","protocol":"TCP","port":4141,"targetPort":4141,"nodePort":30261},{"name":"admin","protocol":"TCP","port":9990,"targetPort":9990,"nodePort":31850}],"selector":{"app":"l5d"},"clusterIP":"10.199.242.33","type":"LoadBalancer","sessionAffinity":"None"},"status":{"loadBalancer":{"ingress":[{"ip":"104.155.170.95"}]}}}}""")
+    val AddPort = Buf.Utf8("""{"type":"MODIFIED","object":{"kind":"Service","apiVersion":"v1","metadata":{"name":"l5d","namespace":"pythonsky","selfLink":"/api/v1/namespaces/pythonsky/services/l5d","uid":"53fb416f-8c0a-11e6-a2a5-42010af00004","resourceVersion":"11624505","creationTimestamp":"2016-10-06T21:17:46Z","annotations":{"kubectl.kubernetes.io/last-applied-configuration":"{\"kind\":\"Service\",\"apiVersion\":\"v1\",\"metadata\":{\"name\":\"l5d\",\"creationTimestamp\":null},\"spec\":{\"ports\":[{\"name\":\"external\",\"port\":80,\"targetPort\":8080},{\"name\":\"outgoing\",\"port\":4140,\"targetPort\":0},{\"name\":\"incoming\",\"port\":4141,\"targetPort\":0},{\"name\":\"admin\",\"port\":9990,\"targetPort\":0},{\"name\":\"admin2\",\"port\":9991,\"targetPort\":0}],\"selector\":{\"app\":\"l5d\"},\"type\":\"LoadBalancer\"},\"status\":{\"loadBalancer\":{}}}"}},"spec":{"ports":[{"name":"external","protocol":"TCP","port":80,"targetPort":8080,"nodePort":32131},{"name":"outgoing","protocol":"TCP","port":4140,"targetPort":4140,"nodePort":30735},{"name":"incoming","protocol":"TCP","port":4141,"targetPort":4141,"nodePort":30261},{"name":"admin","protocol":"TCP","port":9990,"targetPort":9990,"nodePort":31850},{"name":"admin2","protocol":"TCP","port":9991,"targetPort":9991,"nodePort":32561}],"selector":{"app":"l5d"},"clusterIP":"10.199.242.33","type":"LoadBalancer","sessionAffinity":"None"},"status":{"loadBalancer":{"ingress":[{"ip":"104.155.170.94"}]}}}}""")
+  }
+
+  trait Fixtures {
+
+    @volatile var writer: Writer = null
+
+    val service = Service.mk[Request, Response] {
+      case req if req.uri == "/api/v1/namespaces/pythonsky/services" =>
+        val rsp = Response()
+        rsp.content = Rsps.Init
+        Future.value(rsp)
+
+      case req if req.uri == "/api/v1/namespaces/pythonsky/services?watch=true&resourceVersion=11600623" =>
+        val rsp = Response()
+        rsp.setChunked(true)
+
+        writer = rsp.writer
+
+        Future.value(rsp)
+      case req =>
+        fail(s"unexpected request: $req")
+    }
+    val api = v1.Api(service)
+    val timer = new MockTimer
+    val namer = new ServiceNamer(Path.read("/test"), api.withNamespace, Stream.continually(1.millis))(timer)
+
+    def lookup: Path
+
+    @volatile var state: Activity.State[NameTree[Name]] = Activity.Pending
+    val activity = namer.lookup(lookup)
+    val _ = activity.states.respond { s =>
+      state = s
+    }
+  }
+
+  test("gets initial value and updates") {
+    val _ = new Fixtures {
+      def lookup = Path.read("/pythonsky/external/l5d/residual")
+
+      var noChanges = false
+      activity.values.respond { _ =>
+        if (noChanges) fail("NameTree changed unexpectedly")
+      }
+
+      // initial value
+      val init = await(activity.values.toFuture().flatMap(Future.const))
+      val NameTree.Leaf(bound0: Name.Bound) = init
+      val Addr.Bound(addresses0, meta0) = await(bound0.addr.changes.toFuture)
+      assert(addresses0 == Set(Address(new InetSocketAddress("104.155.170.94", 80))))
+      assert(bound0.id == Path.read("/test/pythonsky/external/l5d"))
+      assert(bound0.path == Path.read("/residual"))
+
+      // modified
+      noChanges = true // modifying the address should not update the NameTree
+      await(writer.write(Rsps.Modified))
+
+      val modified = await(activity.values.toFuture().flatMap(Future.const))
+      val NameTree.Leaf(bound1: Name.Bound) = init
+      val Addr.Bound(addresses1, meta1) = await(bound1.addr.changes.toFuture)
+      assert(addresses1 == Set(Address(new InetSocketAddress("104.155.170.95", 80))))
+      assert(bound1.id == Path.read("/test/pythonsky/external/l5d"))
+      assert(bound1.path == Path.read("/residual"))
+
+      // deleted
+      noChanges = false
+      await(writer.write(Rsps.Deleted))
+
+      val deleted = await(activity.values.toFuture().flatMap(Future.const))
+      assert(deleted == NameTree.Neg)
+    }
+  }
+
+  test("unknown service name is negative") {
+    val _ = new Fixtures {
+      def lookup = Path.read("/pythonsky/external/foo/residual")
+
+      val init = await(activity.values.toFuture().flatMap(Future.const))
+      assert(init == NameTree.Neg)
+    }
+  }
+
+  test("unknown port name is negative") {
+    val _ = new Fixtures {
+      def lookup = Path.read("/pythonsky/foo/l5d/residual")
+
+      val init = await(activity.values.toFuture().flatMap(Future.const))
+      assert(init == NameTree.Neg)
+    }
+  }
+
+  test("gets service creation") {
+    val _ = new Fixtures {
+      def lookup = Path.read("/pythonsky/external/foo/residual")
+
+      val init = await(activity.values.toFuture().flatMap(Future.const))
+      assert(init == NameTree.Neg)
+
+      // created
+      await(writer.write(Rsps.Created))
+
+      val created = await(activity.values.toFuture().flatMap(Future.const))
+      val NameTree.Leaf(bound: Name.Bound) = created
+      val Addr.Bound(addresses, meta) = await(bound.addr.changes.toFuture)
+      assert(addresses == Set(Address(new InetSocketAddress("104.155.170.95", 80))))
+      assert(bound.id == Path.read("/test/pythonsky/external/foo"))
+      assert(bound.path == Path.read("/residual"))
+    }
+  }
+
+  test("gets port creation/deletion") {
+    val _ = new Fixtures {
+      def lookup = Path.read("/pythonsky/admin2/l5d/residual")
+
+      val init = await(activity.values.toFuture().flatMap(Future.const))
+      assert(init == NameTree.Neg)
+
+      // modified (port created)
+      await(writer.write(Rsps.Modified))
+
+      val modified0 = await(activity.values.toFuture().flatMap(Future.const))
+      val NameTree.Leaf(bound0: Name.Bound) = modified0
+      val Addr.Bound(addresses0, meta0) = await(bound0.addr.changes.toFuture)
+      assert(addresses0 == Set(Address(new InetSocketAddress("104.155.170.95", 9991))))
+      assert(bound0.id == Path.read("/test/pythonsky/admin2/l5d"))
+      assert(bound0.path == Path.read("/residual"))
+
+      // modified (port deleted)
+      await(writer.write(Rsps.DeletePort))
+
+      val modified1 = await(activity.values.toFuture().flatMap(Future.const))
+      assert(modified1 == NameTree.Neg)
+    }
+  }
+
+  test("updates to a different service should not cause NameTree updates") {
+    val _ = new Fixtures {
+      def lookup = Path.read("/pythonsky/external/l5d/residual")
+
+      var noChanges = false
+      activity.values.respond { _ =>
+        if (noChanges) fail("NameTree changed unexpectedly")
+      }
+
+      // initial value
+      val init = await(activity.values.toFuture().flatMap(Future.const))
+      val NameTree.Leaf(bound: Name.Bound) = init
+      val Addr.Bound(addresses, meta) = await(bound.addr.changes.toFuture)
+      assert(addresses == Set(Address(new InetSocketAddress("104.155.170.94", 80))))
+      assert(bound.id == Path.read("/test/pythonsky/external/l5d"))
+      assert(bound.path == Path.read("/residual"))
+
+      bound.addr.changes.respond { _ =>
+        if (noChanges) fail("Addr changed unexpectedly")
+      }
+
+      // create foo service
+      noChanges = true
+      await(writer.write(Rsps.Created))
+    }
+  }
+}

--- a/linkerd/docs/namer.md
+++ b/linkerd/docs/namer.md
@@ -264,6 +264,56 @@ namespace | yes | The Kubernetes namespace.
 port-name | yes | The port name.
 svc-name | yes | The name of the service.
 
+### K8s-External Configuration
+
+> Configure a K8s-External namer
+
+```yaml
+namers:
+- kind: io.l5d.k8s-external
+  experimental: true
+  host: localhost
+  port: 8001
+```
+
+> Then reference the namer in the dtab to use it:
+
+```
+baseDtab: |
+  /http/1.1/* => /#/io.l5d.k8s-external/prod/http;
+```
+
+The [Kubernetes](https://k8s.io/) External namer looks up the IP of the external
+load balancer for the given service on the given port.  This can be used by
+linkerd instances running outside of k8s to route to services running in k8s.
+
+Key | Default Value | Description
+--- | ------------- | -----------
+prefix | `io.l5d.k8s-external` | Resolves names with `/#/<prefix>`.
+experimental | _required_ | Because this namer is still considered experimental, you must set this to `true` to use it.
+host | `localhost` | The Kubernetes master host.
+port | `8001` | The Kubernetes master post.
+
+<aside class="notice">
+The Kubernetes namer does not support TLS.  Instead, you should run `kubectl proxy` on each host
+which will create a local proxy for securely talking to the Kubernetes cluster API. See (the k8s guide)[https://linkerd.io/doc/latest/k8s/] for more information.
+</aside>
+
+### K8s-External Path Parameters
+
+> Dtab Path Format
+
+```yaml
+/#/<prefix>/<namespace>/<port-name>/<svc-name>
+```
+
+Key | Required | Description
+--- | -------- | -----------
+prefix | yes | Tells linkerd to resolve the request path using the k8s-external namer.
+namespace | yes | The Kubernetes namespace.
+port-name | yes | The port name.
+svc-name | yes | The name of the service.
+
 
 <a name="marathon"></a>
 ## Marathon service discovery (experimental)

--- a/linkerd/docs/namer.md
+++ b/linkerd/docs/namer.md
@@ -264,13 +264,13 @@ namespace | yes | The Kubernetes namespace.
 port-name | yes | The port name.
 svc-name | yes | The name of the service.
 
-### K8s-External Configuration
+### K8s External Configuration
 
-> Configure a K8s-External namer
+> Configure a K8s External namer
 
 ```yaml
 namers:
-- kind: io.l5d.k8s-external
+- kind: io.l5d.k8s.external
   experimental: true
   host: localhost
   port: 8001
@@ -280,7 +280,7 @@ namers:
 
 ```
 baseDtab: |
-  /http/1.1/* => /#/io.l5d.k8s-external/prod/http;
+  /http/1.1/* => /#/io.l5d.k8s.external/prod/http;
 ```
 
 The [Kubernetes](https://k8s.io/) External namer looks up the IP of the external
@@ -289,7 +289,7 @@ linkerd instances running outside of k8s to route to services running in k8s.
 
 Key | Default Value | Description
 --- | ------------- | -----------
-prefix | `io.l5d.k8s-external` | Resolves names with `/#/<prefix>`.
+prefix | `io.l5d.k8s.external` | Resolves names with `/#/<prefix>`.
 experimental | _required_ | Because this namer is still considered experimental, you must set this to `true` to use it.
 host | `localhost` | The Kubernetes master host.
 port | `8001` | The Kubernetes master post.
@@ -299,7 +299,7 @@ The Kubernetes namer does not support TLS.  Instead, you should run `kubectl pro
 which will create a local proxy for securely talking to the Kubernetes cluster API. See (the k8s guide)[https://linkerd.io/doc/latest/k8s/] for more information.
 </aside>
 
-### K8s-External Path Parameters
+### K8s External Path Parameters
 
 > Dtab Path Format
 
@@ -309,7 +309,7 @@ which will create a local proxy for securely talking to the Kubernetes cluster A
 
 Key | Required | Description
 --- | -------- | -----------
-prefix | yes | Tells linkerd to resolve the request path using the k8s-external namer.
+prefix | yes | Tells linkerd to resolve the request path using the k8s external namer.
 namespace | yes | The Kubernetes namespace.
 port-name | yes | The port name.
 svc-name | yes | The name of the service.

--- a/linkerd/examples/k8s.yaml
+++ b/linkerd/examples/k8s.yaml
@@ -6,6 +6,10 @@ namers:
   experimental: true
   host: localhost
   port: 8001
+- kind: io.l5d.k8s-external
+  experimental: true
+  host: localhost
+  port: 8001
 
 routers:
 - protocol: http

--- a/linkerd/examples/k8s.yaml
+++ b/linkerd/examples/k8s.yaml
@@ -6,7 +6,7 @@ namers:
   experimental: true
   host: localhost
   port: 8001
-- kind: io.l5d.k8s-external
+- kind: io.l5d.k8s.external
   experimental: true
   host: localhost
   port: 8001

--- a/namer/k8s/src/main/resources/META-INF/services/io.buoyant.namer.NamerInitializer
+++ b/namer/k8s/src/main/resources/META-INF/services/io.buoyant.namer.NamerInitializer
@@ -1,1 +1,2 @@
+io.buoyant.namer.k8s.K8sExternalInitializer
 io.buoyant.namer.k8s.K8sInitializer

--- a/namer/k8s/src/main/scala/io/buoyant/namer/k8s/K8sExternalInitializer.scala
+++ b/namer/k8s/src/main/scala/io/buoyant/namer/k8s/K8sExternalInitializer.scala
@@ -1,0 +1,54 @@
+package io.buoyant.namer.k8s
+
+import com.fasterxml.jackson.annotation.JsonIgnore
+import com.twitter.finagle._
+import io.buoyant.config.types.Port
+import io.buoyant.k8s.{ClientConfig, ServiceNamer}
+import io.buoyant.k8s.v1.Api
+import io.buoyant.namer.{NamerConfig, NamerInitializer}
+
+/**
+ * Supports namer configurations in the form:
+ *
+ * <pre>
+ * namers:
+ * - kind: io.l5d.k8s-external
+ *   exerimental: true
+ *   host: localhost
+ *   port: 8001
+ * </pre>
+ */
+class K8sExternalInitializer extends NamerInitializer {
+  val configClass = classOf[K8sExternalConfig]
+  override def configId = "io.l5d.k8s-external"
+}
+
+object K8sExternalInitializer extends K8sExternalInitializer
+
+case class K8sExternalConfig(
+  host: Option[String],
+  port: Option[Port]
+) extends NamerConfig with ClientConfig {
+
+  @JsonIgnore
+  override val experimentalRequired = true
+
+  @JsonIgnore
+  override def defaultPrefix: Path = Path.read("/io.l5d.k8s-external")
+
+  @JsonIgnore
+  def portNum = port.map(_.port)
+
+  /**
+   * Construct a namer.
+   */
+  @JsonIgnore
+  override def newNamer(params: Stack.Params): Namer = {
+    val client = mkClient(params)
+    def mkNs(ns: String) = {
+      val label = param.Label(s"namer${prefix.show}/$ns")
+      Api(client.configured(label).newService(dst)).withNamespace(ns)
+    }
+    new ServiceNamer(prefix, mkNs)
+  }
+}

--- a/namer/k8s/src/main/scala/io/buoyant/namer/k8s/K8sExternalInitializer.scala
+++ b/namer/k8s/src/main/scala/io/buoyant/namer/k8s/K8sExternalInitializer.scala
@@ -12,7 +12,7 @@ import io.buoyant.namer.{NamerConfig, NamerInitializer}
  *
  * <pre>
  * namers:
- * - kind: io.l5d.k8s-external
+ * - kind: io.l5d.k8s.external
  *   exerimental: true
  *   host: localhost
  *   port: 8001
@@ -20,7 +20,7 @@ import io.buoyant.namer.{NamerConfig, NamerInitializer}
  */
 class K8sExternalInitializer extends NamerInitializer {
   val configClass = classOf[K8sExternalConfig]
-  override def configId = "io.l5d.k8s-external"
+  override def configId = "io.l5d.k8s.external"
 }
 
 object K8sExternalInitializer extends K8sExternalInitializer
@@ -34,7 +34,7 @@ case class K8sExternalConfig(
   override val experimentalRequired = true
 
   @JsonIgnore
-  override def defaultPrefix: Path = Path.read("/io.l5d.k8s-external")
+  override def defaultPrefix: Path = Path.read("/io.l5d.k8s.external")
 
   @JsonIgnore
   def portNum = port.map(_.port)

--- a/namer/k8s/src/test/scala/io/buoyant/namer/k8s/K8sExternalTest.scala
+++ b/namer/k8s/src/test/scala/io/buoyant/namer/k8s/K8sExternalTest.scala
@@ -1,0 +1,49 @@
+package io.buoyant.namer.k8s
+
+import com.twitter.finagle.Stack
+import com.twitter.finagle.util.LoadService
+import io.buoyant.config.Parser
+import io.buoyant.config.types.Port
+import io.buoyant.namer.{NamerConfig, NamerInitializer}
+import org.scalatest.FunSuite
+
+class K8sExternalTest extends FunSuite {
+
+  test("sanity") {
+    // ensure it doesn't totally blowup
+    val _ = K8sExternalConfig(None, None).newNamer(Stack.Params.empty)
+  }
+
+  test("service registration") {
+    assert(LoadService[NamerInitializer]().exists(_.isInstanceOf[K8sExternalInitializer]))
+  }
+
+  test("parse config") {
+    val yaml = s"""
+                  |kind: io.l5d.k8s-external
+                  |experimental: true
+                  |host: k8s-master.site.biz
+                  |port: 80
+      """.stripMargin
+
+    val mapper = Parser.objectMapper(yaml, Iterable(Seq(K8sExternalInitializer)))
+    val k8s = mapper.readValue[NamerConfig](yaml).asInstanceOf[K8sExternalConfig]
+    assert(k8s.host == Some("k8s-master.site.biz"))
+    assert(k8s.port == Some(Port(80)))
+    assert(!k8s.disabled)
+  }
+
+  test("parse config without experimental param") {
+    val yaml = s"""
+                  |kind: io.l5d.k8s-external
+                  |host: k8s-master.site.biz
+                  |port: 80
+      """.stripMargin
+
+    val mapper = Parser.objectMapper(yaml, Iterable(Seq(K8sExternalInitializer)))
+    val k8s = mapper.readValue[NamerConfig](yaml).asInstanceOf[K8sExternalConfig]
+    assert(k8s.host == Some("k8s-master.site.biz"))
+    assert(k8s.port == Some(Port(80)))
+    assert(k8s.disabled)
+  }
+}

--- a/namer/k8s/src/test/scala/io/buoyant/namer/k8s/K8sExternalTest.scala
+++ b/namer/k8s/src/test/scala/io/buoyant/namer/k8s/K8sExternalTest.scala
@@ -20,7 +20,7 @@ class K8sExternalTest extends FunSuite {
 
   test("parse config") {
     val yaml = s"""
-                  |kind: io.l5d.k8s-external
+                  |kind: io.l5d.k8s.external
                   |experimental: true
                   |host: k8s-master.site.biz
                   |port: 80
@@ -35,7 +35,7 @@ class K8sExternalTest extends FunSuite {
 
   test("parse config without experimental param") {
     val yaml = s"""
-                  |kind: io.l5d.k8s-external
+                  |kind: io.l5d.k8s.external
                   |host: k8s-master.site.biz
                   |port: 80
       """.stripMargin


### PR DESCRIPTION
Fixes #726

The [Kubernetes](https://k8s.io/) External namer looks up the IP of the external
load balancer for the given service on the given port.  This can be used by
linkerd instances running outside of k8s to route to services running in k8s.