### PR TITLE
Modify RetryFilter to use a counter for retries stat

### DIFF
--- a/linkerd/protocol/http/src/e2e/scala/io/buoyant/linkerd/protocol/HttpEndToEndTest.scala
+++ b/linkerd/protocol/http/src/e2e/scala/io/buoyant/linkerd/protocol/HttpEndToEndTest.scala
@@ -276,7 +276,7 @@ class HttpEndToEndTest extends FunSuite with Awaits {
         assert(stats.counters.get(Seq("http", "dst", "path", name, "requests")) == Some(1))
         assert(stats.counters.get(Seq("http", "dst", "path", name, "success")) == Some(1))
         assert(stats.counters.get(Seq("http", "dst", "path", name, "failures")) == None)
-        assert(stats.stats.get(Seq("http", "dst", "path", name, "retries")) == Some(Seq(1.0)))
+        assert(stats.counters.get(Seq("http", "dst", "path", name, "retries")) == Some(1))
         withAnnotations { anns =>
           assert(annotationKeys(anns) == Seq("sr", "cs", "ws", "wr", "l5d.retryable", "cr", "cs", "ws", "wr", "l5d.success", "cr", "ss"))
         }
@@ -303,7 +303,7 @@ class HttpEndToEndTest extends FunSuite with Awaits {
         assert(stats.counters.get(Seq("http", "dst", "path", name, "requests")) == Some(1))
         assert(stats.counters.get(Seq("http", "dst", "path", name, "success")) == None)
         assert(stats.counters.get(Seq("http", "dst", "path", name, "failures")) == Some(1))
-        assert(stats.stats.get(Seq("http", "dst", "path", name, "retries")) == Some(Seq(0.0)))
+        assert(stats.counters.get(Seq("http", "dst", "path", name, "retries")) == Some(0))
         withAnnotations { anns =>
           assert(annotationKeys(anns) == Seq("sr", "cs", "ws", "wr", "l5d.failure", "cr", "ss"))
         }

--- a/linkerd/protocol/http/src/e2e/scala/io/buoyant/linkerd/protocol/HttpEndToEndTest.scala
+++ b/linkerd/protocol/http/src/e2e/scala/io/buoyant/linkerd/protocol/HttpEndToEndTest.scala
@@ -276,7 +276,7 @@ class HttpEndToEndTest extends FunSuite with Awaits {
         assert(stats.counters.get(Seq("http", "dst", "path", name, "requests")) == Some(1))
         assert(stats.counters.get(Seq("http", "dst", "path", name, "success")) == Some(1))
         assert(stats.counters.get(Seq("http", "dst", "path", name, "failures")) == None)
-        assert(stats.stats.get(Seq("http", "dst", "path", name, "retries")) == Some(Seq(1.0)))
+        assert(stats.stats.get(Seq("http", "dst", "path", name, "retries", "per_request")) == Some(Seq(1.0)))
         assert(stats.counters.get(Seq("http", "dst", "path", name, "retries", "total")) == Some(1))
         withAnnotations { anns =>
           assert(annotationKeys(anns) == Seq("sr", "cs", "ws", "wr", "l5d.retryable", "cr", "cs", "ws", "wr", "l5d.success", "cr", "ss"))
@@ -304,7 +304,7 @@ class HttpEndToEndTest extends FunSuite with Awaits {
         assert(stats.counters.get(Seq("http", "dst", "path", name, "requests")) == Some(1))
         assert(stats.counters.get(Seq("http", "dst", "path", name, "success")) == None)
         assert(stats.counters.get(Seq("http", "dst", "path", name, "failures")) == Some(1))
-        assert(stats.stats.get(Seq("http", "dst", "path", name, "retries")) == Some(Seq(0.0)))
+        assert(stats.stats.get(Seq("http", "dst", "path", name, "retries", "per_request")) == Some(Seq(0.0)))
         assert(!stats.counters.contains(Seq("http", "dst", "path", name, "retries", "total")))
         withAnnotations { anns =>
           assert(annotationKeys(anns) == Seq("sr", "cs", "ws", "wr", "l5d.failure", "cr", "ss"))

--- a/linkerd/protocol/http/src/e2e/scala/io/buoyant/linkerd/protocol/HttpEndToEndTest.scala
+++ b/linkerd/protocol/http/src/e2e/scala/io/buoyant/linkerd/protocol/HttpEndToEndTest.scala
@@ -276,7 +276,8 @@ class HttpEndToEndTest extends FunSuite with Awaits {
         assert(stats.counters.get(Seq("http", "dst", "path", name, "requests")) == Some(1))
         assert(stats.counters.get(Seq("http", "dst", "path", name, "success")) == Some(1))
         assert(stats.counters.get(Seq("http", "dst", "path", name, "failures")) == None)
-        assert(stats.counters.get(Seq("http", "dst", "path", name, "retries")) == Some(1))
+        assert(stats.stats.get(Seq("http", "dst", "path", name, "retries")) == Some(Seq(1.0)))
+        assert(stats.counters.get(Seq("http", "dst", "path", name, "retries", "total")) == Some(1))
         withAnnotations { anns =>
           assert(annotationKeys(anns) == Seq("sr", "cs", "ws", "wr", "l5d.retryable", "cr", "cs", "ws", "wr", "l5d.success", "cr", "ss"))
         }
@@ -303,7 +304,8 @@ class HttpEndToEndTest extends FunSuite with Awaits {
         assert(stats.counters.get(Seq("http", "dst", "path", name, "requests")) == Some(1))
         assert(stats.counters.get(Seq("http", "dst", "path", name, "success")) == None)
         assert(stats.counters.get(Seq("http", "dst", "path", name, "failures")) == Some(1))
-        assert(stats.counters.get(Seq("http", "dst", "path", name, "retries")) == Some(0))
+        assert(stats.stats.get(Seq("http", "dst", "path", name, "retries")) == Some(Seq(0.0)))
+        assert(!stats.counters.contains(Seq("http", "dst", "path", name, "retries", "total")))
         withAnnotations { anns =>
           assert(annotationKeys(anns) == Seq("sr", "cs", "ws", "wr", "l5d.failure", "cr", "ss"))
         }

--- a/router/core/src/main/scala/com/twitter/finagle/buoyant/RetryFilter.scala
+++ b/router/core/src/main/scala/com/twitter/finagle/buoyant/RetryFilter.scala
@@ -1,0 +1,82 @@
+package com.twitter.finagle.buoyant
+
+import com.twitter.conversions.time._
+import com.twitter.finagle.service.{RetryBudget, RetryPolicy}
+import com.twitter.finagle.stats.StatsReceiver
+import com.twitter.finagle.tracing.Trace
+import com.twitter.finagle.{Filter, Service}
+import com.twitter.util._
+
+/**
+ * Cribbed from:
+ * https://github.com/twitter/finagle/blob/develop/finagle-core/src/main/scala/com/twitter/finagle/service/RetryFilter.scala
+ *
+ * Copied here and modified in order to change the type of stats exported by the filter.
+ */
+class RetryFilter[Req, Rep](
+  retryPolicy: RetryPolicy[(Req, Try[Rep])],
+  timer: Timer,
+  statsReceiver: StatsReceiver,
+  retryBudget: RetryBudget
+)
+  extends Filter[Req, Rep, Req, Rep] {
+
+  def this(
+    retryPolicy: RetryPolicy[(Req, Try[Rep])],
+    timer: Timer,
+    statsReceiver: StatsReceiver
+  ) = this(
+    retryPolicy,
+    timer,
+    statsReceiver,
+    RetryBudget()
+  )
+
+  private[this] val retriesStat = statsReceiver.counter("retries")
+
+  private[this] val budgetExhausted =
+    statsReceiver.scope("retries").counter("budget_exhausted")
+
+  @inline
+  private[this] def schedule(d: Duration)(f: => Future[Rep]) = {
+    if (d > 0.seconds) {
+      val promise = new Promise[Rep]
+      timer.schedule(Time.now + d) {
+        promise.become(f)
+      }
+      promise
+    } else f
+  }
+
+  private[this] def dispatch(
+    req: Req,
+    service: Service[Req, Rep],
+    policy: RetryPolicy[(Req, Try[Rep])],
+    count: Int = 0
+  ): Future[Rep] = {
+    val svcRep = service(req)
+    svcRep.transform { rep =>
+      policy((req, rep)) match {
+        case Some((howlong, nextPolicy)) =>
+          if (retryBudget.tryWithdraw()) {
+            schedule(howlong) {
+              Trace.record("finagle.retry")
+              dispatch(req, service, nextPolicy, count + 1)
+            }
+          } else {
+            budgetExhausted.incr()
+            retriesStat.incr(count)
+            svcRep
+          }
+        case None =>
+          retriesStat.incr(count)
+          svcRep
+      }
+    }
+  }
+
+  def apply(request: Req, service: Service[Req, Rep]): Future[Rep] = {
+    retryBudget.deposit()
+    dispatch(request, service, retryPolicy)
+  }
+}

--- a/router/core/src/main/scala/com/twitter/finagle/buoyant/RetryFilter.scala
+++ b/router/core/src/main/scala/com/twitter/finagle/buoyant/RetryFilter.scala
@@ -32,7 +32,7 @@ class RetryFilter[Req, Rep](
     RetryBudget()
   )
 
-  private[this] val retriesStat = statsReceiver.stat("retries")
+  private[this] val retriesStat = statsReceiver.scope("retries").stat("per_request")
 
   private[this] val totalRetries = statsReceiver.scope("retries").counter("total")
 

--- a/router/core/src/main/scala/io/buoyant/router/ClassifiedRetries.scala
+++ b/router/core/src/main/scala/io/buoyant/router/ClassifiedRetries.scala
@@ -1,7 +1,8 @@
 package io.buoyant.router
 
 import com.twitter.finagle.{Stack, Stackable, ServiceFactory, param}
-import com.twitter.finagle.service._
+import com.twitter.finagle.buoyant.RetryFilter
+import com.twitter.finagle.service.{RetryFilter => _, _}
 import com.twitter.util.{Duration, Try}
 
 object ClassifiedRetries {

--- a/router/core/src/test/scala/io/buoyant/router/ClassifiedRetriesTest.scala
+++ b/router/core/src/test/scala/io/buoyant/router/ClassifiedRetriesTest.scala
@@ -50,7 +50,7 @@ class ClassifiedRetriesTest extends FunSuite with Awaits with Exceptions {
     // issuing a normal request works as expected
     nextValue = Return(0)
     assert(await(svc("ok")) == 0)
-    assert(stats.stats == Map(Seq("retries") -> Seq(0.0)))
+    assert(stats.counters(Seq("retries")) == 0)
     assert(tracer.iterator.map(_.annotation).toSeq == Seq.empty)
   }
 
@@ -61,7 +61,7 @@ class ClassifiedRetriesTest extends FunSuite with Awaits with Exceptions {
     // issuing a normal request works as expected
     nextValue = Throw(new Badness)
     assertThrows[Badness] { await(svc("ok")) }
-    assert(stats.stats == Map(Seq("retries") -> Seq(0.0)))
+    assert(stats.counters(Seq("retries")) == 0)
     assert(tracer.iterator.map(_.annotation).toSeq == Seq.empty)
   }
 
@@ -90,7 +90,7 @@ class ClassifiedRetriesTest extends FunSuite with Awaits with Exceptions {
       timer.tick()
       assert(f.isDefined)
       assert(await(f) == 2)
-      assert(stats.stats == Map(Seq("retries") -> Seq(2.0)))
+      assert(stats.counters(Seq("retries")) == 2)
       assert(tracer.iterator.map(_.annotation).toSeq ==
         Seq(Annotation.Message("finagle.retry"), Annotation.Message("finagle.retry")))
     }
@@ -119,7 +119,7 @@ class ClassifiedRetriesTest extends FunSuite with Awaits with Exceptions {
       clock.advance(1.millisecond)
       timer.tick()
       assertThrows[Badness] { await(f) }
-      assert(stats.stats == Map(Seq("retries") -> Seq(2.0)))
+      assert(stats.counters(Seq("retries")) == 2)
       assert(tracer.iterator.map(_.annotation).toSeq ==
         Seq(Annotation.Message("finagle.retry"), Annotation.Message("finagle.retry")))
     }
@@ -146,7 +146,7 @@ class ClassifiedRetriesTest extends FunSuite with Awaits with Exceptions {
       timer.tick()
       assert(f.isDefined)
       assertThrows[Badness] { await(f) }
-      assert(stats.stats == Map(Seq("retries") -> Seq(2.0)))
+      assert(stats.counters(Seq("retries")) == 2)
       assert(tracer.iterator.map(_.annotation).toSeq ==
         Seq(Annotation.Message("finagle.retry"), Annotation.Message("finagle.retry")))
     }

--- a/router/core/src/test/scala/io/buoyant/router/ClassifiedRetriesTest.scala
+++ b/router/core/src/test/scala/io/buoyant/router/ClassifiedRetriesTest.scala
@@ -50,7 +50,8 @@ class ClassifiedRetriesTest extends FunSuite with Awaits with Exceptions {
     // issuing a normal request works as expected
     nextValue = Return(0)
     assert(await(svc("ok")) == 0)
-    assert(stats.counters(Seq("retries")) == 0)
+    assert(stats.stats == Map(Seq("retries") -> Seq(0.0)))
+    assert(!stats.counters.contains(Seq("retries", "total")))
     assert(tracer.iterator.map(_.annotation).toSeq == Seq.empty)
   }
 
@@ -61,7 +62,8 @@ class ClassifiedRetriesTest extends FunSuite with Awaits with Exceptions {
     // issuing a normal request works as expected
     nextValue = Throw(new Badness)
     assertThrows[Badness] { await(svc("ok")) }
-    assert(stats.counters(Seq("retries")) == 0)
+    assert(stats.stats == Map(Seq("retries") -> Seq(0.0)))
+    assert(!stats.counters.contains(Seq("retries", "total")))
     assert(tracer.iterator.map(_.annotation).toSeq == Seq.empty)
   }
 
@@ -90,7 +92,8 @@ class ClassifiedRetriesTest extends FunSuite with Awaits with Exceptions {
       timer.tick()
       assert(f.isDefined)
       assert(await(f) == 2)
-      assert(stats.counters(Seq("retries")) == 2)
+      assert(stats.stats == Map(Seq("retries") -> Seq(2.0)))
+      assert(stats.counters(Seq("retries", "total")) == 2)
       assert(tracer.iterator.map(_.annotation).toSeq ==
         Seq(Annotation.Message("finagle.retry"), Annotation.Message("finagle.retry")))
     }
@@ -119,7 +122,8 @@ class ClassifiedRetriesTest extends FunSuite with Awaits with Exceptions {
       clock.advance(1.millisecond)
       timer.tick()
       assertThrows[Badness] { await(f) }
-      assert(stats.counters(Seq("retries")) == 2)
+      assert(stats.stats == Map(Seq("retries") -> Seq(2.0)))
+      assert(stats.counters(Seq("retries", "total")) == 2)
       assert(tracer.iterator.map(_.annotation).toSeq ==
         Seq(Annotation.Message("finagle.retry"), Annotation.Message("finagle.retry")))
     }
@@ -146,7 +150,8 @@ class ClassifiedRetriesTest extends FunSuite with Awaits with Exceptions {
       timer.tick()
       assert(f.isDefined)
       assertThrows[Badness] { await(f) }
-      assert(stats.counters(Seq("retries")) == 2)
+      assert(stats.stats == Map(Seq("retries") -> Seq(2.0)))
+      assert(stats.counters(Seq("retries", "total")) == 2)
       assert(tracer.iterator.map(_.annotation).toSeq ==
         Seq(Annotation.Message("finagle.retry"), Annotation.Message("finagle.retry")))
     }

--- a/router/core/src/test/scala/io/buoyant/router/ClassifiedRetriesTest.scala
+++ b/router/core/src/test/scala/io/buoyant/router/ClassifiedRetriesTest.scala
@@ -50,7 +50,7 @@ class ClassifiedRetriesTest extends FunSuite with Awaits with Exceptions {
     // issuing a normal request works as expected
     nextValue = Return(0)
     assert(await(svc("ok")) == 0)
-    assert(stats.stats == Map(Seq("retries") -> Seq(0.0)))
+    assert(stats.stats == Map(Seq("retries", "per_request") -> Seq(0.0)))
     assert(!stats.counters.contains(Seq("retries", "total")))
     assert(tracer.iterator.map(_.annotation).toSeq == Seq.empty)
   }
@@ -62,7 +62,7 @@ class ClassifiedRetriesTest extends FunSuite with Awaits with Exceptions {
     // issuing a normal request works as expected
     nextValue = Throw(new Badness)
     assertThrows[Badness] { await(svc("ok")) }
-    assert(stats.stats == Map(Seq("retries") -> Seq(0.0)))
+    assert(stats.stats == Map(Seq("retries", "per_request") -> Seq(0.0)))
     assert(!stats.counters.contains(Seq("retries", "total")))
     assert(tracer.iterator.map(_.annotation).toSeq == Seq.empty)
   }
@@ -92,7 +92,7 @@ class ClassifiedRetriesTest extends FunSuite with Awaits with Exceptions {
       timer.tick()
       assert(f.isDefined)
       assert(await(f) == 2)
-      assert(stats.stats == Map(Seq("retries") -> Seq(2.0)))
+      assert(stats.stats == Map(Seq("retries", "per_request") -> Seq(2.0)))
       assert(stats.counters(Seq("retries", "total")) == 2)
       assert(tracer.iterator.map(_.annotation).toSeq ==
         Seq(Annotation.Message("finagle.retry"), Annotation.Message("finagle.retry")))
@@ -122,7 +122,7 @@ class ClassifiedRetriesTest extends FunSuite with Awaits with Exceptions {
       clock.advance(1.millisecond)
       timer.tick()
       assertThrows[Badness] { await(f) }
-      assert(stats.stats == Map(Seq("retries") -> Seq(2.0)))
+      assert(stats.stats == Map(Seq("retries", "per_request") -> Seq(2.0)))
       assert(stats.counters(Seq("retries", "total")) == 2)
       assert(tracer.iterator.map(_.annotation).toSeq ==
         Seq(Annotation.Message("finagle.retry"), Annotation.Message("finagle.retry")))
@@ -150,7 +150,7 @@ class ClassifiedRetriesTest extends FunSuite with Awaits with Exceptions {
       timer.tick()
       assert(f.isDefined)
       assertThrows[Badness] { await(f) }
-      assert(stats.stats == Map(Seq("retries") -> Seq(2.0)))
+      assert(stats.stats == Map(Seq("retries", "per_request") -> Seq(2.0)))
       assert(stats.counters(Seq("retries", "total")) == 2)
       assert(tracer.iterator.map(_.annotation).toSeq ==
         Seq(Annotation.Message("finagle.retry"), Annotation.Message("finagle.retry")))


### PR DESCRIPTION
## Problem

Finagle's [RetryFilter](https://github.com/twitter/finagle/blob/develop/finagle-core/src/main/scala/com/twitter/finagle/service/RetryFilter.scala) uses a histogram to track the number of retries per request.  That's not immediately comparable to other stats -- such as requests, failures, and success -- that are tracked with a counter.

## Solution

Copy Finagle's RetryFilter into router-core, and update it to use a counter instead of a stat.

With this change in place, I now see stats in the following format, for example:

```
  "rt/incoming/dst/path/http/1.1/GET/books/pending": 0,
  "rt/incoming/dst/path/http/1.1/GET/books/requests": 581,
  "rt/incoming/dst/path/http/1.1/GET/books/retries": 74,
  "rt/incoming/dst/path/http/1.1/GET/books/retries/budget_exhausted": 0,
  "rt/incoming/dst/path/http/1.1/GET/books/success": 581,
```
