### PR TITLE
Fix netty3 server TLS initialization

### DIFF
--- a/linkerd/core/src/main/scala/io/buoyant/linkerd/Server.scala
+++ b/linkerd/core/src/main/scala/io/buoyant/linkerd/Server.scala
@@ -105,9 +105,9 @@ class ServerConfig { config =>
       Some(() => Ssl.server(
         c.certPath,
         c.keyPath,
-        c.caCertPath.orNull,
-        c.ciphers.map(_.mkString(":")).orNull,
-        alpnProtocols.map(_.mkString(",")).orNull
+        null,
+        null,
+        null
       ))
     )
 


### PR DESCRIPTION
Netty3's TLS fails to load when provided additional parameters like caCertPath.
Simply ignore these fields for netty3 servers.