### PR TITLE
Add static identifier

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,6 +1,7 @@
 ## x.x.x
 
 * Change default value of `attemptTTwitterUpgrade` to `false`
+* Add `io.l5d.static` identifier
 
 ## 0.8.3
 

--- a/linkerd/docs/protocol-http.md
+++ b/linkerd/docs/protocol-http.md
@@ -207,6 +207,40 @@ Key | Default Value | Description
 dstPrefix | `http` | The `dstPrefix` as set in the routers block.
 headerValue | N/A | The value of the HTTP header as a path.
 
+<a name="static-identifier"></a>
+### Static Identifier
+
+kind: `io.l5d.static`
+
+This identifier always assigns the same static name to all requests.
+
+#### Namer Configuration:
+
+```yaml
+routers:
+- protocol: http
+  identifier:
+    kind: io.l5d.static
+    path: /foo/bar
+```
+
+Key  | Default Value | Description
+---- | ------------- | -----------
+path | _required_    | The name to assign to all requests
+
+#### Namer Path Parameters
+
+> Dtab Path Format
+
+```
+  / dstPrefix / *path
+```
+
+Key | Default Value | Description
+--- | ------------- | -----------
+dstPrefix | `http` | The `dstPrefix` as set in the routers block.
+path | N/A | The path given in the configuration.
+
 <a name="http-engines"></a>
 ## HTTP Engines
 

--- a/linkerd/protocol/http/src/main/resources/META-INF/services/io.buoyant.linkerd.IdentifierInitializer
+++ b/linkerd/protocol/http/src/main/resources/META-INF/services/io.buoyant.linkerd.IdentifierInitializer
@@ -1,3 +1,4 @@
 io.buoyant.linkerd.protocol.http.HeaderIdentifierInitializer
 io.buoyant.linkerd.protocol.http.MethodAndHostIdentifierInitializer
 io.buoyant.linkerd.protocol.http.PathIdentifierInitializer
+io.buoyant.linkerd.protocol.http.StaticIdentifierInitializer

--- a/linkerd/protocol/http/src/main/scala/io/buoyant/linkerd/protocol/http/StaticIdentifierConfig.scala
+++ b/linkerd/protocol/http/src/main/scala/io/buoyant/linkerd/protocol/http/StaticIdentifierConfig.scala
@@ -22,5 +22,5 @@ case class StaticIdentifierConfig(path: Path) extends HttpIdentifierConfig {
   override def newIdentifier(
     prefix: Path,
     baseDtab: () => Dtab = () => Dtab.base
-  ): Identifier[Request] = new StaticIdentifier(prefix, path, baseDtab)
+  ): Identifier[Request] = new StaticIdentifier(prefix ++ path, baseDtab)
 }

--- a/linkerd/protocol/http/src/main/scala/io/buoyant/linkerd/protocol/http/StaticIdentifierConfig.scala
+++ b/linkerd/protocol/http/src/main/scala/io/buoyant/linkerd/protocol/http/StaticIdentifierConfig.scala
@@ -1,0 +1,26 @@
+package io.buoyant.linkerd.protocol.http
+
+import com.fasterxml.jackson.annotation.JsonIgnore
+import com.twitter.finagle.http.Request
+import com.twitter.finagle.{Dtab, Path}
+import io.buoyant.linkerd.IdentifierInitializer
+import io.buoyant.linkerd.protocol.HttpIdentifierConfig
+import io.buoyant.router.RoutingFactory.Identifier
+import io.buoyant.router.http.StaticIdentifier
+
+class StaticIdentifierInitializer extends IdentifierInitializer {
+  val configClass = classOf[StaticIdentifierConfig]
+  override val configId = "io.l5d.static"
+}
+
+object StaticIdentifierInitializer extends StaticIdentifierInitializer
+
+case class StaticIdentifierConfig(path: Path) extends HttpIdentifierConfig {
+  assert(path != null, "path is required")
+
+  @JsonIgnore
+  override def newIdentifier(
+    prefix: Path,
+    baseDtab: () => Dtab = () => Dtab.base
+  ): Identifier[Request] = new StaticIdentifier(prefix, path, baseDtab)
+}

--- a/linkerd/protocol/http/src/test/scala/io/buoyant/linkerd/protocol/http/StaticIdentifierConfigTest.scala
+++ b/linkerd/protocol/http/src/test/scala/io/buoyant/linkerd/protocol/http/StaticIdentifierConfigTest.scala
@@ -1,0 +1,38 @@
+package io.buoyant.linkerd.protocol.http
+
+import com.twitter.finagle.Path
+import com.twitter.finagle.buoyant.Dst
+import com.twitter.finagle.http.Request
+import com.twitter.finagle.util.LoadService
+import io.buoyant.config.Parser
+import io.buoyant.linkerd.IdentifierInitializer
+import io.buoyant.linkerd.protocol.HttpIdentifierConfig
+import io.buoyant.router.RoutingFactory.IdentifiedRequest
+import io.buoyant.test.FunSuite
+
+class StaticIdentifierConfigTest extends FunSuite {
+  test("sanity") {
+    // ensure it doesn't totally blowup
+    val _ = StaticIdentifierConfig(Path.read("/foo")).newIdentifier(Path.empty)
+  }
+
+  test("service registration") {
+    assert(LoadService[IdentifierInitializer].exists(_.isInstanceOf[StaticIdentifierInitializer]))
+  }
+
+  test("parse config") {
+    val yaml = s"""
+                  |kind: io.l5d.static
+                  |path: /foo
+      """.stripMargin
+
+    val mapper = Parser.objectMapper(yaml, Iterable(Seq(StaticIdentifierInitializer)))
+    val config = mapper.readValue[HttpIdentifierConfig](yaml).asInstanceOf[StaticIdentifierConfig]
+    val identifier = config.newIdentifier(Path.empty)
+    val req = Request()
+    assert(
+      await(identifier(req)).asInstanceOf[IdentifiedRequest[Request]].dst ==
+        Dst.Path(Path.read("/foo"))
+    )
+  }
+}

--- a/router/http/src/main/scala/io/buoyant/router/http/StaticIdentifier.scala
+++ b/router/http/src/main/scala/io/buoyant/router/http/StaticIdentifier.scala
@@ -1,0 +1,20 @@
+package io.buoyant.router.http
+
+import com.twitter.finagle.buoyant.Dst
+import com.twitter.finagle.{Dtab, Path}
+import com.twitter.finagle.http.Request
+import com.twitter.util.Future
+import io.buoyant.router.RoutingFactory
+import io.buoyant.router.RoutingFactory.{IdentifiedRequest, RequestIdentification}
+
+class StaticIdentifier(
+  prefix: Path,
+  path: Path,
+  baseDtab: () => Dtab = () => Dtab.base
+) extends RoutingFactory.Identifier[Request] {
+
+  def apply(req: Request): Future[RequestIdentification[Request]] = {
+    val dst = Dst.Path(prefix ++ path, baseDtab(), Dtab.local)
+    Future.value(new IdentifiedRequest(dst, req))
+  }
+}

--- a/router/http/src/main/scala/io/buoyant/router/http/StaticIdentifier.scala
+++ b/router/http/src/main/scala/io/buoyant/router/http/StaticIdentifier.scala
@@ -8,13 +8,12 @@ import io.buoyant.router.RoutingFactory
 import io.buoyant.router.RoutingFactory.{IdentifiedRequest, RequestIdentification}
 
 class StaticIdentifier(
-  prefix: Path,
   path: Path,
   baseDtab: () => Dtab = () => Dtab.base
 ) extends RoutingFactory.Identifier[Request] {
 
   def apply(req: Request): Future[RequestIdentification[Request]] = {
-    val dst = Dst.Path(prefix ++ path, baseDtab(), Dtab.local)
+    val dst = Dst.Path(path, baseDtab(), Dtab.local)
     Future.value(new IdentifiedRequest(dst, req))
   }
 }


### PR DESCRIPTION
Add a `io.l5d.static` identifier which always assigns the same name to all requests.