### PR TITLE
Configure jackson so that only public fields are used for config classes

### DIFF
--- a/config/src/main/scala/io/buoyant/config/Parser.scala
+++ b/config/src/main/scala/io/buoyant/config/Parser.scala
@@ -45,15 +45,21 @@ object Parser {
    */
   def objectMapper(
     config: String,
-    configInitializers: Iterable[Seq[ConfigInitializer]]
+    inits: Iterable[Seq[ConfigInitializer]]
   ): ObjectMapper with ScalaObjectMapper = {
-    val factory = if (peekJsonObject(config)) new JsonFactory() else new YAMLFactory()
-    objectMapper(factory, configInitializers)
+    if (peekJsonObject(config)) jsonObjectMapper(inits)
+    else yamlObjectMapper(inits)
   }
 
   def jsonObjectMapper(
     configInitializers: Iterable[Seq[ConfigInitializer]]
-  ): ObjectMapper with ScalaObjectMapper = objectMapper(new JsonFactory(), configInitializers)
+  ): ObjectMapper with ScalaObjectMapper =
+    objectMapper(new JsonFactory, configInitializers)
+
+  def yamlObjectMapper(
+    configInitializers: Iterable[Seq[ConfigInitializer]]
+  ): ObjectMapper with ScalaObjectMapper =
+    objectMapper(new YAMLFactory, configInitializers)
 
   private[this] def objectMapper(
     factory: JsonFactory,

--- a/config/src/main/scala/io/buoyant/config/Parser.scala
+++ b/config/src/main/scala/io/buoyant/config/Parser.scala
@@ -1,6 +1,8 @@
 package io.buoyant.config
 
+import com.fasterxml.jackson.annotation.JsonAutoDetect.Visibility
 import com.fasterxml.jackson.annotation.JsonInclude.Include
+import com.fasterxml.jackson.annotation.PropertyAccessor
 import com.fasterxml.jackson.core.JsonFactory
 import com.fasterxml.jackson.databind.deser.std.StdDeserializer
 import com.fasterxml.jackson.databind.module.SimpleModule
@@ -72,6 +74,8 @@ object Parser {
     mapper.registerModule(DefaultScalaModule)
     mapper.registerModule(customTypes)
     mapper.setSerializationInclusion(Include.NON_NULL)
+    mapper.setVisibility(PropertyAccessor.ALL, Visibility.PUBLIC_ONLY)
+    mapper.setVisibility(PropertyAccessor.FIELD, Visibility.PUBLIC_ONLY)
 
     // Subtypes must not conflict
     for (kinds <- configInitializers) {

--- a/config/src/main/scala/io/buoyant/config/Parser.scala
+++ b/config/src/main/scala/io/buoyant/config/Parser.scala
@@ -75,7 +75,6 @@ object Parser {
     mapper.registerModule(customTypes)
     mapper.setSerializationInclusion(Include.NON_NULL)
     mapper.setVisibility(PropertyAccessor.ALL, Visibility.PUBLIC_ONLY)
-    mapper.setVisibility(PropertyAccessor.FIELD, Visibility.PUBLIC_ONLY)
 
     // Subtypes must not conflict
     for (kinds <- configInitializers) {

--- a/linkerd/examples/src/test/scala/io/buoyant/linkerd/examples/ExamplesTest.scala
+++ b/linkerd/examples/src/test/scala/io/buoyant/linkerd/examples/ExamplesTest.scala
@@ -1,6 +1,7 @@
-package io.buoyant.linkerd.examples
+package io.buoyant.linkerd
+package examples
 
-import io.buoyant.linkerd.Linker
+import io.buoyant.config.Parser
 import java.io.{FilenameFilter, File}
 import org.scalatest.FunSuite
 import scala.io.Source
@@ -12,6 +13,8 @@ class ExamplesTest extends FunSuite {
     override def accept(dir: File, name: String): Boolean = name.endsWith(".yaml")
   })
 
+  val mapper = Parser.jsonObjectMapper(Linker.LoadedInitializers.iter)
+
   for (file <- files) {
     test(file.getName) {
       val source = Source.fromFile(file)
@@ -19,12 +22,12 @@ class ExamplesTest extends FunSuite {
         val lines = source.getLines().toSeq
         val firstLine = lines.headOption
         if (!firstLine.contains("#notest")) {
-          val config = lines.mkString("\n")
-          val _ = Linker.load(config)
+          val yaml = lines.mkString("\n")
+          val parsed = Linker.parse(yaml)
+          val loaded = parsed.mk()
+          assert(mapper.writeValueAsString(parsed).nonEmpty)
         }
-      } finally {
-        source.close()
-      }
+      } finally source.close()
     }
   }
 }

--- a/linkerd/protocol/http/src/main/scala/io/buoyant/linkerd/protocol/HttpIdentifierConfig.scala
+++ b/linkerd/protocol/http/src/main/scala/io/buoyant/linkerd/protocol/HttpIdentifierConfig.scala
@@ -1,13 +1,11 @@
 package io.buoyant.linkerd.protocol
 
-import com.fasterxml.jackson.annotation.JsonAutoDetect.Visibility
-import com.fasterxml.jackson.annotation.{JsonAutoDetect, JsonIgnore, JsonTypeInfo}
+import com.fasterxml.jackson.annotation.{JsonIgnore, JsonTypeInfo}
 import com.twitter.finagle.http.Request
 import com.twitter.finagle.{Dtab, Path}
 import io.buoyant.router.RoutingFactory.Identifier
 
 @JsonTypeInfo(use = JsonTypeInfo.Id.NAME, include = JsonTypeInfo.As.PROPERTY, property = "kind")
-@JsonAutoDetect(fieldVisibility = Visibility.ANY)
 trait HttpIdentifierConfig {
   @JsonIgnore
   def newIdentifier(

--- a/namer/core/src/main/scala/io/buoyant/namer/InterpreterInitializer.scala
+++ b/namer/core/src/main/scala/io/buoyant/namer/InterpreterInitializer.scala
@@ -7,7 +7,6 @@ import com.twitter.finagle.naming.NameInterpreter
 import io.buoyant.config.ConfigInitializer
 
 @JsonTypeInfo(use = JsonTypeInfo.Id.NAME, include = JsonTypeInfo.As.PROPERTY, property = "kind")
-@JsonAutoDetect(fieldVisibility = Visibility.PUBLIC_ONLY)
 trait InterpreterConfig {
 
   var transformers: Option[Seq[TransformerConfig]] = None

--- a/namer/core/src/main/scala/io/buoyant/namer/NamerInitializer.scala
+++ b/namer/core/src/main/scala/io/buoyant/namer/NamerInitializer.scala
@@ -22,7 +22,6 @@ import io.buoyant.config.ConfigInitializer
  * `/#/i` (after this prefix has been stripped).
  */
 @JsonTypeInfo(use = JsonTypeInfo.Id.NAME, include = JsonTypeInfo.As.PROPERTY, property = "kind")
-@JsonAutoDetect(fieldVisibility = Visibility.PUBLIC_ONLY)
 abstract class NamerConfig {
   @JsonProperty("prefix")
   var _prefix: Option[Path] = None

--- a/namer/core/src/main/scala/io/buoyant/namer/TransformerConfig.scala
+++ b/namer/core/src/main/scala/io/buoyant/namer/TransformerConfig.scala
@@ -5,7 +5,6 @@ import com.fasterxml.jackson.annotation.{JsonAutoDetect, JsonTypeInfo}
 import io.buoyant.config.ConfigInitializer
 
 @JsonTypeInfo(use = JsonTypeInfo.Id.NAME, include = JsonTypeInfo.As.PROPERTY, property = "kind")
-@JsonAutoDetect(fieldVisibility = Visibility.PUBLIC_ONLY)
 trait TransformerConfig {
   def mk(): NameTreeTransformer
 }

--- a/namer/marathon/src/main/scala/io/buoyant/namer/marathon/MarathonInitializer.scala
+++ b/namer/marathon/src/main/scala/io/buoyant/namer/marathon/MarathonInitializer.scala
@@ -11,6 +11,7 @@ import com.twitter.util.{Return, Throw}
 import io.buoyant.config.types.Port
 import io.buoyant.namer.{NamerConfig, NamerInitializer}
 import io.buoyant.marathon.v2.{Api, AppIdNamer}
+import scala.util.control.NoStackTrace
 
 /**
  * Supports namer configurations in the form:
@@ -41,8 +42,56 @@ case class MarathonSecret(
   uid: Option[String]
 )
 
+/**
+ * Marathon credentials are encoded as JSON objects, e.g:
+ *
+ *  {
+ *    "login_endpoint": "https://leader.mesos/acs/api/v1/auth/login",
+ *    "private_key": "<private-key-value>",
+ *    "scheme": "RS256",
+ *    "uid": "service-acct"
+ *  }
+ *
+ * This JSON blob is stored in the `DCOS_SERVICE_ACCOUNT_CREDENTIAL` environment variable.
+ *
+ * See also:
+ *   - https://docs.mesosphere.com/1.8/administration/id-and-access-mgt/service-auth/custom-service-auth/
+ *   - https://github.com/mesosphere/universe/search?utf8=%E2%9C%93&q=DCOS_SERVICE_ACCOUNT_CREDENTIAL
+ */
+object MarathonSecret {
+  val EnvKey = "DCOS_SERVICE_ACCOUNT_CREDENTIAL"
+
+  case class Invalid(secret: MarathonSecret) extends NoStackTrace
+
+  def mkAuthRequest(s: MarathonSecret): Authenticator.AuthRequest = s match {
+    case MarathonSecret(Some(loginEndpoint), Some(privateKey), Some("RS256"), Some(uid)) =>
+      Authenticator.AuthRequest(loginEndpoint, uid, privateKey)
+    case s =>
+      throw Invalid(s)
+  }
+
+  def load(): Option[MarathonSecret] =
+    sys.env.get(EnvKey) match {
+      case None => None
+      case Some(json) =>
+        Api.readJson[MarathonSecret](Buf.Utf8(json)) match {
+          case Throw(e) => throw e
+          case Return(secret) => Some(secret)
+        }
+    }
+}
+
 object MarathonConfig {
-  private val log = Logger.get(getClass.getName)
+  private val DefaultHost = "marathon.mesos"
+  private val DefaultPrefix = Path.read("/io.l5d.marathon")
+
+  private case class SetHost(host: String) extends SimpleFilter[http.Request, http.Response] {
+    def apply(req: http.Request, service: Service[http.Request, http.Response]) = {
+      req.host = host
+      service(req)
+    }
+  }
+
 }
 
 case class MarathonConfig(
@@ -53,78 +102,41 @@ case class MarathonConfig(
   ttlMs: Option[Int],
   useHealthCheck: Option[Boolean]
 ) extends NamerConfig {
-
-  import MarathonConfig.log
+  import MarathonConfig._
 
   @JsonIgnore
   override val experimentalRequired = true
 
   @JsonIgnore
-  override def defaultPrefix: Path = Path.read("/io.l5d.marathon")
-
-  private[this] def getHost = host.getOrElse("marathon.mesos")
-  private[this] def getPort = port match {
-    case Some(p) => p.port
-    case None => 80
-  }
-  private[this] def getUriPrefix = uriPrefix.getOrElse("")
-  private[this] def getTtl = ttlMs.getOrElse(5000).millis
-  private[this] def getMarathonHealth = useHealthCheck.getOrElse(false)
-
-  private[this] def getDst = dst.getOrElse(s"/$$/inet/$getHost/$getPort")
-
-  // canonical environment variable holding marathon auth info
-  // example secret json object:
-  // {
-  //   "login_endpoint": "https://leader.mesos/acs/api/v1/auth/login",
-  //   "private_key": "<private-key-value>",
-  //   "scheme": "RS256",
-  //   "uid": "service-acct"
-  // }
-  // more info at:
-  // https://docs.mesosphere.com/1.8/administration/id-and-access-mgt/service-auth/custom-service-auth/
-  // https://github.com/mesosphere/universe/search?utf8=%E2%9C%93&q=DCOS_SERVICE_ACCOUNT_CREDENTIAL
-  private[this] val SecretKey = "DCOS_SERVICE_ACCOUNT_CREDENTIAL"
-  private[this] def getAuth =
-    sys.env.get(SecretKey).flatMap { secret =>
-      Api.readJson[MarathonSecret](Buf.Utf8(secret)) match {
-        case Return(MarathonSecret(Some(loginEndpoint), Some(privateKey), Some("RS256"), Some(uid))) =>
-          Some(Authenticator.AuthRequest(loginEndpoint, uid, privateKey))
-        case Throw(e) =>
-          log.error(e, "readJson error")
-          throw e
-        case _ =>
-          val e = new Exception(s"unexpected format for $SecretKey")
-          log.error(e, s"unexpected format for $SecretKey")
-          throw e
-      }
-    }
-
-  private[this] case class SetHost(host: String)
-    extends SimpleFilter[http.Request, http.Response] {
-
-    def apply(req: http.Request, service: Service[http.Request, http.Response]) = {
-      req.host = host
-      service(req)
-    }
-  }
+  override def defaultPrefix: Path = DefaultPrefix
 
   /**
    * Construct a namer.
    */
   def newNamer(params: Stack.Params) = {
-    val client = SetHost(getHost).andThen(
-      Http.client
-        .withParams(params)
-        .configured(Label("namer" + prefix.show))
-        .withTracer(NullTracer)
-        .newService(getDst)
-    )
-    val service = getAuth match {
-      case Some(authRequest) => new Authenticator.Authenticated(client, authRequest)
+    val host0 = host.getOrElse(DefaultHost)
+    val port0 = port.map(_.port).getOrElse(80)
+    val dst0 = dst.getOrElse(s"/$$/inet/$host0/$port0")
+
+    val client = Http.client
+      .withParams(params)
+      .configured(Label("namer" + prefix.show))
+      .withTracer(NullTracer)
+      .filtered(SetHost(host0))
+      .newService(dst0)
+
+    val service = MarathonSecret.load() match {
       case None => client
+      case Some(secret) =>
+        val auth = MarathonSecret.mkAuthRequest(secret)
+        new Authenticator.Authenticated(client, auth)
     }
 
-    new AppIdNamer(Api(service, getUriPrefix, getMarathonHealth), prefix, getTtl)
+    val uriPrefix0 = uriPrefix.getOrElse("")
+    val useHealthCheck0 = useHealthCheck.getOrElse(false)
+    val api = Api(service, uriPrefix0, useHealthCheck0)
+
+    val ttl = ttlMs.getOrElse(5000).millis
+    new AppIdNamer(api, prefix, ttl)
   }
 }

--- a/namer/marathon/src/main/scala/io/buoyant/namer/marathon/MarathonInitializer.scala
+++ b/namer/marathon/src/main/scala/io/buoyant/namer/marathon/MarathonInitializer.scala
@@ -41,6 +41,10 @@ case class MarathonSecret(
   uid: Option[String]
 )
 
+object MarathonConfig {
+  private val log = Logger.get(getClass.getName)
+}
+
 case class MarathonConfig(
   host: Option[String],
   port: Option[Port],
@@ -50,7 +54,7 @@ case class MarathonConfig(
   useHealthCheck: Option[Boolean]
 ) extends NamerConfig {
 
-  private[this] val log = Logger.get(getClass.getName)
+  import MarathonConfig.log
 
   @JsonIgnore
   override val experimentalRequired = true


### PR DESCRIPTION
Configuration de/serializers sometimes get confused by non-public members.
This change removes the need for per-class visibility configuration.