### PR TITLE
Admit HTTP/1 upgrade requests in h2 plaintext servers.

### DIFF
--- a/router/h2/src/e2e/scala/io/buoyant/router/h2/RouterEndToEndTest.scala
+++ b/router/h2/src/e2e/scala/io/buoyant/router/h2/RouterEndToEndTest.scala
@@ -3,6 +3,7 @@ package h2
 
 import com.twitter.finagle.{Dtab, Path}
 import com.twitter.finagle.buoyant.Dst
+import com.twitter.logging.Level
 import com.twitter.util.Future
 import io.buoyant.test.FunSuite
 import java.net.InetSocketAddress
@@ -11,9 +12,8 @@ class RouterEndToEndTest
   extends FunSuite
   with ClientServerHelpers {
 
-  // logLevel = Level.DEBUG
-
   test("router with prior knowledge") {
+    // setLogLevel(Level.DEBUG)
     val cat = Downstream.const("cat", "meow")
     val dog = Downstream.const("dog", "woof")
     val dtab = Dtab.read(s"""
@@ -37,6 +37,7 @@ class RouterEndToEndTest
       client.get("felix")(_ == Some("meow"))
       client.get("clifford", "/the/big/red/dog")(_ == Some("woof"))
     } finally {
+      setLogLevel(Level.OFF)
       await(client.close())
       await(cat.server.close())
       await(dog.server.close())

--- a/router/h2/src/main/scala/com/twitter/finagle/buoyant/h2/netty4/Netty4H2Listener.scala
+++ b/router/h2/src/main/scala/com/twitter/finagle/buoyant/h2/netty4/Netty4H2Listener.scala
@@ -35,7 +35,7 @@ object Netty4H2Listener {
 
   private[this] object PlaintextListener extends ListenerMaker {
     override protected[this] val pipelineInit = { p: ChannelPipeline =>
-      p.addLast(new Http2FrameCodec(true)); ()
+      p.addLast(new ServerUpgradeHandler); ()
     }
   }
 

--- a/router/h2/src/main/scala/com/twitter/finagle/buoyant/h2/netty4/ServerUpgradeHandler.scala
+++ b/router/h2/src/main/scala/com/twitter/finagle/buoyant/h2/netty4/ServerUpgradeHandler.scala
@@ -8,10 +8,6 @@ import io.netty.handler.codec.http.{HttpServerCodec, HttpServerUpgradeHandler}
 import io.netty.handler.codec.http2._
 import io.netty.util.AsciiString
 
-/*
- * XXX TODO -- this currently isn't used, but it should be.
- */
-
 object ServerUpgradeHandler {
   private val log = Logger.get(getClass.getName)
 
@@ -29,20 +25,23 @@ object ServerUpgradeHandler {
  * Accept either H2C requests (beginning with a Connection preface)
  * or HTTP requests with h2c protocol upgrading.
  */
-class ServerUpgradeHandler(stream: ChannelHandler) extends ChannelDuplexHandler {
+class ServerUpgradeHandler extends ChannelDuplexHandler {
   import ServerUpgradeHandler._
 
-  private[this] val rawH2 = new Http2FrameCodec(true /*server*/ )
+  // Parses HTTP/1 objects.
+  private[this] val h1Codec = new HttpServerCodec
 
-  private[this] val h1 = new HttpServerCodec
+  // Parses HTTP/2 frames
+  private[this] val framer = new Http2FrameCodec(true /*server*/ )
 
-  // private[this] val upgradedH2 = new HttpServerUpgradeHandler.UpgradeCodecFactory {
-  //   // TODO we could transparently upgrade h1 requests as h2 requests, couldn't we?
-  //   override def newUpgradeCodec(proto: CharSequence): HttpServerUpgradeHandler.UpgradeCodec =
-  //     if (isH2C(proto)) new Http2ServerUpgradeCodec(rawH2) else null
-  // }
-
-  // private[this] val upgrader = new HttpServerUpgradeHandler(h1, upgradedH2)
+  // Intercepts HTTP/1 requests with the HTTP2-Settings headers and
+  // initiate protocol upgrade.
+  private[this] val upgrader =
+    new HttpServerUpgradeHandler(h1Codec, new HttpServerUpgradeHandler.UpgradeCodecFactory {
+      override def newUpgradeCodec(proto: CharSequence): HttpServerUpgradeHandler.UpgradeCodec =
+        if (isH2C(proto)) new Http2FrameCodecServerUpgrader(framer)
+        else null
+    })
 
   /**
    * Detect the HTTP2 connection preface to support Prior Knowledge
@@ -53,14 +52,13 @@ class ServerUpgradeHandler(stream: ChannelHandler) extends ChannelDuplexHandler 
       case bb: ByteBuf if isPreface(bb) =>
         // If the connection starts with the magical prior-knowledge
         // preface, just assume we're speaking plain h2c.
-        ctx.pipeline.addLast("h2", rawH2)
-        ctx.pipeline.addLast("h2 debug", new DebugHandler("s.frame"))
-        ctx.pipeline.addLast("h2 stream", stream)
+        ctx.pipeline.addLast("h2 framer", framer)
 
-      // case bb: ByteBuf =>
-      //   // Otherwise, Upgrade from h1 to h2
-      //   ctx.pipeline.addLast("h1", h1)
-      //   ctx.pipeline.addLast("h2 upgrader", upgrader)
+      case bb: ByteBuf =>
+        // Otherwise, Upgrade from h1 to h2
+        ctx.pipeline.addLast("h1 codec", h1Codec)
+        ctx.pipeline.addLast("h1 upgrade h2", upgrader)
+      // TODO silently translate native h1 to h2
 
       case _ => // Fall through and pass on the read.
     }

--- a/router/h2/src/main/scala/com/twitter/finagle/buoyant/h2/netty4/ServerUpgradeHandler.scala
+++ b/router/h2/src/main/scala/com/twitter/finagle/buoyant/h2/netty4/ServerUpgradeHandler.scala
@@ -52,12 +52,12 @@ class ServerUpgradeHandler extends ChannelDuplexHandler {
       case bb: ByteBuf if isPreface(bb) =>
         // If the connection starts with the magical prior-knowledge
         // preface, just assume we're speaking plain h2c.
-        ctx.pipeline.addLast("h2 framer", framer)
+        ctx.pipeline.addAfter(ctx.name, "h2 framer", framer)
 
       case bb: ByteBuf =>
         // Otherwise, Upgrade from h1 to h2
-        ctx.pipeline.addLast("h1 codec", h1Codec)
-        ctx.pipeline.addLast("h1 upgrade h2", upgrader)
+        ctx.pipeline.addAfter(ctx.name, "h1 codec", h1Codec)
+        ctx.pipeline.addAfter("h1 codec", "h1 upgrade h2", upgrader)
       // TODO silently translate native h1 to h2
 
       case _ => // Fall through and pass on the read.

--- a/router/h2/src/main/scala/io/netty/handler/codec/http2/Http2FrameCodecServerUpgrader.scala
+++ b/router/h2/src/main/scala/io/netty/handler/codec/http2/Http2FrameCodecServerUpgrader.scala
@@ -1,0 +1,12 @@
+package io.netty.handler.codec.http2
+
+import io.netty.channel.ChannelHandler
+
+/**
+ * Adapt Http2ServerUpgradeCodec to be instantiated with an Http2FrameCodec
+ */
+class Http2FrameCodecServerUpgrader(name: String, framer: Http2FrameCodec, handler: ChannelHandler)
+  extends Http2ServerUpgradeCodec(name, framer.connectionHandler, handler) {
+  def this(framer: Http2FrameCodec, handler: ChannelHandler) = this(null, framer, handler)
+  def this(framer: Http2FrameCodec) = this(null, framer, framer)
+}


### PR DESCRIPTION
In 59df8f2, ServerUpgradeHandler was disabled to accomodate the new
multiplexing regime, requiring that all plaintext clients send a prior
knowledge request.

This change introduces an adapter, io.netty4...Http2FrameCodecServerUpgrader,
that instantiates an Http2ServerUpgradeCodec with a Http2FrameCodec so that the
server properly accepts HTTP/1 upgrade requests in addition to prior-knowledge
requests.

Fixes #765
