### PR TITLE
announce all routable addresses when config uses meta-address

### DIFF
--- a/linkerd/main/src/main/scala/io/buoyant/linkerd/Main.scala
+++ b/linkerd/main/src/main/scala/io/buoyant/linkerd/Main.scala
@@ -2,10 +2,12 @@ package io.buoyant.linkerd
 
 import com.twitter.finagle.Path
 import com.twitter.util._
+import collection.JavaConversions.enumerationAsScalaIterator
 import io.buoyant.admin.App
 import io.buoyant.linkerd.admin.LinkerdAdmin
 import io.buoyant.telemetry.CommonMetricsTelemeter
 import java.io.File
+import java.net.{InetSocketAddress, NetworkInterface}
 import scala.io.Source
 import sun.misc.{Signal, SignalHandler}
 
@@ -95,17 +97,33 @@ object Main extends App {
     server: Server.Initializer,
     name: Path
   ): Closable = {
+    val addrs = if (server.ip.getHostAddress == "0.0.0.0") {
+      val a = for {
+        interface <- NetworkInterface.getNetworkInterfaces
+        if interface.isUp
+        inet <- interface.getInetAddresses
+        if !inet.isLoopbackAddress
+      } yield new InetSocketAddress(inet.getHostAddress, server.port)
+      a.toSeq
+    } else {
+      Seq(server.addr)
+    }
+
     announcers0.filter { case (pfx, _) => name.startsWith(pfx) } match {
       case Nil =>
         log.warning("no announcer found for %s", name.show)
         Closable.nop
 
       case announcers =>
-        val closers = announcers.map {
+        val closers = announcers.flatMap {
           case (prefix, announcer) =>
-            log.info("announcing %s as %s to %s", server.addr, name.show, announcer.scheme)
-            announcer.announce(server.addr, name.drop(prefix.size))
-        }
+            for {
+              addr <- addrs
+            } yield {
+              log.info("announcing %s as %s to %s", addr, name.show, announcer.scheme)
+              announcer.announce(addr, name.drop(prefix.size))
+            }
+          }
         Closable.all(closers: _*)
     }
   }


### PR DESCRIPTION
This change should resolve https://github.com/BuoyantIO/linkerd/issues/748.

When an announcer is configured to server the `meta-address=0.0.0.0` the following should occur
```sh
I 1018 21:14:50.537 THREAD1: serving http on /0.0.0.0:4140
I 1018 21:14:50.556 THREAD1: announcing /10.111.254.195:4140 as /#/io.l5d.serversets/prod/linkerd to zk-serversets
I 1018 21:14:50.670 THREAD1: announcing /10.111.255.50:4140 as /#/io.l5d.serversets/prod/linkerd to zk-serversets
I 1018 21:14:50.673 THREAD1: initialized
I 1018 21:14:50.723 THREAD22: Set group member ID to member_0000000014
I 1018 21:14:50.747 THREAD22: Set group member ID to member_0000000015
``` 

When an announcer is configured to serve a `concrete-address=10.111.254.195` the following should occur
```sh
I 1018 21:15:12.897 THREAD1: serving http admin on /0.0.0.0:9990
I 1018 21:15:12.907 THREAD1: serving http on /10.111.254.195:4140
I 1018 21:15:12.918 THREAD1: announcing /10.111.254.195:4140 as /#/io.l5d.serversets/prod/linkerd to zk-serversets
I 1018 21:15:13.024 THREAD1: initialized
I 1018 21:15:13.087 THREAD22: Set group member ID to member_0000000016
```