### PR TITLE
Fix typo in HTTP/2 Indentifiers documentation

### DIFF
--- a/linkerd/docs/protocol-h2.md
+++ b/linkerd/docs/protocol-h2.md
@@ -94,8 +94,7 @@ kind | _required_ | The name of an identifier plugin, such as [`io.l5d.headerTok
 kind: `io.l5d.headerToken`.
 
 With this identifier, requests are turned into logical names using the
-value of the named header. By default, the `:authority` pseudo-header
-is used to provide host-based routing.
+value of the named header.
 
 #### Namer Configuration:
 
@@ -115,7 +114,7 @@ routers:
 
 Key | Default Value | Description
 --- | ------------- | -----------
-header | `:path` | The name of the header to extract a token from.  If there are multiple headers with this name, the last one is used.
+header | _required_ | The name of the header to extract a token from.  If there are multiple headers with this name, the last one is used.
 
 #### Namer Path Parameters:
 
@@ -135,8 +134,9 @@ headerValue | N/A | The value of the header.
 
 kind: `io.l5d.headerPath`
 
-With this identifier, requests are identified using a path read from a
-header.  This is useful for routing gRPC requests.
+With this identifier, requests are identified using a path read from a header.
+This is useful for routing gRPC requests.  By default, the `:path` psuedo-header
+is used.
 
 #### Namer Configuration:
 

--- a/linkerd/docs/protocol-h2.md
+++ b/linkerd/docs/protocol-h2.md
@@ -94,7 +94,8 @@ kind | _required_ | The name of an identifier plugin, such as [`io.l5d.headerTok
 kind: `io.l5d.headerToken`.
 
 With this identifier, requests are turned into logical names using the
-value of the named header.
+value of the named header. By default, the `:authority` pseudo-header
+is used to provide host-based routing.
 
 #### Namer Configuration:
 
@@ -114,7 +115,7 @@ routers:
 
 Key | Default Value | Description
 --- | ------------- | -----------
-header | _required_ | The name of the header to extract a token from.  If there are multiple headers with this name, the last one is used.
+header | `:authority` | The name of the header to extract a token from.  If there are multiple headers with this name, the last one is used.
 
 #### Namer Path Parameters:
 
@@ -134,9 +135,9 @@ headerValue | N/A | The value of the header.
 
 kind: `io.l5d.headerPath`
 
-With this identifier, requests are identified using a path read from a header.
-This is useful for routing gRPC requests.  By default, the `:path` psuedo-header
-is used.
+With this identifier, requests are identified using a path read from a
+header. This is useful for routing gRPC requests. By default, the `:path`
+psuedo-header is used.
 
 #### Namer Configuration:
 

--- a/linkerd/main/src/main/scala/io/buoyant/linkerd/Main.scala
+++ b/linkerd/main/src/main/scala/io/buoyant/linkerd/Main.scala
@@ -123,7 +123,7 @@ object Main extends App {
               log.info("announcing %s as %s to %s", addr, name.show, announcer.scheme)
               announcer.announce(addr, name.drop(prefix.size))
             }
-          }
+        }
         Closable.all(closers: _*)
     }
   }

--- a/linkerd/protocol/h2/src/main/scala/io/buoyant/linkerd/protocol/h2/HeaderTokenIdentifier.scala
+++ b/linkerd/protocol/h2/src/main/scala/io/buoyant/linkerd/protocol/h2/HeaderTokenIdentifier.scala
@@ -5,7 +5,7 @@ package h2
 import com.fasterxml.jackson.annotation.JsonIgnore
 import com.twitter.finagle.{Dtab, Path, Stack}
 import com.twitter.finagle.buoyant.Dst
-import com.twitter.finagle.buoyant.h2.{Headers, LinkerdHeaders, Request}
+import com.twitter.finagle.buoyant.h2.{Headers, Request}
 import com.twitter.util.Future
 import io.buoyant.router.H2
 import io.buoyant.router.RoutingFactory._
@@ -54,7 +54,6 @@ class HeaderTokenIdentifierConfig extends H2IdentifierConfig {
 
 object HeaderTokenIdentifierConfig {
   val kind = "io.l5d.headerToken"
-  val defaultHeaderToken = LinkerdHeaders.Prefix + "name"
 }
 
 class HeaderTokenIdentifierInitializer extends IdentifierInitializer {


### PR DESCRIPTION
Looking at the code, the `header` param is required when configuring the `io.l5d.headerToken` h2 identifier, but the documentation had it listed as optional with a default.  Updating the documentation to match.