### PR TITLE
Upgrade to finagle 6.39.0

### DIFF
--- a/linkerd/examples/acceptance-test.yaml
+++ b/linkerd/examples/acceptance-test.yaml
@@ -36,7 +36,7 @@ namers:
 - kind: io.l5d.marathon
   experimental: true
   prefix: /#/io.l5d.marathon
-  host: marathon.mesos
+  host: localhost
   port: 80
   uriPrefix: /marathon
 

--- a/linkerd/examples/marathon.yaml
+++ b/linkerd/examples/marathon.yaml
@@ -2,7 +2,7 @@ namers:
 - kind:         io.l5d.marathon
   experimental: true
   prefix:       /io.l5d.marathon
-  host:         marathon.mesos
+  host:         localhost
   port:         80
   uriPrefix:    /marathon
   ttlMs:        300

--- a/linkerd/protocol/http/src/main/scala/com/twitter/finagle/buoyant/linkerd/Headers.scala
+++ b/linkerd/protocol/http/src/main/scala/com/twitter/finagle/buoyant/linkerd/Headers.scala
@@ -1,8 +1,8 @@
 package com.twitter.finagle.buoyant.linkerd
 
-import com.twitter.finagle.{Deadline => FDeadline, Dtab => FDtab, Status => _, _}
+import com.twitter.finagle.{Dtab => FDtab, Status => _, _}
 import com.twitter.finagle.buoyant.{Dst => BuoyantDst}
-import com.twitter.finagle.context.Contexts
+import com.twitter.finagle.context.{Contexts, Deadline => FDeadline}
 import com.twitter.finagle.http._
 import com.twitter.finagle.tracing._
 import com.twitter.util.{Future, Return, Throw, Time, Try}

--- a/linkerd/protocol/http/src/test/scala/com/twitter/finagle/buoyant/linkerd/HeadersTest.scala
+++ b/linkerd/protocol/http/src/test/scala/com/twitter/finagle/buoyant/linkerd/HeadersTest.scala
@@ -1,9 +1,9 @@
 package com.twitter.finagle.buoyant.linkerd
 
 import com.twitter.conversions.time._
-import com.twitter.finagle.{Addr, Deadline, Dtab, Path, Service, ServiceFactory, Stack}
+import com.twitter.finagle.{Addr, Dtab, Path, Service, ServiceFactory, Stack}
 import com.twitter.finagle.buoyant.Dst
-import com.twitter.finagle.context.Contexts
+import com.twitter.finagle.context.{Contexts, Deadline}
 import com.twitter.finagle.http.{Request, Response}
 import com.twitter.finagle.tracing.Trace
 import com.twitter.util.{Future, Time, Var}

--- a/linkerd/protocol/http/src/test/scala/io/buoyant/linkerd/protocol/http/ErrorResponderTest.scala
+++ b/linkerd/protocol/http/src/test/scala/io/buoyant/linkerd/protocol/http/ErrorResponderTest.scala
@@ -8,6 +8,7 @@ import com.twitter.util.Future
 import io.buoyant.router.RoutingFactory
 import io.buoyant.test.Awaits
 import java.net.URLEncoder
+import java.nio.charset.StandardCharsets.ISO_8859_1
 import org.scalatest.FunSuite
 
 class ErrorResponderTest extends FunSuite with Awaits {
@@ -29,6 +30,6 @@ class ErrorResponderTest extends FunSuite with Awaits {
     val rsp = await(service(Request()))
     val headerErr = rsp.headerMap(Headers.Err.Key)
     assert(!headerErr.contains("\n"))
-    assert(headerErr.contains(URLEncoder.encode("\n", Charsets.Iso8859_1.toString)))
+    assert(headerErr.contains(URLEncoder.encode("\n", ISO_8859_1.toString)))
   }
 }

--- a/project/Base.scala
+++ b/project/Base.scala
@@ -41,7 +41,7 @@ class Base extends Build {
     // XXX
     //conflictManager := ConflictManager.strict,
     resolvers ++= Seq(
-      "twitter-repo" at "https://maven.twttr.com",
+      // "twitter-repo" at "https://maven.twttr.com",
       Resolver.mavenLocal,
       "typesafe" at "https://repo.typesafe.com/typesafe/releases"
     ),

--- a/project/Base.scala
+++ b/project/Base.scala
@@ -41,6 +41,7 @@ class Base extends Build {
     // XXX
     //conflictManager := ConflictManager.strict,
     resolvers ++= Seq(
+      // com.twitter dependencies used to be hosted here:
       // "twitter-repo" at "https://maven.twttr.com",
       Resolver.mavenLocal,
       "typesafe" at "https://repo.typesafe.com/typesafe/releases"

--- a/project/Deps.scala
+++ b/project/Deps.scala
@@ -4,15 +4,15 @@ object Deps {
 
   // process lifecycle
   val twitterServer =
-    ("com.twitter" %% "twitter-server" % "1.21.0")
+    ("com.twitter" %% "twitter-server" % "1.24.0")
       .exclude("com.twitter", "finagle-zipkin_2.11")
 
   def twitterUtil(mod: String) =
-    "com.twitter" %% s"util-$mod" % "6.35.0"
+    "com.twitter" %% s"util-$mod" % "6.38.0"
 
   // networking
   def finagle(mod: String) =
-    "com.twitter" %% s"finagle-$mod" % "6.36.0"
+    "com.twitter" %% s"finagle-$mod" % "6.39.0"
 
   def zkCandidate = "com.twitter.common.zookeeper" % "candidate" % "0.0.76"
 
@@ -25,7 +25,7 @@ object Deps {
   val jacksonDatabind =
     "com.fasterxml.jackson.core" % "jackson-databind" % jacksonVersion
   val jacksonScala =
-    "com.fasterxml.jackson.module" %% "jackson-module-scala" % jacksonVersion 
+    "com.fasterxml.jackson.module" %% "jackson-module-scala" % jacksonVersion
   val jackson =
     jacksonCore :: jacksonAnnotations :: jacksonDatabind :: jacksonScala :: Nil
 

--- a/router/core/src/e2e/scala/com/twitter/finagle/buoyant/Echo.scala
+++ b/router/core/src/e2e/scala/com/twitter/finagle/buoyant/Echo.scala
@@ -10,6 +10,7 @@ import com.twitter.finagle.transport.Transport
 import com.twitter.io.Charsets
 import com.twitter.util.Future
 import java.net.SocketAddress
+import java.nio.charset.StandardCharsets.UTF_8
 import org.jboss.netty.channel._
 import org.jboss.netty.handler.codec.frame.{DelimiterBasedFrameDecoder, Delimiters}
 import org.jboss.netty.handler.codec.string.{StringDecoder, StringEncoder}
@@ -48,8 +49,8 @@ object Echo extends Client[String, String] with Server[String, String] {
   private object StringClientPipeline extends ChannelPipelineFactory {
     def getPipeline = {
       val pipeline = Channels.pipeline()
-      pipeline.addLast("stringEncode", new StringEncoder(Charsets.Utf8))
-      pipeline.addLast("stringDecode", new StringDecoder(Charsets.Utf8))
+      pipeline.addLast("stringEncode", new StringEncoder(UTF_8))
+      pipeline.addLast("stringDecode", new StringDecoder(UTF_8))
       pipeline.addLast("line", new DelimEncoder('\n'))
       pipeline
     }
@@ -96,8 +97,8 @@ object Echo extends Client[String, String] with Server[String, String] {
     def getPipeline = {
       val pipeline = Channels.pipeline()
       pipeline.addLast("line", new DelimiterBasedFrameDecoder(100, Delimiters.lineDelimiter: _*))
-      pipeline.addLast("stringDecoder", new StringDecoder(Charsets.Utf8))
-      pipeline.addLast("stringEncoder", new StringEncoder(Charsets.Utf8))
+      pipeline.addLast("stringDecoder", new StringDecoder(UTF_8))
+      pipeline.addLast("stringEncoder", new StringEncoder(UTF_8))
       pipeline
     }
   }


### PR DESCRIPTION
Remove unresolveable hostnames from examples, since they cause spurious logging
from tests.

Fixes #734 