### PR TITLE
[namerd:747] Namerd does not recognize namer io.l5d.zkLeader

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,3 +1,6 @@
+## X.X.X
+* Enable namer zkLeader in namerd
+
 ## 0.8.2
 
 * Consul namer can use `.local` to reference local agent's datacenter.

--- a/project/LinkerdBuild.scala
+++ b/project/LinkerdBuild.scala
@@ -281,7 +281,7 @@ object LinkerdBuild extends Base {
     )
 
     val BundleProjects = Seq[ProjectReference](
-      Namer.consul, Namer.k8s, Namer.marathon, Namer.serversets,
+      Namer.consul, Namer.k8s, Namer.marathon, Namer.serversets, Namer.zkLeader,
       Storage.etcd, Storage.inMemory, Storage.k8s, Storage.zk, Storage.consul
     )
 


### PR DESCRIPTION
Namerd wasn't requiring Namer.zkLeader and as a result one cannot use zkLeader as a valid namer w/ namerd.