### PR TITLE
Add nodeName to namerd addr metadata

### DIFF
--- a/interpreter/k8s/src/main/scala/io/buoyant/transformer/k8s/DaemonSetTransformerInitializer.scala
+++ b/interpreter/k8s/src/main/scala/io/buoyant/transformer/k8s/DaemonSetTransformerInitializer.scala
@@ -7,7 +7,7 @@ import com.twitter.finagle.{NameTree, Path}
 import io.buoyant.config.types.Port
 import io.buoyant.k8s.v1.Api
 import io.buoyant.k8s.{ClientConfig, EndpointsNamer}
-import io.buoyant.namer.{NameTreeTransformer, TransformerConfig, TransformerInitializer}
+import io.buoyant.namer.{Metadata, NameTreeTransformer, TransformerConfig, TransformerInitializer}
 import java.net.InetAddress
 
 class DaemonSetTransformerInitializer extends TransformerInitializer {
@@ -38,7 +38,7 @@ case class DaemonSetTransformerConfig(
     val namer = new EndpointsNamer(Path.empty, None, mkNs)
     val daemonSet = namer.bind(NameTree.Leaf(Path.Utf8(namespace, port, service)))
     if (hostNetwork.getOrElse(false))
-      new MetadataGatewayTransformer(daemonSet, NodeNameMetaKey)
+      new MetadataGatewayTransformer(daemonSet, Metadata.nodeName)
     else
       new SubnetGatewayTransformer(daemonSet, Netmask("255.255.255.0"))
   }

--- a/interpreter/k8s/src/main/scala/io/buoyant/transformer/k8s/LocalNodeTransformerInitializer.scala
+++ b/interpreter/k8s/src/main/scala/io/buoyant/transformer/k8s/LocalNodeTransformerInitializer.scala
@@ -1,7 +1,6 @@
 package io.buoyant.transformer
 package k8s
 
-import com.twitter.finagle.Address
 import io.buoyant.namer._
 import java.net.InetAddress
 
@@ -21,7 +20,7 @@ case class LocalNodeTransformerConfig(hostNetwork: Option[Boolean])
           "NODE_NAME env variable must be set to the node's name"
         )
       )
-      new MetadataFiltertingNameTreeTransformer(NodeNameMetaKey, Some(nodeName))
+      new MetadataFiltertingNameTreeTransformer(Metadata.nodeName, nodeName)
     } else {
       val ip = sys.env.getOrElse(
         "POD_IP",

--- a/interpreter/k8s/src/main/scala/io/buoyant/transformer/k8s/package.scala
+++ b/interpreter/k8s/src/main/scala/io/buoyant/transformer/k8s/package.scala
@@ -1,5 +1,0 @@
-package io.buoyant.transformer
-
-package object k8s {
-  val NodeNameMetaKey = "nodeName"
-}

--- a/interpreter/k8s/src/test/scala/io/buoyant/transformer/k8s/DaemonSetTransformerTest.scala
+++ b/interpreter/k8s/src/test/scala/io/buoyant/transformer/k8s/DaemonSetTransformerTest.scala
@@ -4,6 +4,7 @@ import com.twitter.finagle.Name.Bound
 import com.twitter.finagle._
 import com.twitter.finagle.naming.NameInterpreter
 import com.twitter.util.{Activity, Future, Var}
+import io.buoyant.namer.Metadata
 import io.buoyant.test.FunSuite
 import io.buoyant.transformer.{MetadataGatewayTransformer, Netmask, SubnetGatewayTransformer}
 import java.net.InetSocketAddress
@@ -57,13 +58,13 @@ class DaemonSetTransformerTest extends FunSuite {
   test("daemonset transformer with hostNetwork") {
     val daemonset = Activity.value(
       NameTree.Leaf(Name.Bound(Var(Addr.Bound(
-        Address.Inet(new InetSocketAddress("7.7.7.1", 4141), Map(NodeNameMetaKey -> Some("7.7.7.1"))),
-        Address.Inet(new InetSocketAddress("7.7.7.2", 4141), Map(NodeNameMetaKey -> Some("7.7.7.2"))),
-        Address.Inet(new InetSocketAddress("7.7.7.3", 4141), Map(NodeNameMetaKey -> Some("7.7.7.3")))
+        Address.Inet(new InetSocketAddress("7.7.7.1", 4141), Map(Metadata.nodeName -> "7.7.7.1")),
+        Address.Inet(new InetSocketAddress("7.7.7.2", 4141), Map(Metadata.nodeName -> "7.7.7.2")),
+        Address.Inet(new InetSocketAddress("7.7.7.3", 4141), Map(Metadata.nodeName -> "7.7.7.3"))
       )), Path.read("/#/io.l5d.k8s/default/incoming/l5d"), Path.empty))
     )
 
-    val transformer = new MetadataGatewayTransformer(daemonset, NodeNameMetaKey)
+    val transformer = new MetadataGatewayTransformer(daemonset, Metadata.nodeName)
 
     val interpreter = new NameInterpreter {
       override def bind(
@@ -73,7 +74,7 @@ class DaemonSetTransformerTest extends FunSuite {
         val Path.Utf8(ip, nodeName) = path
         Activity.value(
           NameTree.Leaf(Name.Bound(Var(Addr.Bound(
-            Address.Inet(new InetSocketAddress(ip, 8888), Map(NodeNameMetaKey -> Some(nodeName)))
+            Address.Inet(new InetSocketAddress(ip, 8888), Map(Metadata.nodeName -> nodeName))
           )), path, Path.empty))
         )
       }
@@ -97,7 +98,7 @@ class DaemonSetTransformerTest extends FunSuite {
         addresses
       }
 
-      assert(addrs == Set(Address.Inet(new InetSocketAddress(expected, 4141), Map(NodeNameMetaKey -> Some(expected)))))
+      assert(addrs == Set(Address.Inet(new InetSocketAddress(expected, 4141), Map(Metadata.nodeName -> expected))))
     }
   }
 }

--- a/interpreter/k8s/src/test/scala/io/buoyant/transformer/k8s/LocalnodeTransformerTest.scala
+++ b/interpreter/k8s/src/test/scala/io/buoyant/transformer/k8s/LocalnodeTransformerTest.scala
@@ -4,7 +4,7 @@ import com.twitter.finagle.Name.Bound
 import com.twitter.finagle._
 import com.twitter.finagle.naming.NameInterpreter
 import com.twitter.util.{Activity, Future, Var}
-import io.buoyant.namer.MetadataFiltertingNameTreeTransformer
+import io.buoyant.namer.{Metadata, MetadataFiltertingNameTreeTransformer}
 import io.buoyant.test.FunSuite
 import io.buoyant.transformer.{Netmask, SubnetLocalTransformer}
 import java.net.{InetAddress, InetSocketAddress}
@@ -43,7 +43,7 @@ class LocalnodeTransformerTest extends FunSuite {
   }
 
   test("localnode transformer with host network") {
-    val transformer = new MetadataFiltertingNameTreeTransformer(NodeNameMetaKey, Some("7.7.7.7"))
+    val transformer = new MetadataFiltertingNameTreeTransformer(Metadata.nodeName, "7.7.7.7")
 
     val interpreter = new NameInterpreter {
       override def bind(
@@ -51,10 +51,10 @@ class LocalnodeTransformerTest extends FunSuite {
         path: Path
       ): Activity[NameTree[Bound]] = Activity.value(
         NameTree.Leaf(Name.Bound(Var(Addr.Bound(
-          Address.Inet(new InetSocketAddress("1.1.1.1", 8888), Map(NodeNameMetaKey -> Some("7.7.7.7"))),
-          Address.Inet(new InetSocketAddress("1.1.1.2", 8888), Map(NodeNameMetaKey -> Some("7.7.7.7"))),
-          Address.Inet(new InetSocketAddress("1.1.1.3", 8888), Map(NodeNameMetaKey -> Some("7.7.7.8"))),
-          Address.Inet(new InetSocketAddress("1.1.1.4", 8888), Map(NodeNameMetaKey -> Some("7.7.7.8")))
+          Address.Inet(new InetSocketAddress("1.1.1.1", 8888), Map(Metadata.nodeName -> "7.7.7.7")),
+          Address.Inet(new InetSocketAddress("1.1.1.2", 8888), Map(Metadata.nodeName -> "7.7.7.7")),
+          Address.Inet(new InetSocketAddress("1.1.1.3", 8888), Map(Metadata.nodeName -> "7.7.7.8")),
+          Address.Inet(new InetSocketAddress("1.1.1.4", 8888), Map(Metadata.nodeName -> "7.7.7.8"))
         )), path, Path.empty))
       )
     }
@@ -71,8 +71,8 @@ class LocalnodeTransformerTest extends FunSuite {
     }
 
     assert(addrs == Set(
-      Address.Inet(new InetSocketAddress("1.1.1.1", 8888), Map(NodeNameMetaKey -> Some("7.7.7.7"))),
-      Address.Inet(new InetSocketAddress("1.1.1.2", 8888), Map(NodeNameMetaKey -> Some("7.7.7.7")))
+      Address.Inet(new InetSocketAddress("1.1.1.1", 8888), Map(Metadata.nodeName -> "7.7.7.7")),
+      Address.Inet(new InetSocketAddress("1.1.1.2", 8888), Map(Metadata.nodeName -> "7.7.7.7"))
     ))
   }
 }

--- a/k8s/src/main/scala/io/buoyant/k8s/EndpointsNamer.scala
+++ b/k8s/src/main/scala/io/buoyant/k8s/EndpointsNamer.scala
@@ -6,7 +6,7 @@ import com.twitter.finagle.service.Backoff
 import com.twitter.finagle.util.DefaultTimer
 import com.twitter.util._
 import io.buoyant.k8s.v1._
-import io.buoyant.namer.EnumeratingNamer
+import io.buoyant.namer.{EnumeratingNamer, Metadata}
 import java.net.InetSocketAddress
 import scala.collection.mutable
 
@@ -129,7 +129,7 @@ private object EndpointsNamer {
             val addrs: Set[Address] = ips.map {
               case (ip, nodeName) =>
                 val isa = new InetSocketAddress(ip, port.port)
-                Address.Inet(isa, Map("nodeName" -> nodeName))
+                Address.Inet(isa, nodeName.map(Metadata.nodeName -> _).toMap)
             }
             addrsByPort(name) = addrsByPort.getOrElse(name, Set.empty) ++ addrs
 

--- a/namer/core/src/main/scala/io/buoyant/namer/Metadata.scala
+++ b/namer/core/src/main/scala/io/buoyant/namer/Metadata.scala
@@ -2,4 +2,5 @@ package io.buoyant.namer
 
 object Metadata {
   val authority = "authority" // HTTP/1.1 Host or HTTP/2.0 :authority
+  val nodeName = "nodeName"
 }

--- a/namerd/iface/interpreter-thrift-idl/src/main/thrift/namer.thrift
+++ b/namerd/iface/interpreter-thrift-idl/src/main/thrift/namer.thrift
@@ -82,6 +82,7 @@ struct AddrReq {
 
 struct AddrMeta {
   1: optional string authority // HTTP/1.1 Host or HTTP/2.0 :authority
+  2: optional string nodeName
 }
 
 struct TransportAddress {

--- a/namerd/iface/interpreter-thrift-idl/src/main/thrift/namer.thrift
+++ b/namerd/iface/interpreter-thrift-idl/src/main/thrift/namer.thrift
@@ -82,7 +82,8 @@ struct AddrReq {
 
 struct AddrMeta {
   1: optional string authority // HTTP/1.1 Host or HTTP/2.0 :authority
-  2: optional string nodeName
+  2: optional string nodeName // In scheduled environments, the name of the node
+                              // that this address is scheduled on.
 }
 
 struct TransportAddress {

--- a/namerd/iface/interpreter-thrift/src/main/scala/io/buoyant/namerd/iface/ThriftNamerClient.scala
+++ b/namerd/iface/interpreter-thrift/src/main/scala/io/buoyant/namerd/iface/ThriftNamerClient.scala
@@ -150,11 +150,9 @@ class ThriftNamerClient(
    * Converts Thrift AddrMeta into Addr.Metadata
    */
   private[this] def convertMeta(thriftMeta: Option[thrift.AddrMeta]): Addr.Metadata = {
-    // TODO handle non-String metadata
-    thriftMeta match {
-      case Some(thrift.AddrMeta(Some(authority))) => Addr.Metadata(Metadata.authority -> authority)
-      case _ => Addr.Metadata.empty
-    }
+    val authority = thriftMeta.flatMap(_.authority).map(Metadata.authority -> _)
+    val nodeName = thriftMeta.flatMap(_.nodeName).map(Metadata.nodeName -> _)
+    (authority ++ nodeName).toMap
   }
 
   private[this] def watchAddr(id: TPath): Var[Addr] = {

--- a/namerd/iface/interpreter-thrift/src/main/scala/io/buoyant/namerd/iface/ThriftNamerInterface.scala
+++ b/namerd/iface/interpreter-thrift/src/main/scala/io/buoyant/namerd/iface/ThriftNamerInterface.scala
@@ -410,10 +410,17 @@ class ThriftNamerInterface(
    */
   private[this] def convertMeta(scalaMeta: Addr.Metadata): Option[thrift.AddrMeta] = {
     // TODO translate metadata (weight info, latency compensation, etc)
-    scalaMeta.get(Metadata.authority) match {
-      case Some(authority: String) => Some(thrift.AddrMeta(Some(authority)))
-      case _ => None
-    }
+
+    val authority = scalaMeta.get(Metadata.authority).map(_.toString)
+    val nodeName = scalaMeta.get(Metadata.nodeName).map(_.toString)
+
+    if (authority.isDefined || nodeName.isDefined)
+      Some(thrift.AddrMeta(
+        authority = authority,
+        nodeName = nodeName
+      ))
+    else
+      None
   }
 
   /**


### PR DESCRIPTION
Fixes #805 

This allows namerd to turn on the `hostNetwork` option for the localnode and daemonset transformers.

In this change we also switch the type of the nodeName metadata field from `Option[String]` to `String]`.