### PR TITLE
Instrument h2 stream transport with stats

### DIFF
--- a/router/h2/src/main/scala/com/twitter/finagle/buoyant/h2/netty4/Netty4ServerDispatcher.scala
+++ b/router/h2/src/main/scala/com/twitter/finagle/buoyant/h2/netty4/Netty4ServerDispatcher.scala
@@ -2,7 +2,6 @@ package com.twitter.finagle.buoyant.h2
 package netty4
 
 import com.twitter.finagle.{Failure, Service}
-import com.twitter.finagle.stats.{StatsReceiver, NullStatsReceiver}
 import com.twitter.finagle.transport.Transport
 import com.twitter.logging.Logger
 import com.twitter.util.{Closable, Future, Stopwatch, Time}
@@ -18,7 +17,7 @@ object Netty4ServerDispatcher {
 class Netty4ServerDispatcher(
   transport: Transport[Http2Frame, Http2Frame],
   service: Service[Request, Response],
-  statsReceiver: StatsReceiver = NullStatsReceiver
+  streamStats: Netty4StreamTransport.StatsReceiver
 ) extends Closable {
 
   import Netty4ServerDispatcher._
@@ -28,9 +27,6 @@ class Netty4ServerDispatcher(
   private[this] val closed = new AtomicBoolean(false)
 
   private[this] val streams = new ConcurrentHashMap[Int, Netty4StreamTransport[Response, Request]]
-
-  private[this] val requestMillis = statsReceiver.stat("latency_ms")
-  private[this] val streamStats = statsReceiver.scope("stream")
 
   // Initialize a new Stream; and store it so that a response may be
   // demultiplexed to it.

--- a/router/h2/src/main/scala/io/buoyant/router/h2/StreamStatsFilter.scala
+++ b/router/h2/src/main/scala/io/buoyant/router/h2/StreamStatsFilter.scala
@@ -1,0 +1,61 @@
+package io.buoyant.router.h2
+
+import com.twitter.finagle.{Status => _, _}
+import com.twitter.finagle.buoyant.h2.{Request, Response, Stream}
+import com.twitter.finagle.stats.StatsReceiver
+import com.twitter.util.{Future, Return, Stopwatch, Throw}
+
+object StreamStatsFilter {
+  val role = Stack.Role("StreamStatsFilter")
+  val module: Stackable[ServiceFactory[Request, Response]] =
+    new Stack.Module1[param.Stats, ServiceFactory[Request, Response]] {
+      override def role = StreamStatsFilter.role
+      override def description = "Record stats on h2 streams"
+      override def make(statsP: param.Stats, next: ServiceFactory[Request, Response]) = {
+        val param.Stats(stats) = statsP
+        new StreamStatsFilter(stats).andThen(next)
+      }
+    }
+}
+
+class StreamStatsFilter(statsReceiver: StatsReceiver)
+  extends SimpleFilter[Request, Response] {
+
+  private[this] val reqStreamTimeMs = statsReceiver.stat("stream", "request", "duration_ms")
+  private[this] val rspStreamTimeMs = statsReceiver.stat("stream", "response", "duration_ms")
+  private[this] val streamTimeMs = statsReceiver.stat("stream", "duration_ms")
+  private[this] val reqStreamFailures = statsReceiver.counter("stream", "request", "failures")
+  private[this] val rspStreamFailures = statsReceiver.counter("stream", "response", "failures")
+  private[this] val streamFailures = statsReceiver.counter("stream", "failures")
+
+  override def apply(req: Request, service: Service[Request, Response]): Future[Response] = {
+    val reqT = Stopwatch.start()
+    req.data match {
+      case Stream.Nil =>
+      case r: Stream.Reader => r.onEnd.respond {
+        case Return(_) => reqStreamTimeMs.add(reqT().inMillis)
+        case Throw(_) => reqStreamFailures.incr()
+      }
+    }
+
+    val rspF = service(req)
+    rspF.onSuccess { rsp =>
+      val rspT = Stopwatch.start()
+      rsp.data match {
+        case Stream.Nil =>
+        case r: Stream.Reader =>
+          r.onEnd.respond {
+            case Return(_) => rspStreamTimeMs.add(rspT().inMillis)
+            case Throw(_) => rspStreamFailures.incr()
+          }
+      }
+      val _ = req.data.onEnd.join(rsp.data.onEnd).respond {
+        case Return(_) => streamTimeMs.add(reqT().inMillis)
+        case Throw(_) => streamFailures.incr()
+      }
+    }
+
+    rspF
+  }
+
+}

--- a/router/h2/src/test/scala/com/twitter/finagle/buoyant/h2/netty4/Netty4ClientDispatcherTest.scala
+++ b/router/h2/src/test/scala/com/twitter/finagle/buoyant/h2/netty4/Netty4ClientDispatcherTest.scala
@@ -34,7 +34,8 @@ class Netty4ClientDispatchTest extends FunSuite {
     }
 
     val stats = new InMemoryStatsReceiver
-    val dispatcher = new Netty4ClientDispatcher(transport, stats)
+    val tstats = new Netty4StreamTransport.StatsReceiver(stats)
+    val dispatcher = new Netty4ClientDispatcher(transport, tstats)
 
     var released = 0
     def releaser: Int => Future[Unit] = { bytes =>

--- a/router/h2/src/test/scala/com/twitter/finagle/buoyant/h2/netty4/Netty4ServerDispatcherTest.scala
+++ b/router/h2/src/test/scala/com/twitter/finagle/buoyant/h2/netty4/Netty4ServerDispatcherTest.scala
@@ -61,7 +61,8 @@ class Netty4ServerDispatchTest extends FunSuite {
     }
 
     val stats = new InMemoryStatsReceiver
-    val dispatcher = new Netty4ServerDispatcher(transport, service, stats)
+    val tstats = new Netty4StreamTransport.StatsReceiver(stats)
+    val dispatcher = new Netty4ServerDispatcher(transport, service, tstats)
 
     assert(!bartmanCalled.get)
     assert(recvq.offer({

--- a/router/h2/src/test/scala/com/twitter/finagle/buoyant/h2/netty4/Netty4StreamTransportTest.scala
+++ b/router/h2/src/test/scala/com/twitter/finagle/buoyant/h2/netty4/Netty4StreamTransportTest.scala
@@ -25,7 +25,8 @@ class Netty4StreamTransportTest extends FunSuite with Awaits {
       }
     }
     val stats = new InMemoryStatsReceiver
-    val stream = Netty4StreamTransport.client(id, writer, stats)
+    val tstats = new Netty4StreamTransport.StatsReceiver(stats)
+    val stream = Netty4StreamTransport.client(id, writer, tstats)
 
     val headers: Headers = {
       val hs = new DefaultHttp2Headers
@@ -60,7 +61,8 @@ class Netty4StreamTransportTest extends FunSuite with Awaits {
       }
     }
     val stats = new InMemoryStatsReceiver
-    val stream = Netty4StreamTransport.client(id, writer, stats)
+    val tstats = new Netty4StreamTransport.StatsReceiver(stats)
+    val stream = Netty4StreamTransport.client(id, writer, tstats)
 
     val sendq = new AsyncQueue[Frame]
     val endP = new Promise[Unit]
@@ -91,7 +93,8 @@ class Netty4StreamTransportTest extends FunSuite with Awaits {
       def write(f: Http2Frame) = ???
     }
     val stats = new InMemoryStatsReceiver
-    val stream = Netty4StreamTransport.client(id, writer, stats)
+    val tstats = new Netty4StreamTransport.StatsReceiver(stats)
+    val stream = Netty4StreamTransport.client(id, writer, tstats)
 
     val rspf = stream.remoteMsg
     assert(!rspf.isDefined)


### PR DESCRIPTION
Since a Netty4StreamTransport is instantiated for each stream (i.e.
request/response pair), we don't want to instantiate stats/counters/etc
directly within the transport.  Instead, we build a single
Netty4StreamTransport.StatsReceiver instance for each client/server and share
this object across all streams on that client/server.

Furthermore, the h2.StreamStatsFilter is introduced on H2 clients and servers
to record remote, local, and complete stream lifetimes.
