### PR TITLE
Bump twitter-server, util and finagle deps + fixup H2Listener and Transporter.

### DIFF
--- a/project/Deps.scala
+++ b/project/Deps.scala
@@ -8,15 +8,15 @@ object Deps {
 
   // process lifecycle
   val twitterServer =
-    ("com.twitter" %% "twitter-server" % "1.24.0")
+    ("com.twitter" %% "twitter-server" % "1.25.0")
       .exclude("com.twitter", "finagle-zipkin_2.11")
 
   def twitterUtil(mod: String) =
-    "com.twitter" %% s"util-$mod" % "6.38.0"
+    "com.twitter" %% s"util-$mod" % "6.39.0"
 
   // networking
   def finagle(mod: String) =
-    "com.twitter" %% s"finagle-$mod" % "6.39.0"
+    "com.twitter" %% s"finagle-$mod" % "6.40.0"
 
   def netty4(mod: String) =
     "io.netty" % s"netty-$mod" % "4.1.4.Final"

--- a/router/h2/src/main/scala/com/twitter/finagle/buoyant/h2/netty4/Netty4H2Listener.scala
+++ b/router/h2/src/main/scala/com/twitter/finagle/buoyant/h2/netty4/Netty4H2Listener.scala
@@ -3,6 +3,7 @@ package netty4
 
 import com.twitter.finagle.Stack
 import com.twitter.finagle.netty4.Netty4Listener
+import com.twitter.finagle.netty4.channel.DirectToHeapInboundHandler
 import com.twitter.finagle.server.Listener
 import com.twitter.finagle.transport.{TlsConfig, Transport}
 import io.netty.buffer.ByteBuf
@@ -35,6 +36,7 @@ object Netty4H2Listener {
 
   private[this] object PlaintextListener extends ListenerMaker {
     override protected[this] val pipelineInit = { p: ChannelPipeline =>
+      p.addLast(DirectToHeapInboundHandler)
       p.addLast(new ServerUpgradeHandler); ()
     }
   }
@@ -42,6 +44,7 @@ object Netty4H2Listener {
   private[this] object TlsListener extends ListenerMaker {
     val PlaceholderKey = "h2 framer placeholder"
     override protected[this] val pipelineInit = { p: ChannelPipeline =>
+      p.addLast(DirectToHeapInboundHandler)
       p.addLast(PlaceholderKey, new ChannelDuplexHandler)
         .addLast("alpn", new Alpn); ()
     }

--- a/router/h2/src/main/scala/com/twitter/finagle/buoyant/h2/netty4/Netty4H2Transporter.scala
+++ b/router/h2/src/main/scala/com/twitter/finagle/buoyant/h2/netty4/Netty4H2Transporter.scala
@@ -5,6 +5,7 @@ import com.twitter.finagle.Stack
 import com.twitter.finagle.client.Transporter
 import com.twitter.finagle.netty4.Netty4Transporter
 import com.twitter.finagle.netty4.buoyant.BufferingConnectDelay
+import com.twitter.finagle.netty4.channel.DirectToHeapInboundHandler
 import com.twitter.finagle.transport.{TlsConfig, Transport}
 import io.buoyant.router.H2
 import io.netty.channel.ChannelPipeline
@@ -31,11 +32,19 @@ object Netty4H2Transporter {
 
       case TlsConfig.Disabled =>
         // Prior Knowledge: ensure messages are buffered until handshake completes.
-        p => { p.addLast(framer).addLast(new BufferingConnectDelay); () }
+        p => { 
+          p.addLast(DirectToHeapInboundHandler)
+          p.addLast(framer).addLast(new BufferingConnectDelay)
+          () 
+        }
 
       case _ =>
         // TLS is configured by the transport, so just install a framer.
-        p => { p.addLast(framer); () }
+        p => { 
+          p.addLast(DirectToHeapInboundHandler)
+          p.addLast(framer)
+          () 
+        }
     }
 
     Netty4Transporter(initializer, params)


### PR DESCRIPTION
Problem

As of https://github.com/twitter/finagle/commit/5a3cb15fdd125fb4b7d70c57bf5c4606983788bc finagle delegates buffer ref-counting to the protocol implementations but also provides a handler that implements the previous semantics of copying all direct buffer contents on heap and releasing the direct buffer.

Solution

Use the DirectToHeapHandler to spare linkerd's http2 impl from ref-counting or leaking direct buffers.