### PR TITLE
Add Logging and FunSuite test-utilities

### DIFF
--- a/namer/consul/src/main/scala/io/buoyant/namer/consul/LookupCache.scala
+++ b/namer/consul/src/main/scala/io/buoyant/namer/consul/LookupCache.scala
@@ -27,7 +27,7 @@ private[consul] class LookupCache(
     id: Path,
     residual: Path
   ): Activity[NameTree[Name]] = {
-    log.debug("consul lookup: %s %s", id.show)
+    log.debug("consul lookup: %s %s", dc, id.show)
     lookupCounter.incr()
 
     resolveDc(dc).flatMap(Dc.watch).map { services =>

--- a/project/Base.scala
+++ b/project/Base.scala
@@ -178,11 +178,13 @@ class Base extends Build {
   val testUtil = projectDir("test-util")
     .settings(coverageExcludedPackages := "io.buoyant.test.*")
     .settings(libraryDependencies += Deps.scalatest)
-    .settings(libraryDependencies += {
-      val dep = Deps.twitterUtil("core")
+    .settings(libraryDependencies ++= {
+      val deps = Deps.twitterUtil("core") :: Deps.twitterUtil("logging") :: Nil
       if (doDevelopTwitterDeps.value) {
-        dep.copy(revision = dep.revision+"-SNAPSHOT")
-      } else dep
+        deps.map { dep =>
+          dep.copy(revision = dep.revision+"-SNAPSHOT")
+        }
+      } else deps
     })
 
   /**

--- a/test-util/src/main/scala/io/buoyant/test/FunSuite.scala
+++ b/test-util/src/main/scala/io/buoyant/test/FunSuite.scala
@@ -1,0 +1,6 @@
+package io.buoyant.test
+
+trait FunSuite extends org.scalatest.FunSuite
+  with Awaits
+  with Exceptions
+  with Logging

--- a/test-util/src/main/scala/io/buoyant/test/Logging.scala
+++ b/test-util/src/main/scala/io/buoyant/test/Logging.scala
@@ -1,0 +1,22 @@
+package io.buoyant.test
+
+import com.twitter.logging._
+import com.twitter.util.{Await, Duration, Future, Time, TimeoutException}
+import org.scalatest.BeforeAndAfter
+
+trait Logging extends BeforeAndAfter { _: org.scalatest.FunSuite =>
+
+  var logLevel: Level = Level.OFF
+
+  before {
+    Logger.configure(List(LoggerFactory(
+      node = "",
+      level = Some(logLevel),
+      handlers = List(ConsoleHandler())
+    )))
+  }
+
+  after {
+    Logger.reset()
+  }
+}


### PR DESCRIPTION
Logging allows logging to be enabled for a test.

FunSuite is a base test class that pulls in all of our test utilties, intended
to replace use of scalatest's FunSuite.  This can be done incrementally/later.