### PR TITLE
Add transformers to namerd build

### DIFF
--- a/namerd/core/src/main/scala/io/buoyant/namerd/NamerdConfig.scala
+++ b/namerd/core/src/main/scala/io/buoyant/namerd/NamerdConfig.scala
@@ -5,7 +5,7 @@ import com.twitter.finagle.util.LoadService
 import com.twitter.finagle.{Namer, Path, Stack}
 import io.buoyant.admin.AdminConfig
 import io.buoyant.config.{ConfigError, ConfigInitializer, Parser}
-import io.buoyant.namer.{NamerConfig, NamerInitializer}
+import io.buoyant.namer.{NamerConfig, NamerInitializer, TransformerInitializer}
 import io.buoyant.telemetry.{NullTelemeter, Telemeter}
 import java.net.InetSocketAddress
 import scala.util.control.NoStackTrace
@@ -77,16 +77,18 @@ private[namerd] object NamerdConfig {
   private[namerd] case class Initializers(
     namer: Seq[NamerInitializer] = Nil,
     dtabStore: Seq[DtabStoreInitializer] = Nil,
-    iface: Seq[InterfaceInitializer] = Nil
+    iface: Seq[InterfaceInitializer] = Nil,
+    transformers: Seq[TransformerInitializer] = Nil
   ) {
     def iter: Iterable[Seq[ConfigInitializer]] =
-      Seq(namer, dtabStore, iface)
+      Seq(namer, dtabStore, iface, transformers)
   }
 
   private[namerd] lazy val LoadedInitializers = Initializers(
     LoadService[NamerInitializer],
     LoadService[DtabStoreInitializer],
-    LoadService[InterfaceInitializer]
+    LoadService[InterfaceInitializer],
+    LoadService[TransformerInitializer]
   )
 
   def loadNamerd(configText: String, initializers: Initializers): NamerdConfig = {

--- a/namerd/examples/k8s-mesh.yaml
+++ b/namerd/examples/k8s-mesh.yaml
@@ -1,0 +1,35 @@
+admin:
+  port: 9990
+namers:
+- kind: io.l5d.k8s
+  experimental: true
+  host: localhost
+  port: 8001
+  prefix: /ds
+  transformers:
+  - kind: io.l5d.k8s.daemonset
+    namespace: default
+    port: incoming
+    service: l5d
+- kind: io.l5d.k8s
+  experimental: true
+  host: localhost
+  port: 8001
+
+storage:
+  kind: io.l5d.inMemory
+  namespaces:
+    incoming: |
+     /host => /#/io.l5d.k8s/default/http ;
+     /http/*/* => /host ;
+    outgoing: |
+     /host => /#/ds/default/http ;
+     /http/*/* => /host ;
+
+interfaces:
+- kind: io.l5d.thriftNameInterpreter
+  ip: 0.0.0.0
+  port: 4100
+- kind: io.l5d.httpController
+  ip: 0.0.0.0
+  port: 4180

--- a/project/LinkerdBuild.scala
+++ b/project/LinkerdBuild.scala
@@ -288,6 +288,7 @@ object LinkerdBuild extends Base {
 
     val BundleProjects = Seq[ProjectReference](
       Namer.consul, Namer.k8s, Namer.marathon, Namer.serversets, Namer.zkLeader,
+      Interpreter.perHost, Interpreter.k8s,
       Storage.etcd, Storage.inMemory, Storage.k8s, Storage.zk, Storage.consul
     )
 
@@ -335,7 +336,7 @@ object LinkerdBuild extends Base {
 
     val all = projectDir("namerd")
       .settings(aggregateSettings)
-      .aggregate(core, dcosBootstrap, Storage.all, Iface.all, main)
+      .aggregate(core, dcosBootstrap, Storage.all, Interpreter.all, Iface.all, main)
       .configs(Minimal, Bundle, Dcos)
       // Minimal cofiguration includes a runtime, HTTP routing and the
       // fs service discovery.


### PR DESCRIPTION
# Problem

Even though transformers can be specified in a namer block in namerd, the transformer plugins were not being bundled with the namerd build, making it impossible to use them.

# Solution

Bundle transformer plugins with namerd.