### PR TITLE
add auth support to marathon namer

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,5 +1,6 @@
 ## X.X.X
 * Enable namer zkLeader in namerd
+* Add authentication support to marathon namer
 
 ## 0.8.2
 
@@ -79,7 +80,7 @@
   * All endpoints return json
 * Add `authority` metadata field to re-write HTTP host/:authority on demand
 * Consul improvements:
-  * Add `setHost` parameter for Consul CatalogNamer to set `authority` metadata 
+  * Add `setHost` parameter for Consul CatalogNamer to set `authority` metadata
   * Add auth `token` parameter to Consul Namer & Dtab Store
   * Add `datacenter` parameter to Consul Dtab Store
 * Add file-system based name interpreter.

--- a/linkerd/docs/namer.md
+++ b/linkerd/docs/namer.md
@@ -368,7 +368,26 @@ Key | Required | Description
 prefix | yes | Tells linkerd to resolve the request path using the marathon namer.
 appId | yes | The app id of a marathon application. This id can be multiple path segments long. For example, the app with id "/users" can be reached with `/#/io.l5d.marathon/users`. Likewise, the app with id "/appgroup/usergroup/users" can be reached with `/#/io.l5d.marathon/appgroup/usergroup/users`.
 
+### Marathon Authentication
 
+> Example environment variable
+
+```json
+{
+  "login_endpoint": "https://leader.mesos/acs/api/v1/auth/login",
+  "private_key": "<private-key-value>",
+  "scheme": "RS256",
+  "uid": "service-acct"
+}
+```
+
+The Marathon namer supports loading authentication data from a
+`DCOS_SERVICE_ACCOUNT_CREDENTIAL` environment variable at boot time.
+
+Further reading:
+
+* [Mesosphere Docs](https://docs.mesosphere.com/1.8/administration/id-and-access-mgt/service-auth/custom-service-auth/)
+* [Mesosphere Universe Repo](https://github.com/mesosphere/universe/search?utf8=%E2%9C%93&q=DCOS_SERVICE_ACCOUNT_CREDENTIAL)
 
 <a name="zkLeader"></a>
 ## ZooKeeper Leader

--- a/marathon/src/test/scala/io/buoyant/marathon/v2/ApiTest.scala
+++ b/marathon/src/test/scala/io/buoyant/marathon/v2/ApiTest.scala
@@ -65,7 +65,7 @@ class ApiTest extends FunSuite with Awaits with Exceptions {
   test("getAppIds endpoint returns a seq of app names") {
     val service = stubService(appsBuf)
 
-    val response = await(Api(service, "host", "prefix").getAppIds())
+    val response = await(Api(service, "prefix").getAppIds())
     assert(response == Set(
       Path.read("/foo"),
       Path.read("/bar"),
@@ -76,14 +76,14 @@ class ApiTest extends FunSuite with Awaits with Exceptions {
   test("getAppIds endpoint returns an empty seq when there are no apps") {
     val service = stubService(noApps)
 
-    val response = await(Api(service, "host", "prefix").getAppIds())
+    val response = await(Api(service, "prefix").getAppIds())
     assert(response.size == 0)
   }
 
   test("getAddrs endpoint returns a seq of addresses") {
     val service = stubService(appBuf)
 
-    val response = await(Api(service, "host", "prefix").getAddrs(Path.Utf8("foo")))
+    val response = await(Api(service, "prefix").getAddrs(Path.Utf8("foo")))
     assert(response == Set(
       Address("1.2.3.4", 7000),
       Address("5.6.7.8", 7003)
@@ -93,7 +93,7 @@ class ApiTest extends FunSuite with Awaits with Exceptions {
   test("getAddrs endpoint returns an empty set of addresses if app not found") {
     val service = stubService(appNotFoundBuf)
 
-    val response = await(Api(service, "host", "prefix").getAddrs(Path.Utf8("foo")))
+    val response = await(Api(service, "prefix").getAddrs(Path.Utf8("foo")))
     assert(response.size == 0)
   }
 
@@ -104,7 +104,7 @@ class ApiTest extends FunSuite with Awaits with Exceptions {
       Future.exception(new ClientFailure)
     }
     assertThrows[ClientFailure] {
-      await(Api(failureService, "host", "prefix").getAppIds())
+      await(Api(failureService, "prefix").getAppIds())
     }
   }
 }

--- a/namer/marathon/src/main/scala/io/buoyant/namer/marathon/Authenticator.scala
+++ b/namer/marathon/src/main/scala/io/buoyant/namer/marathon/Authenticator.scala
@@ -1,0 +1,109 @@
+package io.buoyant.namer.marathon
+
+import com.twitter.finagle.{Failure, http}
+import com.twitter.util.{Future, Promise, Return, Throw, Time}
+import io.buoyant.marathon.v2.Api
+import java.net.URL
+import java.util.concurrent.atomic.AtomicReference
+import pdi.jwt.{Jwt, JwtAlgorithm}
+import scala.annotation.tailrec
+
+object Authenticator {
+
+  case class AuthRequest(
+    loginEndpoint: String,
+    uid: String,
+    privateKey: String,
+    algorithm: JwtAlgorithm = JwtAlgorithm.RS256
+  ) {
+    val path: String = new URL(loginEndpoint).getPath
+    val jwt: String = {
+      val token = Jwt.encode(s"""{"uid":"$uid"}""", privateKey, algorithm)
+      s"""{"uid":"$uid","token":"$token"}"""
+    }
+  }
+  private[marathon] case class UnauthorizedResponse(rsp: http.Response) extends Throwable
+  private[this] case class AuthToken(token: Option[String])
+  private[this] val closedException = Failure("closed").flagged(Failure.Interrupted)
+  private[this] val closedExceptionF = Future.exception(closedException)
+  private[this] val missingTokenException = Failure("missing token")
+  private[this] val missingTokenExceptionF = Future.exception(missingTokenException)
+
+  class Authenticated(client: Api.Client, authRequest: AuthRequest) extends Api.Client {
+    private[this] sealed trait State
+    private[this] object Init extends State
+    private[this] case class Authenticating(token: Future[String]) extends State
+    private[this] object Closed extends State
+    private[this] val state = new AtomicReference[State](Init)
+
+    final def apply(req: http.Request): Future[http.Response] = state.get match {
+      case Init =>
+        val tokenP = new Promise[String]
+        if (state.compareAndSet(Init, Authenticating(tokenP))) {
+          tokenP.become(getToken())
+          tokenP.flatMap(issueAuthed(req, _))
+        } else apply(req) // try again on race
+
+      case s0@Authenticating(tokenF) =>
+        tokenF.flatMap(issueAuthed(req, _)).rescue {
+          case UnauthorizedResponse(rsp) =>
+            // If a request is unauthorized even though we have a
+            // token, it may have expired. If another request hasn't
+            // already started authenticating, get a new token and
+            // reissue the request at most once.
+            val tokenP = new Promise[String]
+            if (state.compareAndSet(s0, Authenticating(tokenP))) {
+              tokenP.become(getToken())
+              tokenP.flatMap(issueAuthed(req, _))
+            } else apply(req) // try again on race
+          case e =>
+            Future.exception(e)
+        }
+
+      case Closed => closedExceptionF
+    }
+
+    private[this] def issueAuthed(req: http.Request, token: String): Future[http.Response] = {
+      req.headerMap.set("Authorization", s"token=$token")
+      client(req).flatMap {
+        case rsp if rsp.status == http.Status.Unauthorized =>
+          Future.exception(UnauthorizedResponse(rsp))
+        case rsp => Future.value(rsp)
+      }
+    }
+
+    private[this] def getToken(): Future[String] = {
+      val tokReq = http.Request(http.Method.Post, authRequest.path)
+      tokReq.setContentTypeJson()
+      tokReq.setContentString(authRequest.jwt)
+      client(tokReq).flatMap {
+        case rsp if rsp.status == http.Status.Ok =>
+          Api.readJson[AuthToken](rsp.content) match {
+            case Return(AuthToken(Some(token))) => Future.value(token)
+            case Return(AuthToken(None)) => missingTokenExceptionF
+            case Throw(e) => Future.exception(e)
+          }
+        case rsp if rsp.status == http.Status.Unauthorized =>
+          Future.exception(UnauthorizedResponse(rsp))
+        case rsp =>
+          Future.exception(Api.UnexpectedResponse(rsp))
+      }
+    }
+
+    @tailrec final override def close(d: Time): Future[Unit] = {
+      state.get match {
+        case Init =>
+          if (state.compareAndSet(Init, Closed)) {
+            client.close(d)
+          } else close(d)
+        case s0@Authenticating(tokenF) =>
+          if (state.compareAndSet(s0, Closed)) {
+            tokenF.raise(closedException)
+            client.close(d)
+          } else close(d)
+        case Closed => Future.Unit
+      }
+    }
+  }
+
+}

--- a/namer/marathon/src/main/scala/io/buoyant/namer/marathon/MarathonInitializer.scala
+++ b/namer/marathon/src/main/scala/io/buoyant/namer/marathon/MarathonInitializer.scala
@@ -4,7 +4,10 @@ import com.fasterxml.jackson.annotation.JsonIgnore
 import com.twitter.conversions.time._
 import com.twitter.finagle.param.Label
 import com.twitter.finagle.tracing.NullTracer
-import com.twitter.finagle.{Stack, Http, Path}
+import com.twitter.finagle._
+import com.twitter.io.Buf
+import com.twitter.logging.Logger
+import com.twitter.util.{Return, Throw}
 import io.buoyant.config.types.Port
 import io.buoyant.namer.{NamerConfig, NamerInitializer}
 import io.buoyant.marathon.v2.{Api, AppIdNamer}
@@ -30,6 +33,13 @@ class MarathonInitializer extends NamerInitializer {
 
 object MarathonInitializer extends MarathonInitializer
 
+case class MarathonSecret(
+  login_endpoint: Option[String],
+  private_key: Option[String],
+  scheme: Option[String],
+  uid: Option[String]
+)
+
 case class MarathonConfig(
   host: Option[String],
   port: Option[Port],
@@ -37,6 +47,9 @@ case class MarathonConfig(
   uriPrefix: Option[String],
   ttlMs: Option[Int]
 ) extends NamerConfig {
+
+  private[this] val log = Logger.get(getClass.getName)
+
   @JsonIgnore
   override val experimentalRequired = true
 
@@ -53,16 +66,58 @@ case class MarathonConfig(
 
   private[this] def getDst = dst.getOrElse(s"/$$/inet/$getHost/$getPort")
 
+  // canonical environment variable holding marathon auth info
+  // example secret json object:
+  // {
+  //   "login_endpoint": "https://leader.mesos/acs/api/v1/auth/login",
+  //   "private_key": "<private-key-value>",
+  //   "scheme": "RS256",
+  //   "uid": "service-acct"
+  // }
+  // more info at:
+  // https://docs.mesosphere.com/1.8/administration/id-and-access-mgt/service-auth/custom-service-auth/
+  // https://github.com/mesosphere/universe/search?utf8=%E2%9C%93&q=DCOS_SERVICE_ACCOUNT_CREDENTIAL
+  private[this] val SecretKey = "DCOS_SERVICE_ACCOUNT_CREDENTIAL"
+  private[this] def getAuth =
+    sys.env.get(SecretKey).flatMap { secret =>
+      Api.readJson[MarathonSecret](Buf.Utf8(secret)) match {
+        case Return(MarathonSecret(Some(loginEndpoint), Some(privateKey), Some("RS256"), Some(uid))) =>
+          Some(Authenticator.AuthRequest(loginEndpoint, uid, privateKey))
+        case Throw(e) =>
+          log.error(e, "readJson error")
+          throw e
+        case _ =>
+          val e = new Exception(s"unexpected format for $SecretKey")
+          log.error(e, s"unexpected format for $SecretKey")
+          throw e
+      }
+    }
+
+  private[this] case class SetHost(host: String)
+    extends SimpleFilter[http.Request, http.Response] {
+
+    def apply(req: http.Request, service: Service[http.Request, http.Response]) = {
+      req.host = host
+      service(req)
+    }
+  }
+
   /**
    * Construct a namer.
    */
   def newNamer(params: Stack.Params) = {
-    val service = Http.client
-      .withParams(params)
-      .configured(Label("namer" + prefix.show))
-      .withTracer(NullTracer)
-      .newService(getDst)
+    val client = SetHost(getHost).andThen(
+      Http.client
+        .withParams(params)
+        .configured(Label("namer" + prefix.show))
+        .withTracer(NullTracer)
+        .newService(getDst)
+    )
+    val service = getAuth match {
+      case Some(authRequest) => new Authenticator.Authenticated(client, authRequest)
+      case None => client
+    }
 
-    new AppIdNamer(Api(service, getHost, getUriPrefix), prefix, getTtl)
+    new AppIdNamer(Api(service, getUriPrefix), prefix, getTtl)
   }
 }

--- a/namer/marathon/src/test/scala/io/buoyant/namer/marathon/AuthenticatorTest.scala
+++ b/namer/marathon/src/test/scala/io/buoyant/namer/marathon/AuthenticatorTest.scala
@@ -1,0 +1,227 @@
+package io.buoyant.namer.marathon
+
+import com.fasterxml.jackson.core.JsonParseException
+import com.twitter.finagle.Failure
+import com.twitter.finagle.Service
+import com.twitter.finagle.http.{Request, Response, Status}
+import com.twitter.io.Buf
+import com.twitter.util.Future
+import io.buoyant.marathon.v2.Api
+import io.buoyant.test.{Exceptions, Awaits}
+import org.scalatest.FunSuite
+
+class AuthenticatorTest extends FunSuite with Awaits with Exceptions {
+
+  val privateKeyRSA = """-----BEGIN RSA PRIVATE KEY-----
+MIIEpQIBAAKCAQEAvzoCEC2rpSpJQaWZbUmlsDNwp83Jr4fi6KmBWIwnj1MZ6CUQ
+7rBasuLI8AcfX5/10scSfQNCsTLV2tMKQaHuvyrVfwY0dINk+nkqB74QcT2oCCH9
+XduJjDuwWA4xLqAKuF96FsIes52opEM50W7/W7DZCKXkC8fFPFj6QF5ZzApDw2Qs
+u3yMRmr7/W9uWeaTwfPx24YdY7Ah+fdLy3KN40vXv9c4xiSafVvnx9BwYL7H1Q8N
+iK9LGEN6+JSWfgckQCs6UUBOXSZdreNN9zbQCwyzee7bOJqXUDAuLcFARzPw1EsZ
+AyjVtGCKIQ0/btqK+jFunT2NBC8RItanDZpptQIDAQABAoIBAQCsssO4Pra8hFMC
+gX7tr0x+tAYy1ewmpW8stiDFilYT33YPLKJ9HjHbSms0MwqHftwwTm8JDc/GXmW6
+qUui+I64gQOtIzpuW1fvyUtHEMSisI83QRMkF6fCSQm6jJ6oQAtOdZO6R/gYOPNb
+3gayeS8PbMilQcSRSwp6tNTVGyC33p43uUUKAKHnpvAwUSc61aVOtw2wkD062XzM
+hJjYpHm65i4V31AzXo8HF42NrAtZ8K/AuQZne5F/6F4QFVlMKzUoHkSUnTp60XZx
+X77GuyDeDmCgSc2J7xvR5o6VpjsHMo3ek0gJk5ZBnTgkHvnpbULCRxTmDfjeVPue
+v3NN2TBFAoGBAPxbqNEsXPOckGTvG3tUOAAkrK1hfW3TwvrW/7YXg1/6aNV4sklc
+vqn/40kCK0v9xJIv9FM/l0Nq+CMWcrb4sjLeGwHAa8ASfk6hKHbeiTFamA6FBkvQ
+//7GP5khD+y62RlWi9PmwJY21lEkn2mP99THxqvZjQiAVNiqlYdwiIc7AoGBAMH8
+f2Ay7Egc2KYRYU2qwa5E/Cljn/9sdvUnWM+gOzUXpc5sBi+/SUUQT8y/rY4AUVW6
+YaK7chG9YokZQq7ZwTCsYxTfxHK2pnG/tXjOxLFQKBwppQfJcFSRLbw0lMbQoZBk
+S+zb0ufZzxc2fJfXE+XeJxmKs0TS9ltQuJiSqCPPAoGBALEc84K7DBG+FGmCl1sb
+ZKJVGwwknA90zCeYtadrIT0/VkxchWSPvxE5Ep+u8gxHcqrXFTdILjWW4chefOyF
+5ytkTrgQAI+xawxsdyXWUZtd5dJq8lxLtx9srD4gwjh3et8ZqtFx5kCHBCu29Fr2
+PA4OmBUMfrs0tlfKgV+pT2j5AoGBAKnA0Z5XMZlxVM0OTH3wvYhI6fk2Kx8TxY2G
+nxsh9m3hgcD/mvJRjEaZnZto6PFoqcRBU4taSNnpRr7+kfH8sCht0k7D+l8AIutL
+ffx3xHv9zvvGHZqQ1nHKkaEuyjqo+5kli6N8QjWNzsFbdvBQ0CLJoqGhVHsXuWnz
+W3Z4cBbVAoGAEtnwY1OJM7+R2u1CW0tTjqDlYU2hUNa9t1AbhyGdI2arYp+p+umA
+b5VoYLNsdvZhqjVFTrYNEuhTJFYCF7jAiZLYvYm0C99BqcJnJPl7JjWynoNHNKw3
+9f6PIOE1rAmPE8Cfz/GFF5115ZKVlq+2BY8EKNxbCIy2d/vMEvisnXI=
+-----END RSA PRIVATE KEY-----"""
+
+  val loginEndpoint = "/fake_login_endpoint"
+  val authRequest = Authenticator.AuthRequest(s"http://example.com$loginEndpoint", "fakeuid", privateKeyRSA)
+  val authbuf = Buf.Utf8("""{"token":"foo"}""")
+  val concurrencyLoad = 100
+
+  case class stubService(
+    val authStatus: Status,
+    authContent: Buf,
+    val reqStatus: Status = Status.Ok
+  ) {
+    @volatile var nextAuthStatus = authStatus
+    @volatile var nextReqStatus = reqStatus
+
+    @volatile var auths = 0
+    @volatile var requests = 0
+
+    def service() =
+      Service.mk[Request, Response] { req =>
+        val rsp =
+          if (req.path == loginEndpoint) {
+            assert(req.contentString == authRequest.jwt)
+            auths += 1
+            val r = Response(nextAuthStatus)
+            nextAuthStatus = authStatus
+            r.content = authContent
+            r
+          } else {
+            requests += 1
+            val r = Response(nextReqStatus)
+            nextReqStatus = reqStatus
+            r
+          }
+
+        Future.value(rsp)
+      }
+  }
+
+  test("auths on first request only") {
+    val stub = stubService(Status.Ok, authbuf)
+    val auth = new Authenticator.Authenticated(stub.service(), authRequest)
+
+    val rsp1 = await(auth(Request()))
+    assert(rsp1.status == Status.Ok)
+    assert(stub.auths == 1)
+    assert(stub.requests == 1)
+
+    val rsp2 = await(auth(Request()))
+    assert(rsp2.status == Status.Ok)
+    assert(stub.auths == 1)
+    assert(stub.requests == 2)
+  }
+
+  test("auths once when called repeatedly") {
+    val stub = stubService(Status.Ok, authbuf)
+    val auth = new Authenticator.Authenticated(stub.service(), authRequest)
+
+    val responses = await(
+      Future.collect(
+        Seq.range(0, concurrencyLoad).map { _ =>
+          auth(Request())
+        }
+      )
+    )
+
+    assert(responses.forall(_.status == Status.Ok))
+    assert(stub.auths == 1)
+    assert(stub.requests == concurrencyLoad)
+  }
+
+  test("retries auth on Unauthorized http response") {
+    val stub = stubService(Status.Ok, authbuf)
+    val auth = new Authenticator.Authenticated(stub.service(), authRequest)
+
+    val rsp1 = await(auth(Request()))
+    assert(rsp1.status == Status.Ok)
+    assert(stub.auths == 1)
+    assert(stub.requests == 1)
+
+    stub.nextReqStatus = Status.Unauthorized
+
+    val rsp2 = await(auth(Request()))
+    assert(rsp2.status == Status.Ok)
+    assert(stub.auths == 2)
+    assert(stub.requests == 3)
+  }
+
+  test("fails on BadRequest http responses") {
+    val stub = stubService(Status.Ok, authbuf, Status.BadRequest)
+    val auth = new Authenticator.Authenticated(stub.service(), authRequest)
+
+    val rsp1 = await(auth(Request()))
+    assert(rsp1.status == Status.BadRequest)
+    assert(stub.auths == 1)
+    assert(stub.requests == 1)
+
+    val rsp2 = await(auth(Request()))
+    assert(rsp2.status == Status.BadRequest)
+    assert(stub.auths == 1)
+    assert(stub.requests == 2)
+  }
+
+  test("throws UnauthorizedResponse on subsequent Unauthorized auth failure") {
+    val stub = stubService(Status.Ok, authbuf, Status.Ok)
+    val auth = new Authenticator.Authenticated(stub.service(), authRequest)
+
+    val rsp1 = await(auth(Request()))
+    assert(rsp1.status == Status.Ok)
+    assert(stub.auths == 1)
+    assert(stub.requests == 1)
+
+    stub.nextReqStatus = Status.Unauthorized
+    stub.nextAuthStatus = Status.Unauthorized
+
+    assertThrows[Authenticator.UnauthorizedResponse] {
+      await(auth(Request()))
+    }
+    assert(stub.auths == 2)
+    assert(stub.requests == 2)
+  }
+
+  test("retries and fails on repeated Unauthorized http responses") {
+    val stub = stubService(Status.Ok, authbuf, Status.Unauthorized)
+    val auth = new Authenticator.Authenticated(stub.service(), authRequest)
+
+    assertThrows[Authenticator.UnauthorizedResponse] {
+      await(auth(Request()))
+    }
+    assert(stub.auths == 1)
+    assert(stub.requests == 1)
+
+    assertThrows[Authenticator.UnauthorizedResponse] {
+      await(auth(Request()))
+    }
+    assert(stub.auths == 2)
+    assert(stub.requests == 3)
+  }
+
+  test("throws UnexpectedResponse with BadRequest auth response") {
+    val stub = stubService(Status.BadRequest, authbuf)
+    val auth = new Authenticator.Authenticated(stub.service(), authRequest)
+
+    assertThrows[Api.UnexpectedResponse] {
+      await(auth(Request()))
+    }
+
+    assert(stub.auths == 1)
+    assert(stub.requests == 0)
+  }
+
+  test("throws Failure with unexpected auth response") {
+    val stub = stubService(Status.Ok, Buf.Utf8("""{"unexpected":"foo"}"""))
+    val auth = new Authenticator.Authenticated(stub.service(), authRequest)
+
+    assertThrows[Failure] {
+      await(auth(Request()))
+    }
+
+    assert(stub.auths == 1)
+    assert(stub.requests == 0)
+  }
+
+  test("throws JsonParseException with bad auth response") {
+    val stub = stubService(Status.Ok, Buf.Utf8("bad auth"))
+    val auth = new Authenticator.Authenticated(stub.service(), authRequest)
+
+    assertThrows[JsonParseException] {
+      await(auth(Request()))
+    }
+
+    assert(stub.auths == 1)
+    assert(stub.requests == 0)
+  }
+
+  test("AuthRequest fails on bad loginEndpoint") {
+    assertThrows[java.net.MalformedURLException] {
+      Authenticator.AuthRequest("bad endpoint", "uid", privateKeyRSA)
+    }
+  }
+
+  test("AuthRequest fails on bad privateKey") {
+    assertThrows[java.lang.IllegalArgumentException] {
+      Authenticator.AuthRequest(s"http://example.com$loginEndpoint", "uid", "bad private key")
+    }
+  }
+}

--- a/project/Deps.scala
+++ b/project/Deps.scala
@@ -46,4 +46,7 @@ object Deps {
 
   // guava
   val guava = "com.google.guava" % "guava" % "19.0"
+
+  // jwt for Marathon API
+  val jwt = "com.pauldijou" %% "jwt-core" % "0.9.0"
 }

--- a/project/LinkerdBuild.scala
+++ b/project/LinkerdBuild.scala
@@ -102,6 +102,7 @@ object LinkerdBuild extends Base {
 
     val marathon = projectDir("namer/marathon")
       .dependsOn(LinkerdBuild.marathon, core)
+      .withLib(Deps.jwt)
       .withTests()
 
     val serversets = projectDir("namer/serversets")


### PR DESCRIPTION
modify marathon namer to read credentials from an environment variable,
and, if found, authenticate against a login endpoint

fixes #743