### PR TITLE
Prep 0.8.3

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,14 +1,19 @@
-## X.X.X
+## 0.8.3
 
-* Enable namer zkLeader in namerd
-* Add authentication support to marathon namer
-* Allow transformers to be applied to namers
-* Add Const and Replace transformers
-* Add `useHealthCheck` option to marathon namer
+* Make several namers available to namerd that were missing
+* Fix crash when viewing the dtab playground
+* Announce to all routable addresses when announcing 0.0.0.0
 * Add experimental Apache Curator namer
-* Show transformers in the delegate UI
-* Add `labelSelector` option to k8s and k8s.external namers.
-* Add `hostNetwork` option to k8s transformers to support CNI environments
+* Marathon:
+  * Add authentication support to marathon namer
+  * Add `useHealthCheck` option to marathon namer
+* Transformers:
+  * Allow transformers to be applied to namers
+  * Add Const and Replace transformers
+  * Show transformers in the delegate UI
+* Kubernetes:
+  * Add `labelSelector` option to k8s and k8s.external namers
+  * Add `hostNetwork` option to k8s transformers to support CNI environments
 
 ## 0.8.2
 

--- a/README.md
+++ b/README.md
@@ -264,7 +264,7 @@ For local testing convenience, we supply a config that routes to a single
 backend on _localhost:8080_.
 
 ```
-$ docker run -p 4140:4140 -p 9990:9990 -v /path/to/linkerd/linkerd/examples:/config buoyantio/linkerd:0.8.2-SNAPSHOT /config/static_namer.yaml
+$ docker run -p 4140:4140 -p 9990:9990 -v /path/to/linkerd/linkerd/examples:/config buoyantio/linkerd:0.8.3-SNAPSHOT /config/static_namer.yaml
 ```
 
 The list of image names may be changed with a command like:
@@ -299,14 +299,14 @@ The assembly script executes two commands serially:
 
 ```bash
 $ ./sbt namerd/dcos:assembly
-$ namerd/target/scala-2.11/namerd-0.8.2-SNAPSHOT-dcos-exec namerd/examples/zk.yaml
+$ namerd/target/scala-2.11/namerd-0.8.3-SNAPSHOT-dcos-exec namerd/examples/zk.yaml
 ```
 
 ##### Run assembly script in docker #####
 
 ```bash
 $ ./sbt namerd/dcos:docker
-$ docker run -p 2181:2181 -p 4180:4180 -v /path/to/repo:/myapp -w /myapp buoyantio/namerd:0.8.2-SNAPSHOT-dcos namerd/examples/zk.yaml
+$ docker run -p 2181:2181 -p 4180:4180 -v /path/to/repo:/myapp -w /myapp buoyantio/namerd:0.8.3-SNAPSHOT-dcos namerd/examples/zk.yaml
 ```
 
 ### Contributing ###

--- a/project/Base.scala
+++ b/project/Base.scala
@@ -17,7 +17,7 @@ import scoverage.ScoverageSbtPlugin
  * Base project configuration.
  */
 class Base extends Build {
-  val headVersion = "0.8.2"
+  val headVersion = "0.8.3"
 
   object Git {
     def git(arg: String, args: String*) = Process("git" +: arg +: args)


### PR DESCRIPTION
* Make several namers available to namerd that were missing
* Fix crash when viewing the dtab playground
* Announce to all routable addresses when announcing 0.0.0.0
* Add experimental Apache Curator namer
* Marathon:
  * Add authentication support to marathon namer
  * Add `useHealthCheck` option to marathon namer
* Transformers:
  * Allow transformers to be applied to namers
  * Add Const and Replace transformers
  * Show transformers in the delegate UI
* Kubernetes:
  * Add `labelSelector` option to k8s and k8s.external namers
  * Add `hostNetwork` option to k8s transformers to support CNI environments