### PR TITLE
Add rinet namer

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -5,6 +5,8 @@
 * Add an `ip` option to admin configuration so that access to the admin server may be constrained
 * Add k8s external namer for routing to k8s ingress services
 * Support serving the namerd namer interface over TLS.
+* Add `io.buoyant.rinet` namer which is like `inet` but with the order
+  of host and port reversed
 
 ## 0.8.1
 

--- a/router/core/src/main/scala/io/buoyant/rinet.scala
+++ b/router/core/src/main/scala/io/buoyant/rinet.scala
@@ -1,0 +1,22 @@
+package io.buoyant
+
+import com.twitter.finagle._
+import com.twitter.util.Activity
+
+/**
+ * An alternate form of the inet namer that expects port before host.
+ *
+ *   /$/io.buoyant.rinet/<port>/<host>
+ *
+ * is equivalent to
+ *
+ *   /$/inet/<host>/<port>
+ */
+class rinet extends Namer {
+  override def lookup(path: Path): Activity[NameTree[Name]] = path.take(2) match {
+    case Path.Utf8(port, host) =>
+      Activity.value(NameTree.Leaf(Resolver.eval(s"inet!$host:$port")))
+    case _ =>
+      Activity.value(NameTree.Neg)
+  }
+}

--- a/router/core/src/test/scala/io/buoyant/RinetTest.scala
+++ b/router/core/src/test/scala/io/buoyant/RinetTest.scala
@@ -1,0 +1,18 @@
+package io.buoyant
+
+import com.twitter.finagle._
+import com.twitter.util.Future
+import io.buoyant.test.Awaits
+import org.scalatest.FunSuite
+
+class RinetTest extends FunSuite with Awaits {
+
+  test("rinet binds") {
+    val path = Path.read("/$/io.buoyant.rinet/12345/localhost")
+    val tree = await(Namer.global.lookup(path).values.toFuture.flatMap(Future.const))
+    val NameTree.Leaf(Name.Bound(va)) = tree
+    val addr = await(va.changes.filter(_ != Addr.Pending).toFuture())
+    val Addr.Bound(addresses, _) = addr
+    assert(addresses == Set(Address("localhost", 12345)))
+  }
+}


### PR DESCRIPTION
An alternate form of the inet namer that expects port before host.

`/$/io.buoyant.http.rinet/<port>/<host>/rest*` is rewritten to `/$/inet/<host>/<port>/rest*`

This is useful for dtabs that address services on a fixed port e.g.

```
/host => /$/io.buoyant.http.rinet/80;
/http/1.1/* => /host;
```