### PR TITLE
[h2] Support stream cancelation

### DIFF
--- a/linkerd/protocol/h2/src/test/scala/io/buoyant/linkerd/protocol/h2/ErrorResponderTest.scala
+++ b/linkerd/protocol/h2/src/test/scala/io/buoyant/linkerd/protocol/h2/ErrorResponderTest.scala
@@ -15,23 +15,20 @@ class ErrorResponderTest extends FunSuite with Awaits {
       Future.exception(RoutingFactory.UnknownDst(req, "yodles"))
     })
 
-    val rsp = await(service(Request("http", Method.Get, "hihost", "/", Stream.Nil)))
+    val rsp = await(service(Request("http", Method.Get, "hihost", "/", Stream.empty())))
     assert(rsp.status == Status.BadRequest)
     assert(rsp.headers.contains("l5d-err"))
     rsp.headers.get("l5d-err") match {
       case Seq(msg) => assert(msg.startsWith("Unknown destination: "))
       case msgs => fail(s"unexpected error header: $msgs")
     }
-    rsp.data match {
-      case Stream.Nil => fail("no body")
-      case stream: Stream.Reader =>
-        await(stream.read()) match {
-          case _: Frame.Trailers =>
-            fail("received trailers instead of data")
-          case data: Frame.Data =>
-            val Buf.Utf8(msg) = data.buf
-            assert(msg.startsWith("Unknown destination: "))
-        }
+    assert(rsp.stream.nonEmpty)
+    await(rsp.stream.read()) match {
+      case _: Frame.Trailers =>
+        fail("received trailers instead of data")
+      case data: Frame.Data =>
+        val Buf.Utf8(msg) = data.buf
+        assert(msg.startsWith("Unknown destination: "))
     }
   }
 
@@ -40,30 +37,27 @@ class ErrorResponderTest extends FunSuite with Awaits {
       Future.exception(Failure("yodles"))
     })
 
-    val rsp = await(service(Request("http", Method.Get, "hihost", "/", Stream.Nil)))
+    val rsp = await(service(Request("http", Method.Get, "hihost", "/", Stream.empty())))
     assert(rsp.status == Status.BadGateway)
     assert(rsp.headers.contains("l5d-err"))
     assert(rsp.headers.get("l5d-err") == Seq("yodles"))
-    rsp.data match {
-      case Stream.Nil => fail("no body")
-      case stream: Stream.Reader =>
-        await(stream.read()) match {
-          case _: Frame.Trailers =>
-            fail("received trailers instead of data")
-          case data: Frame.Data =>
-            assert(data.buf == Buf.Utf8("yodles"))
-        }
+    assert(rsp.stream.nonEmpty)
+    await(rsp.stream.read()) match {
+      case _: Frame.Trailers =>
+        fail("received trailers instead of data")
+      case data: Frame.Data =>
+        assert(data.buf == Buf.Utf8("yodles"))
     }
   }
 
   test("success") {
     val service = ErrorResponder.filter.andThen(Service.mk[Request, Response] { _ =>
-      Future.value(Response(Status.Cowabunga, Stream.Nil))
+      Future.value(Response(Status.Cowabunga, Stream.empty()))
     })
 
-    val rsp = await(service(Request("http", Method.Get, "hihost", "/", Stream.Nil)))
+    val rsp = await(service(Request("http", Method.Get, "hihost", "/", Stream.empty())))
     assert(rsp.status == Status.Cowabunga)
     assert(!rsp.headers.contains("l5d-err"))
-    assert(rsp.data == Stream.Nil)
+    assert(rsp.stream.isEmpty)
   }
 }

--- a/linkerd/protocol/h2/src/test/scala/io/buoyant/linkerd/protocol/h2/HeaderPathIdentifierTest.scala
+++ b/linkerd/protocol/h2/src/test/scala/io/buoyant/linkerd/protocol/h2/HeaderPathIdentifierTest.scala
@@ -13,7 +13,7 @@ class HeaderPathIdentifierTest extends FunSuite with Awaits {
     val baseDtab = Dtab.read("/pfx => /other")
     val localDtab = Dtab.read("/pfx => /another")
     val identifier = new HeaderPathIdentifier(Headers.Path, None, Path.Utf8("pfx"), () => baseDtab)
-    val req0 = Request("http", Method.Get, "wacky", "/one/two", Stream.Nil)
+    val req0 = Request("http", Method.Get, "wacky", "/one/two", Stream.empty())
 
     Dtab.local = localDtab
     await(identifier(req0)) match {
@@ -29,7 +29,7 @@ class HeaderPathIdentifierTest extends FunSuite with Awaits {
     val baseDtab = Dtab.read("/pfx => /other")
     val localDtab = Dtab.read("/pfx => /another")
     val identifier = new HeaderPathIdentifier(Headers.Path, Some(1), Path.Utf8("pfx"), () => baseDtab)
-    val req0 = Request("http", Method.Get, "wacky", "/one/two", Stream.Nil)
+    val req0 = Request("http", Method.Get, "wacky", "/one/two", Stream.empty())
 
     Dtab.local = localDtab
     await(identifier(req0)) match {
@@ -45,7 +45,7 @@ class HeaderPathIdentifierTest extends FunSuite with Awaits {
     val baseDtab = Dtab.read("/pfx => /other")
     val localDtab = Dtab.read("/pfx => /another")
     val identifier = new HeaderPathIdentifier(Headers.Path, Some(3), Path.Utf8("pfx"), () => baseDtab)
-    val req0 = Request("http", Method.Get, "wacky", "/one/two", Stream.Nil)
+    val req0 = Request("http", Method.Get, "wacky", "/one/two", Stream.empty())
 
     Dtab.local = localDtab
     assert(await(identifier(req0)).isInstanceOf[UnidentifiedRequest[Request]])
@@ -55,7 +55,7 @@ class HeaderPathIdentifierTest extends FunSuite with Awaits {
     val baseDtab = Dtab.read("/pfx => /other")
     val localDtab = Dtab.read("/pfx => /another")
     val identifier = new HeaderPathIdentifier("lolz", None, Path.Utf8("pfx"), () => baseDtab)
-    val req0 = Request("http", Method.Get, "wacky", "/one/two", Stream.Nil)
+    val req0 = Request("http", Method.Get, "wacky", "/one/two", Stream.empty())
     req0.headers.set("lolz", "/rofl/hah")
 
     Dtab.local = localDtab
@@ -72,7 +72,7 @@ class HeaderPathIdentifierTest extends FunSuite with Awaits {
     val baseDtab = Dtab.read("/pfx => /other")
     val localDtab = Dtab.read("/pfx => /another")
     val identifier = new HeaderPathIdentifier("lolz", None, Path.Utf8("pfx"), () => baseDtab)
-    val req0 = Request("http", Method.Get, "wacky", "/one/two", Stream.Nil)
+    val req0 = Request("http", Method.Get, "wacky", "/one/two", Stream.empty())
 
     Dtab.local = localDtab
     assert(await(identifier(req0)).isInstanceOf[UnidentifiedRequest[Request]])
@@ -82,7 +82,7 @@ class HeaderPathIdentifierTest extends FunSuite with Awaits {
     val baseDtab = Dtab.read("/pfx => /other")
     val localDtab = Dtab.read("/pfx => /another")
     val identifier = new HeaderPathIdentifier("lolz", Some(1), Path.Utf8("pfx"), () => baseDtab)
-    val req0 = Request("http", Method.Get, "wacky", "/one/two", Stream.Nil)
+    val req0 = Request("http", Method.Get, "wacky", "/one/two", Stream.empty())
 
     Dtab.local = localDtab
     assert(await(identifier(req0)).isInstanceOf[UnidentifiedRequest[Request]])

--- a/linkerd/protocol/h2/src/test/scala/io/buoyant/linkerd/protocol/h2/HeaderTokenIdentifierTest.scala
+++ b/linkerd/protocol/h2/src/test/scala/io/buoyant/linkerd/protocol/h2/HeaderTokenIdentifierTest.scala
@@ -13,7 +13,7 @@ class HeaderTokenIdentifierTest extends FunSuite with Awaits {
     val baseDtab = Dtab.read("/pfx => /other")
     val localDtab = Dtab.read("/pfx => /another")
     val identifier = new HeaderTokenIdentifier(":authority", Path.Utf8("pfx"), () => baseDtab)
-    val req0 = Request("http", Method.Get, "wacky", "/path", Stream.Nil)
+    val req0 = Request("http", Method.Get, "wacky", "/path", Stream.empty())
 
     Dtab.local = localDtab
     await(identifier(req0)) match {
@@ -29,7 +29,7 @@ class HeaderTokenIdentifierTest extends FunSuite with Awaits {
     val baseDtab = Dtab.read("/pfx => /other")
     val localDtab = Dtab.read("/pfx => /another")
     val identifier = new HeaderTokenIdentifier("lolz", Path.Utf8("pfx"), () => baseDtab)
-    val req0 = Request("http", Method.Get, "wacky", "/path", Stream.Nil)
+    val req0 = Request("http", Method.Get, "wacky", "/path", Stream.empty())
 
     Dtab.local = localDtab
     assert(await(identifier(req0)).isInstanceOf[UnidentifiedRequest[Request]])

--- a/linkerd/protocol/h2/src/test/scala/io/buoyant/linkerd/protocol/h2/ResponseClassifiersTest.scala
+++ b/linkerd/protocol/h2/src/test/scala/io/buoyant/linkerd/protocol/h2/ResponseClassifiersTest.scala
@@ -19,8 +19,8 @@ class ResponseClassifiersTest extends FunSuite {
     status: Try[Status],
     classification: Option[ResponseClass]
   ): Unit = {
-    val req = Request("http", method, "auf", "/", Stream.Nil)
-    val key = ReqRep(req, status.map(Response(_, Stream.Nil)))
+    val req = Request("http", method, "auf", "/", Stream.empty())
+    val key = ReqRep(req, status.map(Response(_, Stream.empty())))
     classification match {
       case None =>
         assert(!classifier.isDefinedAt(key))
@@ -165,15 +165,15 @@ class ResponseClassifiersTest extends FunSuite {
   test("NonRetryableStream: makes RetryableFailures NonRetryableFailures when chunked") {
     val classifier = ResponseClassifiers.NonRetryableStream { case ReqRep(_, _) => ResponseClass.RetryableFailure }
     val req = Request("http", Method.Get, "auf", "/", Stream.const(Buf.Utf8("yo")))
-    val rsp = Response(Status.EatMyShorts, Stream.Nil)
-    Response(Status.Ok, Stream.Nil)
+    val rsp = Response(Status.EatMyShorts, Stream.empty())
+    Response(Status.Ok, Stream.empty())
     assert(classifier(ReqRep(req, Return(rsp))) == ResponseClass.NonRetryableFailure)
   }
 
   test("NonRetryableStream: does not change RetryableFailures when not chunked") {
     val classifier = ResponseClassifiers.NonRetryableStream { case ReqRep(_, _) => ResponseClass.RetryableFailure }
-    val req = Request("http", Method.Get, "auf", "/", Stream.Nil)
-    val rsp = Response(Status.EatMyShorts, Stream.Nil)
+    val req = Request("http", Method.Get, "auf", "/", Stream.empty())
+    val rsp = Response(Status.EatMyShorts, Stream.empty())
     assert(classifier(ReqRep(req, Return(rsp))) == ResponseClass.RetryableFailure)
   }
 }

--- a/router/h2/src/e2e/scala/io/buoyant/router/h2/ClientServerHelpers.scala
+++ b/router/h2/src/e2e/scala/io/buoyant/router/h2/ClientServerHelpers.scala
@@ -6,6 +6,7 @@ import com.twitter.finagle.{Status => _, param => fparam, _}
 import com.twitter.finagle.buoyant.h2._
 import com.twitter.finagle.stats.InMemoryStatsReceiver
 import com.twitter.io.Buf
+import com.twitter.logging.Level
 import com.twitter.util._
 import io.buoyant.test.FunSuite
 import java.net.InetSocketAddress
@@ -13,18 +14,16 @@ import org.scalatest.BeforeAndAfter
 import scala.collection.JavaConverters._
 
 trait ClientServerHelpers extends BeforeAndAfter { _: FunSuite =>
+  setLogLevel(Level.OFF)
 
   val statsReceiver = new InMemoryStatsReceiver
   before {
+    setLogLevel(Level.OFF)
     statsReceiver.clear()
   }
   after {
+    setLogLevel(Level.OFF)
     statsReceiver.clear()
-  }
-
-  def reader(s: Stream) = s match {
-    case Stream.Nil => fail("empty response stream")
-    case r: Stream.Reader => r
   }
 
   def mkBuf(sz: Int): Buf =
@@ -34,7 +33,9 @@ trait ClientServerHelpers extends BeforeAndAfter { _: FunSuite =>
     val server = Downstream.mk("srv")(srv)
     val client = upstream(server.server)
     try f(client)
+    catch { case e: Throwable => log.info(e, "client") }
     finally {
+      setLogLevel(Level.OFF)
       await(client.close())
       await(server.server.close())
     }
@@ -81,22 +82,16 @@ trait ClientServerHelpers extends BeforeAndAfter { _: FunSuite =>
     def apply(req: Request): Future[Response] = service(req)
 
     def get(host: String, path: String = "/")(check: Option[String] => Boolean): Unit = {
-      val req = Request("http", Method.Get, host, path, Stream.Nil)
+      val req = Request("http", Method.Get, host, path, Stream.empty())
       val rsp = await(service(req))
       assert(rsp.status == Status.Ok)
-      rsp.data match {
-        case Stream.Nil =>
-          assert(check(None))
+      await(rsp.stream.read()) match {
+        case f: Frame.Data if f.isEnd =>
+          val Buf.Utf8(data) = f.buf
+          assert(check(Some(data)))
+          await(f.release())
 
-        case stream: Stream.Reader =>
-          await(stream.read()) match {
-            case f: Frame.Data if f.isEnd =>
-              val Buf.Utf8(data) = f.buf
-              assert(check(Some(data)))
-              await(f.release())
-
-            case f => fail(s"unexpected frame: $f")
-          }
+        case f => fail(s"unexpected frame: $f")
       }
     }
 

--- a/router/h2/src/e2e/scala/io/buoyant/router/h2/ConcurrentStreamsEndToEndTest.scala
+++ b/router/h2/src/e2e/scala/io/buoyant/router/h2/ConcurrentStreamsEndToEndTest.scala
@@ -17,7 +17,7 @@ class ConcurrentStreamsEndToEndTest
 
   val FrameSize = 16 * 1024
   val WindowSize = 4 * FrameSize
-  val lengths = Seq(/*1,*/ WindowSize * 2 - WindowSize / 2)
+  val lengths = Seq(1, WindowSize * 2 - WindowSize / 2)
 
   case class Spec(len: Long, frameSize: Int, concurrency: Int)
   val specs = lengths.flatMap { len =>

--- a/router/h2/src/e2e/scala/io/buoyant/router/h2/ConcurrentStreamsEndToEndTest.scala
+++ b/router/h2/src/e2e/scala/io/buoyant/router/h2/ConcurrentStreamsEndToEndTest.scala
@@ -6,6 +6,7 @@ import com.twitter.io.Buf
 import com.twitter.logging.Level
 import com.twitter.util._
 import io.buoyant.test.FunSuite
+import scala.annotation.tailrec
 
 class ConcurrentStreamsEndToEndTest
   extends FunSuite
@@ -16,7 +17,7 @@ class ConcurrentStreamsEndToEndTest
 
   val FrameSize = 16 * 1024
   val WindowSize = 4 * FrameSize
-  val lengths = Seq(1, WindowSize * 2 - WindowSize / 2)
+  val lengths = Seq(/*1,*/ WindowSize * 2 - WindowSize / 2)
 
   case class Spec(len: Long, frameSize: Int, concurrency: Int)
   val specs = lengths.flatMap { len =>
@@ -32,54 +33,61 @@ class ConcurrentStreamsEndToEndTest
     test(s"$pfx: concurrency=${concurrency} len=${streamLen}B frame=${frameSize}B") {
       // The server simply echos the request stream into the response:
       val server = Downstream.service("server") { req =>
-        Future(reader(req.data)).map(Response(Status.Ok, _))
+        Future(req.stream).map(Response(Status.Ok, _))
       }
       val client = upstream(server.server)
       def open(): Future[Streamer] = {
         val s = Stream()
         client(Request("http", Method.Post, "host", "/", s))
-          .map(r => Streamer(reader(r.data), s))
+          .map(r => Streamer(r.stream, s))
       }
 
       // Send the same data through all streams simultaneously, one frame at a time:
-      def streamToAllInStep(streamers: Seq[Streamer], remaining: Long): Future[Unit] = {
+      @tailrec def streamToAllInStep(streamers: Seq[Streamer], remaining: Long): Unit = {
         require(remaining > 0)
         val len = math.min(frameSize, remaining).toInt
         val buf = mkBuf(len)
         val eos = len == remaining
-        val f = Future.collect(streamers.map(_.stream(buf, eos))).unit
-        if (eos) f
-        else f.before(streamToAllInStep(streamers, remaining - len))
+        await(Future.collect(streamers.map(_.stream(buf, eos))))
+        if (!eos) streamToAllInStep(streamers, remaining - len)
       }
 
       try {
         val elapsed = Stopwatch.start()
-        val streamers = Future.collect((0 until concurrency).map(_ => open()))
-        await(streamers.flatMap(streamToAllInStep(_, streamLen)))
+        val streamers = await(Future.collect((0 until concurrency).map(_ => open())))
+        streamToAllInStep(streamers, streamLen)
         info(s"duration=${elapsed().inMillis}ms")
       } finally {
+        setLogLevel(Level.OFF)
         await(client.close())
         await(server.server.close())
       }
     }
 
-  case class Streamer(reader: Stream.Reader, writer: Stream.Writer) {
+  case class Streamer(reader: Stream, writer: Stream.Writer) {
     def stream(buf: Buf, eos: Boolean): Future[Unit] = {
-      def read(remaining: Int): Future[Unit] =
-        reader.read().flatMap {
-          case d: Frame.Data =>
+      def read(remaining: Int): Future[Unit] = {
+        log.debug("Streamer.read < %d", remaining)
+        reader.read().transform {
+          case t@Throw(e) =>
+            log.error(e, "read error")
+            Future.exception(e)
+
+          case Return(d: Frame.Data) =>
+            log.debug("Streamer.read > %s", d)
             (remaining - d.buf.length) match {
               case 0 =>
                 assert(d.isEnd == eos)
                 d.release()
+
               case remaining =>
                 assert(!d.isEnd)
-                d.release().join(read(remaining)).unit
+                d.release().before(read(remaining))
             }
 
-          case t: Frame.Trailers =>
-            fail(s"unexpected trailers $t")
+          case Return(f) => fail(s"unexpected frame $f")
         }
+      }
 
       writer.write(Frame.Data(buf, eos)).before(read(buf.length))
     }

--- a/router/h2/src/e2e/scala/io/buoyant/router/h2/FlowControlEndToEndTest.scala
+++ b/router/h2/src/e2e/scala/io/buoyant/router/h2/FlowControlEndToEndTest.scala
@@ -11,36 +11,37 @@ import scala.collection.mutable.ListBuffer
 class FlowControlEndToEndTest
   extends FunSuite
   with ClientServerHelpers {
-  setLogLevel(Level.OFF)
 
   test("client/server request flow control") {
     val streamP = new Promise[Stream]
     val server = { req: Request =>
-      streamP.setValue(req.data)
-      Response(Status.Ok, Stream.Nil)
+      streamP.setValue(req.stream)
+      Response(Status.Ok, Stream.empty())
     }
     withClient(server) { client =>
       val writer = Stream()
       val req = Request("http", Method.Get, "host", "/path", writer)
       val rsp = await(client(req))
       assert(rsp.status == Status.Ok)
-      testFlowControl(reader(await(streamP)), writer)
+      testFlowControl(await(streamP), writer)
     }
   }
 
   test("client/server response flow control") {
-    val writer = Stream()
-    withClient(_ => Response(Status.Ok, writer)) { client =>
-      val req = Request("http", Method.Get, "host", "/path", Stream.Nil)
-      val rsp = await(client(req))
-      assert(rsp.status == Status.Ok)
-      testFlowControl(reader(rsp.data), writer)
-    }
+    try {
+      val writer = Stream()
+      withClient(_ => Response(Status.Ok, writer)) { client =>
+        val req = Request("http", Method.Get, "host", "/path", Stream.empty())
+        val rsp = await(client(req))
+        assert(rsp.status == Status.Ok)
+        testFlowControl(rsp.stream, writer)
+      }
+    } finally setLogLevel(Level.OFF)
   }
 
   val WindowSize = 65535
 
-  def testFlowControl(reader: Stream.Reader, writer: Stream.Writer) = {
+  def testFlowControl(reader: Stream, writer: Stream.Writer) = {
     // The first frame is too large to fit in a window. It should not
     // be released until all of the data has been flushed.  This
     // cannot happen until the reader reads and releases some of the
@@ -51,8 +52,8 @@ class FlowControlEndToEndTest
 
     log.debug("offering 2 frames with %d", 2 * WindowSize)
     val wrote0 = writer.write(frame0)
-    val wrote1 = writer.write(frame1)
-    val wrote2 = writer.write(frame2)
+    val wrote1 = wrote0.before(writer.write(frame1))
+    val wrote2 = wrote1.before(writer.write(frame2))
     assert(!wrote0.isDefined && !wrote1.isDefined && !wrote2.isDefined)
 
     // Read a full window, without releasing anything.
@@ -61,12 +62,13 @@ class FlowControlEndToEndTest
     while (read < WindowSize) {
       log.debug("~~~ reading %d/%d", read, WindowSize)
       await(reader.read()) match {
-        case _: Frame.Trailers => fail("unexpected trailers")
         case d: Frame.Data =>
           // frames += d
           read += d.buf.length
           log.debug("~~~ read %d = %d/%d", d.buf.length, read, WindowSize)
           await(d.release())
+
+        case f => fail(s"unexpected frame: $f")
       }
     }
     assert(read == WindowSize)
@@ -79,11 +81,12 @@ class FlowControlEndToEndTest
         read, 2 * WindowSize, wrote1.isDefined)
       if (read > WindowSize + 1024) assert(wrote0.isDefined)
       await(reader.read()) match {
-        case _: Frame.Trailers => fail("unexpected trailers")
         case d: Frame.Data =>
           read += d.buf.length
           log.debug("reader releasing %dB from 1 frame", d.buf.length)
           await(d.release())
+
+        case f => fail(s"unexpected frame: $f")
       }
     }
     assert(read == 2 * WindowSize)
@@ -94,12 +97,13 @@ class FlowControlEndToEndTest
       log.debug("reader reading more after %dB/%dB, released=%s",
         read, 3 * WindowSize, wrote2.isDefined)
       await(reader.read()) match {
-        case _: Frame.Trailers => fail("unexpected trailers")
         case d: Frame.Data =>
           read += d.buf.length
           log.debug("reader releasing %dB from 1 frame", d.buf.length)
           await(d.release())
           assert(d.isEnd == (read == 3 * WindowSize))
+
+        case f => fail(s"unexpected frame: $f")
       }
     }
     assert(read == 3 * WindowSize)

--- a/router/h2/src/e2e/scala/io/buoyant/router/h2/RouterEndToEndTest.scala
+++ b/router/h2/src/e2e/scala/io/buoyant/router/h2/RouterEndToEndTest.scala
@@ -1,10 +1,11 @@
 package io.buoyant.router
 package h2
 
-import com.twitter.finagle.{Dtab, Path}
+import com.twitter.finagle.{Dtab, Failure, Path}
 import com.twitter.finagle.buoyant.Dst
+import com.twitter.finagle.buoyant.h2._
 import com.twitter.logging.Level
-import com.twitter.util.Future
+import com.twitter.util.{Future, Promise, Throw}
 import io.buoyant.test.FunSuite
 import java.net.InetSocketAddress
 
@@ -12,8 +13,7 @@ class RouterEndToEndTest
   extends FunSuite
   with ClientServerHelpers {
 
-  test("router with prior knowledge") {
-    // setLogLevel(Level.DEBUG)
+  test("simple prior knowledge") {
     val cat = Downstream.const("cat", "meow")
     val dog = Downstream.const("dog", "woof")
     val dtab = Dtab.read(s"""
@@ -44,4 +44,132 @@ class RouterEndToEndTest
       await(router.close())
     }
   }
+
+  test("resets downstream on upstream cancelation") {
+    val dogReqP, dogRspP = new Promise[Stream]
+    @volatile var serverInterrupted: Option[Throwable] = None
+    dogRspP.setInterruptHandler { case e => serverInterrupted = Some(e) }
+    val dog = Downstream.service("dog") { req =>
+      dogReqP.setValue(req.stream)
+      dogRspP.map(Response(Status.Ok, _))
+    }
+
+    val dtab = Dtab.read(s"""
+        /p => /$$/inet/127.1 ;
+        /h2/clifford => /p/${dog.port} ;
+      """)
+    val identifierParam = H2.Identifier { _ =>
+      req => {
+        val dst = Dst.Path(Path.Utf8("h2", req.authority), dtab)
+        Future.value(new RoutingFactory.IdentifiedRequest(dst, req))
+      }
+    }
+    val router = H2.serve(new InetSocketAddress(0), H2.router
+      .configured(identifierParam)
+      .factory())
+    val client = upstream(router)
+    try {
+      val clientLocalStream = Stream()
+      val req = Request("http", Method.Get, "clifford", "/path", clientLocalStream)
+      val rspF = client(req)
+      val reqStream = await(dogReqP)
+      assert(!rspF.isDefined)
+
+      rspF.raise(Failure("failz").flagged(Failure.Interrupted))
+      assert(await(rspF.liftToTry) == Throw(Reset.Cancel))
+      eventually(assert(serverInterrupted == Some(Reset.Cancel)))
+
+    } finally {
+      try {
+        await(client.close())
+        await(dog.server.close())
+        await(router.close())
+      } catch {
+        case e: Throwable => log.error(e, "closing")
+      } finally setLogLevel(Level.OFF)
+    }
+  }
+
+  test("resets downstream on upstream disconnect") {
+    val dogReqP, dogRspP = new Promise[Stream]
+    val dog = Downstream.service("dog") { req =>
+      dogReqP.setValue(req.stream)
+      dogRspP.map(Response(Status.Ok, _))
+    }
+
+    val dtab = Dtab.read(s"""
+        /p => /$$/inet/127.1 ;
+        /h2/clifford => /p/${dog.port} ;
+      """)
+    val identifierParam = H2.Identifier { _ =>
+      req => {
+        val dst = Dst.Path(Path.Utf8("h2", req.authority), dtab)
+        Future.value(new RoutingFactory.IdentifiedRequest(dst, req))
+      }
+    }
+    val router = H2.serve(new InetSocketAddress(0), H2.router
+      .configured(identifierParam)
+      .factory())
+    val client = upstream(router)
+    try {
+      val clientLocalStream, serverLocalStream = Stream()
+      val req = Request("http", Method.Get, "clifford", "/path", clientLocalStream)
+      val rspF = client(req)
+      val reqStream = await(dogReqP)
+      assert(!rspF.isDefined)
+
+      dogRspP.setValue(serverLocalStream)
+      val rsp = await(rspF)
+      val reqReadF = reqStream.read()
+      val rspReadF = rsp.stream.read()
+
+      await(client.close())
+      assert(await(reqReadF.liftToTry) == Throw(Reset.Cancel))
+      assert(await(rspReadF.liftToTry) == Throw(Reset.Cancel))
+
+    } finally {
+      setLogLevel(Level.OFF)
+      try await(dog.server.close().before(router.close()))
+      catch { case e: Throwable => log.error(e, "closing") }
+    }
+  }
+
+  test("resets upstream on downstream failure") {
+    val dogReqP, dogRspP = new Promise[Stream]
+    val dog = Downstream.service("dog") { req =>
+      dogReqP.setValue(req.stream)
+      dogRspP.map(Response(Status.Ok, _))
+    }
+
+    val dtab = Dtab.read(s"""
+        /p => /$$/inet/127.1 ;
+        /h2/clifford => /p/${dog.port} ;
+      """)
+    val identifierParam = H2.Identifier { _ =>
+      req => {
+        val dst = Dst.Path(Path.Utf8("h2", req.authority), dtab)
+        Future.value(new RoutingFactory.IdentifiedRequest(dst, req))
+      }
+    }
+    val router = H2.serve(new InetSocketAddress(0), H2.router
+      .configured(identifierParam)
+      .factory())
+    val client = upstream(router)
+    try {
+      val clientLocalStream = Stream()
+      val req = Request("http", Method.Get, "clifford", "/path", clientLocalStream)
+      val rspF = client(req)
+      val _ = await(dogReqP)
+      assert(!rspF.isDefined)
+
+      dogRspP.setException(Failure("failz").flagged(Failure.Rejected))
+      assert(await(rspF.liftToTry) == Throw(Reset.Refused))
+
+    } finally {
+      try await(client.close().before(dog.server.close()).before(router.close()))
+      catch { case e: Throwable => log.error(e, "closing") }
+      finally setLogLevel(Level.OFF)
+    }
+  }
+
 }

--- a/router/h2/src/e2e/scala/io/buoyant/router/h2/RouterEndToEndTest.scala
+++ b/router/h2/src/e2e/scala/io/buoyant/router/h2/RouterEndToEndTest.scala
@@ -46,7 +46,8 @@ class RouterEndToEndTest
   }
 
   test("resets downstream on upstream cancelation") {
-    val dogReqP, dogRspP = new Promise[Stream]
+    val dogReqP = new Promise[Stream]
+    val dogRspP = new Promise[Stream]
     @volatile var serverInterrupted: Option[Throwable] = None
     dogRspP.setInterruptHandler { case e => serverInterrupted = Some(e) }
     val dog = Downstream.service("dog") { req =>
@@ -88,7 +89,8 @@ class RouterEndToEndTest
   }
 
   test("resets downstream on upstream disconnect") {
-    val dogReqP, dogRspP = new Promise[Stream]
+    val dogReqP = new Promise[Stream]
+    val dogRspP = new Promise[Stream]
     val dog = Downstream.service("dog") { req =>
       dogReqP.setValue(req.stream)
       dogRspP.map(Response(Status.Ok, _))

--- a/router/h2/src/e2e/scala/io/buoyant/router/h2/TlsEndToEndTest.scala
+++ b/router/h2/src/e2e/scala/io/buoyant/router/h2/TlsEndToEndTest.scala
@@ -28,7 +28,7 @@ class TlsEndToEndTest extends FunSuite {
   }
 
   val service = Service.mk[h2.Request, h2.Response] { req =>
-    Future.value(h2.Response(h2.Status.Ok, h2.Stream.Nil))
+    Future.value(h2.Response(h2.Status.Ok, h2.Stream.empty()))
   }
 
   test("client/server works with TLS") {
@@ -59,7 +59,7 @@ class TlsEndToEndTest extends FunSuite {
     val client = H2.client.configured(Transport.Tls(clientTls)).newService(srvName, "")
 
     try {
-      val rsp = await(client(h2.Request("http", h2.Method.Get, "auforiteh", "/a/parf", h2.Stream.Nil)))
+      val rsp = await(client(h2.Request("http", h2.Method.Get, "auforiteh", "/a/parf", h2.Stream.empty())))
       assert(rsp.status == h2.Status.Ok)
 
     } finally await(client.close().before(srv.close()))

--- a/router/h2/src/main/scala/com/twitter/finagle/buoyant/h2/Error.scala
+++ b/router/h2/src/main/scala/com/twitter/finagle/buoyant/h2/Error.scala
@@ -1,0 +1,43 @@
+package com.twitter.finagle.buoyant.h2
+
+import scala.util.control.NoStackTrace
+
+sealed trait Error
+  extends Throwable
+  with NoStackTrace
+
+sealed trait GoAway extends Error
+object GoAway {
+  object EnhanceYourCalm extends GoAway { override def toString = "GoAway.EnhanceYourCalm" }
+  object InternalError extends GoAway { override def toString = "GoAway.InternalError" }
+  object NoError extends GoAway { override def toString = "GoAway.NoError" }
+  object ProtocolError extends GoAway { override def toString = "GoAway.ProtocolError" }
+}
+
+sealed trait Reset extends Error
+object Reset {
+  object Cancel extends Reset { override def toString = "Reset.Cancel" }
+  object Closed extends Reset { override def toString = "Reset.Closed" }
+  object EnhanceYourCalm extends Reset { override def toString = "Reset.EnhanceYourCalm" }
+  object InternalError extends Reset { override def toString = "Reset.InternalError" }
+  object NoError extends Reset { override def toString = "Reset.NoError" }
+  object Refused extends Reset { override def toString = "Reset.Refused" }
+}
+
+sealed trait StreamError extends NoStackTrace {
+  def cause: Throwable
+}
+
+object StreamError {
+  case class Local(cause: Throwable) extends StreamError {
+    override def toString = s"StreamError.Local(${cause.toString})"
+    override def getMessage = s"local: ${cause.getMessage}"
+  }
+
+  case class Remote(cause: Throwable) extends StreamError {
+    override def toString = s"StreamError.Remote(${cause.toString})"
+    override def getMessage = s"remote: ${cause.getMessage}"
+  }
+
+  def unapply(e: StreamError): Option[Throwable] = Some(e.cause)
+}

--- a/router/h2/src/main/scala/com/twitter/finagle/buoyant/h2/Error.scala
+++ b/router/h2/src/main/scala/com/twitter/finagle/buoyant/h2/Error.scala
@@ -24,7 +24,15 @@ object Reset {
   object Refused extends Reset { override def toString = "Reset.Refused" }
 }
 
-sealed trait StreamError extends NoStackTrace {
+/**
+ * When an exception is encountered in a stream, it is wrapepd in a
+ * StreamError to indicate whether the error originated from the
+ * remote (network) or local (application) side of the stream.
+ */
+sealed trait StreamError
+  extends Throwable
+  with NoStackTrace {
+
   def cause: Throwable
 }
 

--- a/router/h2/src/main/scala/com/twitter/finagle/buoyant/h2/H2Transport.scala
+++ b/router/h2/src/main/scala/com/twitter/finagle/buoyant/h2/H2Transport.scala
@@ -2,52 +2,37 @@ package com.twitter.finagle.buoyant.h2
 
 import com.twitter.io.Buf
 import com.twitter.util.{Closable, Future, Time}
+import java.net.SocketAddress
 
 object H2Transport {
 
   /**
    * A codec-agnostic interface supporting writes of H2 messages to a transport.
    */
-  trait Writer extends Closable {
+  trait Writer {
 
-    /**
-     * Write an entire message and its Stream.
-     *
-     * The outer Future is satisfied when the message's headers have
-     * been written to the transport.  This Future is satisfied with a
-     * second, inner Future that is satisfied when the message's
-     * stream has been completely written to the transport.
-     */
-    def writeAll(id: Int, msg: Message): Future[Future[Unit]]
+    def localAddress: SocketAddress
+    def remoteAddress: SocketAddress
 
     def write(id: Int, orig: Headers, eos: Boolean): Future[Unit]
     def write(id: Int, buf: Buf, eos: Boolean): Future[Unit]
-    def write(id: Int, data: Frame.Data): Future[Unit]
-    def write(id: Int, tlrs: Frame.Trailers): Future[Unit]
+    def write(id: Int, frame: Frame): Future[Unit]
 
     /**
      * Update the flow control window by `incr` bytes.
      */
     def updateWindow(id: Int, incr: Int): Future[Unit]
 
-    /*
-     * Connection errors: emit GOAWAY and close connection.
+    /**
+     * Write a stream reset.
      */
+    def reset(id: Int, err: Reset): Future[Unit]
 
-    def goAwayNoError(deadline: Time): Future[Unit]
-    def goAwayProtocolError(deadline: Time): Future[Unit]
-    def goAwayInternalError(deadline: Time): Future[Unit]
-    def goAwayChillBro(deadline: Time): Future[Unit]
-
-    /*
-     * Stream errors
+    /**
+     * Write a GO_AWAY frame and close the connection..
      */
+    def goAway(err: GoAway, deadline: Time): Future[Unit]
 
-    def resetNoError(id: Int): Future[Unit]
-    def resetInternalError(id: Int): Future[Unit]
-    def resetRefused(id: Int): Future[Unit]
-    def resetStreamClosed(id: Int): Future[Unit]
-    def resetCancel(id: Int): Future[Unit]
-    def resetChillBro(id: Int): Future[Unit]
+    final def goAway(err: GoAway): Future[Unit] = goAway(err, Time.Top)
   }
 }

--- a/router/h2/src/main/scala/com/twitter/finagle/buoyant/h2/Stream.scala
+++ b/router/h2/src/main/scala/com/twitter/finagle/buoyant/h2/Stream.scala
@@ -1,0 +1,191 @@
+package com.twitter.finagle.buoyant.h2
+
+import com.twitter.io.Buf
+import com.twitter.concurrent.AsyncQueue
+import com.twitter.finagle.Failure
+import com.twitter.util.{Future, Promise, Return, Throw, Try}
+
+/**
+ * A Stream represents a stream of Data frames, optionally
+ * followed by Trailers.
+ *
+ * A Stream is not prescriptive as to how data is produced. However,
+ * flow control semantics are built into the Stream--consumers MUST
+ * release each data frame after it has processed its contents.
+ *
+ * Consumers SHOULD call `read()` until it fails (i.e. when the
+ * stream is fullt closed).
+ *
+ * If a consumer cancels a `read()` Future, the stream is reset.
+ */
+trait Stream {
+  override def toString = s"Stream(empty=$isEmpty, onEnd=$onEnd)"
+
+  def isEmpty: Boolean
+  final def nonEmpty: Boolean = !isEmpty
+
+  def read(): Future[Frame]
+
+  /**
+   * Satisfied when an end-of-stream frame has been read from this
+   * stream.
+   *
+   * If the stream is reset prematurely, onEnd fails with a [[Reset]].
+   */
+  def onEnd: Future[Unit]
+}
+
+/**
+ * A Stream of Frames
+ */
+object Stream {
+
+  // TODO Create a dedicated Static stream type that indicates the
+  // entire message is buffered (i.e. so that retries may be
+  // performed).  This would require some form of buffering, ideally
+  // in the dispatcher and server stream
+
+  /**
+   * In order to create a stream, we need a mechanism to write to it.
+   */
+  trait Writer {
+
+    /**
+     * Write an object to a Stream so that it may be read as a Frame
+     * (i.e. onto an underlying transport). The returned future is not
+     * satisfied until the frame is written and released.
+     */
+    def write(frame: Frame): Future[Unit]
+
+    def reset(err: Reset): Unit
+    def close(): Unit
+  }
+
+  private trait AsyncQueueReader extends Stream {
+    protected[this] val frameQ: AsyncQueue[Frame]
+
+    override def isEmpty = false
+
+    private[this] val endP = new Promise[Unit]
+    override def onEnd: Future[Unit] = endP
+
+    private[this] val endOnReleaseIfEnd: Try[Frame] => Unit = {
+      case Return(f) => if (f.isEnd) endP.become(f.onRelease)
+      case Throw(e) => endP.updateIfEmpty(Throw(e)); ()
+    }
+
+    override def read(): Future[Frame] = {
+      val f = frameQ.poll()
+      f.respond(endOnReleaseIfEnd)
+      f
+    }
+  }
+
+  private class AsyncQueueReaderWriter extends AsyncQueueReader with Writer {
+    override protected[this] val frameQ = new AsyncQueue[Frame]
+
+    override def write(f: Frame): Future[Unit] =
+      if (frameQ.offer(f)) f.onRelease
+      else Future.exception(Reset.Closed)
+
+    override def reset(err: Reset): Unit = frameQ.fail(err, discard = true)
+    override def close(): Unit = frameQ.fail(Reset.NoError, discard = false)
+  }
+
+  def apply(q: AsyncQueue[Frame]): Stream =
+    new AsyncQueueReader { override protected[this] val frameQ = q }
+
+  def apply(): Stream with Writer =
+    new AsyncQueueReaderWriter
+
+  def const(buf: Buf): Stream = {
+    val q = new AsyncQueue[Frame]
+    q.offer(Frame.Data.eos(buf))
+    apply(q)
+  }
+
+  def const(s: String): Stream =
+    const(Buf.Utf8(s))
+
+  def empty(q: AsyncQueue[Frame]): Stream =
+    new AsyncQueueReader {
+      override protected[this] val frameQ = q
+      override def isEmpty = true
+    }
+
+  def empty(): Stream with Writer =
+    new Stream with Writer {
+      private[this] val frameQ = new AsyncQueue[Frame](1)
+      override def isEmpty = true
+      override def onEnd = Future.Unit
+      override def read(): Future[Frame] = frameQ.poll()
+      override def write(f: Frame): Future[Unit] = {
+        frameQ.fail(Reset.Closed, discard = true)
+        Future.exception(Reset.Closed)
+      }
+      override def reset(err: Reset): Unit = frameQ.fail(err, discard = true)
+      override def close(): Unit = frameQ.fail(Reset.NoError, discard = false)
+    }
+
+}
+
+/**
+ * A single item in a Stream.
+ */
+sealed trait Frame {
+
+  /**
+   * When `isEnd` is true, no further events will be returned on the
+   * Stream.
+   */
+  def isEnd: Boolean
+
+  def onRelease: Future[Unit]
+  def release(): Future[Unit]
+}
+
+object Frame {
+  /**
+   * A frame containing aribtrary data.
+   *
+   * `release()` MUST be called so that the producer may manage flow control.
+   */
+  trait Data extends Frame {
+    override def toString = s"Frame.Data(length=${buf.length}, eos=$isEnd)"
+    def buf: Buf
+  }
+
+  object Data {
+
+    def apply(buf0: Buf, eos: Boolean, release0: () => Future[Unit]): Data = new Data {
+      def buf = buf0
+      private[this] val releaseP = new Promise[Unit]
+      def onRelease = releaseP
+      def release() = {
+        val f = release0()
+        releaseP.become(f)
+        f
+      }
+      def isEnd = eos
+    }
+
+    def apply(buf: Buf, eos: Boolean): Data =
+      apply(buf, eos, () => Future.Unit)
+
+    def apply(s: String, eos: Boolean, release: () => Future[Unit]): Data =
+      apply(Buf.Utf8(s), eos, release)
+
+    def apply(s: String, eos: Boolean): Data =
+      apply(Buf.Utf8(s), eos)
+
+    def eos(buf: Buf): Data = apply(buf, true)
+    def eos(s: String): Data = apply(s, true)
+  }
+
+  /** A terminal Frame including headers. */
+  trait Trailers extends Frame with Headers { headers =>
+    override def toString = s"Frame.Trailers(${headers.toSeq})"
+    final override def isEnd = true
+  }
+
+}

--- a/router/h2/src/main/scala/com/twitter/finagle/buoyant/h2/Stream.scala
+++ b/router/h2/src/main/scala/com/twitter/finagle/buoyant/h2/Stream.scala
@@ -14,12 +14,12 @@ import com.twitter.util.{Future, Promise, Return, Throw, Try}
  * release each data frame after it has processed its contents.
  *
  * Consumers SHOULD call `read()` until it fails (i.e. when the
- * stream is fullt closed).
+ * stream is fully closed).
  *
  * If a consumer cancels a `read()` Future, the stream is reset.
  */
 trait Stream {
-  override def toString = s"Stream(empty=$isEmpty, onEnd=$onEnd)"
+  override def toString = s"Stream(isEmpty=$isEmpty, onEnd=${onEnd.poll})"
 
   def isEmpty: Boolean
   final def nonEmpty: Boolean = !isEmpty
@@ -162,7 +162,7 @@ object Frame {
    * `release()` MUST be called so that the producer may manage flow control.
    */
   trait Data extends Frame {
-    override def toString = s"Frame.Data(length=${buf.length}, eos=$isEnd)"
+    override def toString = s"Frame.Data(length=${buf.length}, isEnd=$isEnd)"
     def buf: Buf
   }
 

--- a/router/h2/src/main/scala/com/twitter/finagle/buoyant/h2/netty4/Netty4DispatcherBase.scala
+++ b/router/h2/src/main/scala/com/twitter/finagle/buoyant/h2/netty4/Netty4DispatcherBase.scala
@@ -1,0 +1,160 @@
+package com.twitter.finagle.buoyant.h2
+package netty4
+
+import com.twitter.finagle.{ChannelClosedException, Failure}
+import com.twitter.finagle.transport.Transport
+import com.twitter.logging.Logger
+import com.twitter.util._
+import io.netty.handler.codec.http2.{Http2Frame, Http2GoAwayFrame, Http2StreamFrame}
+import java.util.concurrent.ConcurrentHashMap
+import java.util.concurrent.atomic.AtomicBoolean
+import scala.collection.JavaConverters._
+
+trait Netty4DispatcherBase[LocalMsg <: Message, RemoteMsg <: Message] {
+
+  protected[this] def log: Logger
+  protected[this] def prefix: String
+
+  protected[this] def transport: Transport[Http2Frame, Http2Frame]
+  protected[this] lazy val writer: H2Transport.Writer = Netty4H2Writer(transport)
+
+  /**
+   * The various states a stream can be in (particularly closed).
+   *
+   * The failures are distinguished so that the dispatcher can be
+   * smart about (not) emiting resets to the remote.
+   */
+  private[this] sealed trait StreamTransport
+  private[this] case class StreamOpen(stream: Netty4StreamTransport[LocalMsg, RemoteMsg]) extends StreamTransport
+  private[this] object StreamClosed extends StreamTransport
+  private[this] object StreamLocalReset extends StreamTransport
+  private[this] object StreamRemoteReset extends StreamTransport
+  private[this] case class StreamFailed(cause: Throwable) extends StreamTransport
+
+  private[this] val streams: ConcurrentHashMap[Int, StreamTransport] = new ConcurrentHashMap
+  private[this] val closed: AtomicBoolean = new AtomicBoolean(false)
+  protected[this] def isClosed = closed.get
+
+  protected[this] def demuxing: Future[Unit]
+
+  protected[this] def registerStream(
+    id: Int,
+    stream: Netty4StreamTransport[LocalMsg, RemoteMsg]
+  ): Unit = {
+    val open = StreamOpen(stream)
+    if (streams.putIfAbsent(id, open) != null) {
+      throw new IllegalStateException(s"stream ${stream.streamId} already exists")
+    }
+    log.debug("[%s S:%d] initialized stream", prefix, id)
+    val _ = stream.onReset.respond {
+      case Return(_) =>
+        // Free and clear.
+        if (streams.replace(id, open, StreamClosed)) {
+          log.debug("[%s S:%d] stream closed", prefix, id)
+        }
+
+      case Throw(StreamError.Remote(e)) =>
+        // The remote initiated a reset, so just update the state and
+        // do nothing else.
+        if (streams.replace(id, open, StreamRemoteReset)) {
+          log.debug(e, "[%s S:%d] stream reset from remote", prefix, id)
+        }
+
+      case Throw(StreamError.Local(e)) =>
+        // The local side initiated a reset, so send a reset to
+        // the remote.
+        if (streams.replace(id, open, StreamLocalReset)) {
+          log.debug(e, "[%s S:%d] stream reset from local; resetting remote", prefix, id)
+          val rst = e match {
+            case rst: Reset => rst
+            case _ => Reset.Cancel
+          }
+          if (!closed.get) { writer.reset(id, rst); () }
+        }
+
+      case Throw(e) =>
+        if (streams.replace(id, open, StreamFailed(e))) {
+          log.error(e, "[%s S:%d] stream reset", prefix, id)
+          if (!closed.get) { writer.reset(id, Reset.InternalError); () }
+        }
+    }
+  }
+
+  protected[this] def demux(): Future[Unit] = {
+    lazy val loop: Try[Http2Frame] => Future[Unit] = {
+      case Throw(_: ChannelClosedException) => Future.Unit
+
+      case Throw(e) =>
+        log.error(e, "[%s] dispatcher failed", prefix)
+        goAway(GoAway.InternalError)
+
+      case Return(_: Http2GoAwayFrame) =>
+        if (resetStreams(Reset.Cancel)) transport.close()
+        else Future.Unit
+
+      case Return(f: Http2StreamFrame) =>
+        f.streamId match {
+          case 0 =>
+            val e = new IllegalArgumentException(s"unexpected frame on stream 0: ${f.name}")
+            goAway(GoAway.ProtocolError).before(Future.exception(e))
+
+          case id =>
+            streams.get(id) match {
+              case null =>
+                demuxNewStream(f).before {
+                  if (closed.get) Future.Unit
+                  else transport.read().transform(loop)
+                }
+
+              case StreamOpen(st) =>
+                st.admitRemote(f)
+                if (closed.get) Future.Unit
+                else transport.read().transform(loop)
+
+              case StreamLocalReset | StreamFailed(_) =>
+                // The local stream was already reset, but we may still
+                // receive frames until the remote is notified.  Just
+                // disregard these frames.
+                if (closed.get) Future.Unit
+                else transport.read().transform(loop)
+
+              case StreamClosed | StreamRemoteReset =>
+                // The stream has been closed and should know better than
+                // to send us messages.
+                writer.reset(id, Reset.Closed)
+            }
+        }
+
+      case Return(f) =>
+        log.error("[%s] unexpected frame: %s", prefix, f.name)
+        val e = new IllegalArgumentException(s"unexpected frame on new stream: ${f.name}")
+        goAway(GoAway.ProtocolError).before(Future.exception(e))
+    }
+
+    transport.read().transform(loop)
+  }
+
+  protected[this] def demuxNewStream(frame: Http2StreamFrame): Future[Unit]
+
+  private[this] def resetStreams(err: Reset): Boolean =
+    if (closed.compareAndSet(false, true)) {
+      log.debug("[%s] resetting all streams: %s", prefix, err)
+      streams.values.asScala.foreach {
+        case StreamOpen(st) => st.remoteReset(err)
+        case _ =>
+      }
+      demuxing.raise(Failure(err).flagged(Failure.Interrupted))
+      true
+    } else false
+
+  protected[this] def goAway(err: GoAway, deadline: Time = Time.Top): Future[Unit] =
+    if (resetStreams(Reset.Cancel)) {
+      log.debug("[%s] go away: %s", prefix, err)
+      writer.goAway(err, deadline)
+    } else Future.Unit
+
+  protected[this] val onTransportClose: Throwable => Unit = { e =>
+    log.debug(e, "[%s] transport closed", prefix)
+    resetStreams(Reset.Cancel); ()
+  }
+}

--- a/router/h2/src/main/scala/com/twitter/finagle/buoyant/h2/netty4/Netty4H2Listener.scala
+++ b/router/h2/src/main/scala/com/twitter/finagle/buoyant/h2/netty4/Netty4H2Listener.scala
@@ -53,12 +53,6 @@ object Netty4H2Listener {
         proto match {
           case ApplicationProtocolNames.HTTP_2 =>
             ctx.channel.config.setAutoRead(true)
-            // ctx.pipeline.addBefore(PlaceholderKey, "wtf", new ChannelDuplexHandler {
-            //   override def channelInactive(ctx: ChannelHandlerContext): Unit = {
-            //     log.debug(s"$prefix.channelInactive ${ctx.channel}")
-            //     super.channelInactive(ctx)
-            //   }
-            // })
             ctx.pipeline.replace(PlaceholderKey, "h2 framer", new Http2FrameCodec(true)); ()
 
           // TODO case ApplicationProtocolNames.HTTP_1_1 =>

--- a/router/h2/src/main/scala/com/twitter/finagle/buoyant/h2/netty4/Netty4H2Listener.scala
+++ b/router/h2/src/main/scala/com/twitter/finagle/buoyant/h2/netty4/Netty4H2Listener.scala
@@ -53,6 +53,12 @@ object Netty4H2Listener {
         proto match {
           case ApplicationProtocolNames.HTTP_2 =>
             ctx.channel.config.setAutoRead(true)
+            // ctx.pipeline.addBefore(PlaceholderKey, "wtf", new ChannelDuplexHandler {
+            //   override def channelInactive(ctx: ChannelHandlerContext): Unit = {
+            //     log.debug(s"$prefix.channelInactive ${ctx.channel}")
+            //     super.channelInactive(ctx)
+            //   }
+            // })
             ctx.pipeline.replace(PlaceholderKey, "h2 framer", new Http2FrameCodec(true)); ()
 
           // TODO case ApplicationProtocolNames.HTTP_1_1 =>

--- a/router/h2/src/main/scala/com/twitter/finagle/buoyant/h2/netty4/Netty4H2Writer.scala
+++ b/router/h2/src/main/scala/com/twitter/finagle/buoyant/h2/netty4/Netty4H2Writer.scala
@@ -30,7 +30,7 @@ private[netty4] trait Netty4H2Writer extends H2Transport.Writer {
 
   override def write(id: Int, f: Frame): Future[Unit] = f match {
     case data: Frame.Data => write(id, data.buf, data.isEnd)
-    case tlrs: Frame.Trailers => write(id, tlrs, true /*eos*/ )
+    case tlrs: Frame.Trailers => write(id, tlrs, eos = true)
   }
 
   override def write(id: Int, buf: Buf, eos: Boolean): Future[Unit] = {

--- a/router/h2/src/main/scala/com/twitter/finagle/buoyant/h2/netty4/Netty4ServerDispatcher.scala
+++ b/router/h2/src/main/scala/com/twitter/finagle/buoyant/h2/netty4/Netty4ServerDispatcher.scala
@@ -76,7 +76,7 @@ class Netty4ServerDispatcher(
   private[this] def serveStream(st: Netty4StreamTransport[Response, Request]) = {
     // Note: `remoteMsg` should be satisfied immediately, since the
     // headers frame will have just been admitted to the stream.
-    val serveF = st.onRemoteMessage.flatMap(serve).flatMap(st.write(_).flatten)
+    val serveF = st.onRemoteMessage.flatMap(serve).flatMap(st.writeAll)
 
     // When the stream is reset, ensure that the cancelation is
     // propagated downstream.

--- a/router/h2/src/main/scala/com/twitter/finagle/buoyant/h2/netty4/Netty4ServerDispatcher.scala
+++ b/router/h2/src/main/scala/com/twitter/finagle/buoyant/h2/netty4/Netty4ServerDispatcher.scala
@@ -76,7 +76,7 @@ class Netty4ServerDispatcher(
   private[this] def serveStream(st: Netty4StreamTransport[Response, Request]) = {
     // Note: `remoteMsg` should be satisfied immediately, since the
     // headers frame will have just been admitted to the stream.
-    val serveF = st.onRemoteMessage.flatMap(serve).flatMap(st.writeAll)
+    val serveF = st.onRemoteMessage.flatMap(serve).flatMap(st.write(_).flatten)
 
     // When the stream is reset, ensure that the cancelation is
     // propagated downstream.

--- a/router/h2/src/main/scala/com/twitter/finagle/buoyant/h2/netty4/Netty4StreamTransport.scala
+++ b/router/h2/src/main/scala/com/twitter/finagle/buoyant/h2/netty4/Netty4StreamTransport.scala
@@ -404,15 +404,13 @@ private[h2] trait Netty4StreamTransport[LocalMsg <: Message, RemoteMsg <: Messag
     }
   }
 
-  /** */
   private[this] def toFrame(f: Http2StreamFrame): Frame = f match {
     case f: Http2DataFrame => Netty4Message.Data(f, updateWindow)
     case f: Http2HeadersFrame if f.isEndStream => Netty4Message.Trailers(f.headers)
     case f => throw new IllegalArgumentException(s"invalid stream frame: ${f}")
   }
 
-  private[this] val updateWindow: Int => Future[Unit] =
-    incr => transport.updateWindow(streamId, incr)
+  private[this] val updateWindow: Int => Future[Unit] = transport.updateWindow(streamId, _)
 
   /**
    * Write a `LocalMsg` to the remote.

--- a/router/h2/src/main/scala/com/twitter/finagle/buoyant/h2/netty4/Netty4StreamTransport.scala
+++ b/router/h2/src/main/scala/com/twitter/finagle/buoyant/h2/netty4/Netty4StreamTransport.scala
@@ -2,188 +2,561 @@ package com.twitter.finagle.buoyant.h2
 package netty4
 
 import com.twitter.concurrent.AsyncQueue
-import com.twitter.finagle.Failure
+import com.twitter.finagle.{ChannelClosedException, ChannelWriteException, Failure}
 import com.twitter.finagle.stats.{StatsReceiver => FStatsReceiver, NullStatsReceiver => FNullStatsReceiver}
 import com.twitter.logging.Logger
-import com.twitter.util.{Future, Promise, Return, Stopwatch, Throw}
+import com.twitter.util.{Future, Promise, Return, Stopwatch, Throw, Try}
 import io.netty.buffer.CompositeByteBuf
 import io.netty.handler.codec.http2._
 import java.util.concurrent.atomic.{AtomicInteger, AtomicReference}
 import scala.annotation.tailrec
 import scala.collection.immutable.Queue
+import scala.util.control.NoStackTrace
 
 /**
- * Models a single HTTP/2 stream.
+ * Reads and writes a bi-directional HTTP/2 stream.
  *
- * Transports send a `Local`-typed message via an underlying
- * [[H2Transport.Writer]]. A dispatcher, which models a single HTTP/2
- * connection, provides the transport with `Http2StreamFrame`
- * instances that are used to build a `RemoteMsg`-typed message.
+ * Each stream transport has two "sides":
+ *
+ * - Dispatchers provide a stream with remote frames _from_ a socket
+ *   into a `RemoteMsg`-typed message.  The `onRemoteMessage` future
+ *   is satisfied when an initial HEADERS frame is received from the
+ *   dispatcher.
+ *
+ * - Dispatchers write a `LocalMsg`-typed message _to_ a socket.  The
+ *   stream transport reasds from the message's stream until it
+ *   _fails_, so that errors may be propagated if the local side of
+ *   the stream is reset.
+ *
+ * When both sides of the stram are closed, the `onReset` future is
+ * satisfied.
+ *
+ * Either side may reset the stream prematurely, causing the `onReset`
+ * future to fail, typically with a [[StreamError]] indicating whether
+ * the reset was initiated from the remote or local side of the
+ * stream. This information is used by i.e. dispatchers to determine
+ * whether a reset frame must be written.
  */
-private[h2] trait Netty4StreamTransport[LocalMs <: Message, RemoteMsg <: Message] {
+private[h2] trait Netty4StreamTransport[LocalMsg <: Message, RemoteMsg <: Message] {
   import Netty4StreamTransport._
 
   /** The HTTP/2 STREAM_ID of this stream. */
   def streamId: Int
 
+  /** for logging */
+  protected[this] def prefix: String
+
   protected[this] def transport: H2Transport.Writer
 
   protected[this] def statsReceiver: StatsReceiver
 
-  @volatile private[this] var isRemoteClosed, isLocalClosed = false
-  def isClosed = isRemoteClosed && isLocalClosed
+  /*
+   * A stream's state is represented by the `StreamState` ADT,
+   * reflecting the state diagram detailed in RFC7540 §5.1:
+   *
+   *                       +--------+
+   *               recv ES |        | send ES
+   *               ,-------|  open  |-------.
+   *              /        |        |        \
+   *             v         +--------+         v
+   *     +----------+          |           +----------+
+   *     |   half   |          |           |   half   |
+   *     |  closed  |          | send R /  |  closed  |
+   *     | (remote) |          | recv R    | (local)  |
+   *     +----------+          |           +----------+
+   *          |                |                 |
+   *          | send ES /      |       recv ES / |
+   *          | send R /       v        send R / |
+   *          | recv R     +--------+   recv R   |
+   *          `----------->|        |<-----------'
+   *                       | closed |
+   *                       |        |
+   *                       +--------+
+   *
+   *
+   * (Note that SERVER_PUSH is not supported or represented in this
+   * version of the state diagram).
+   */
 
-  private[this] val closeP = new Promise[Unit]
-  def onClose: Future[Unit] = closeP
-
-  private[this] def setRemoteClosed(): Unit = {
-    isRemoteClosed = true
-    if (isClosed) { closeP.setDone(); () }
+  /** Helper: a state that supports Reset.  (All but Closed) */
+  private[this] trait ResettableState {
+    def reset(rst: Reset): Unit
   }
 
-  private[this] def setLocalClosed(): Unit = {
-    isLocalClosed = true
-    if (isClosed) { closeP.setDone(); () }
+  private[this] sealed trait StreamState
+
+  /** The stream is open in both directions. */
+  private[this] case class Open(remote: RemoteState) extends StreamState with ResettableState {
+    override def reset(rst: Reset): Unit = remote.reset(rst)
   }
 
-  def close(): Future[Unit] =
-    if (isClosed) Future.Unit
-    else {
-      setRemoteClosed()
-      setLocalClosed()
-      transport.resetNoError(streamId)
+  /**
+   * The local message has been fully sent, but the remote message is
+   * still being received.
+   */
+  private[this] case class LocalClosed(remote: RemoteState)
+    extends StreamState with ResettableState {
+    override def reset(rst: Reset): Unit = remote.reset(rst)
+  }
+
+  /**
+   * The full remote message has been received and the LocalMsg is
+   * still being sent.
+   *
+   * The remote frame queue is preserved so that it may be failed when
+   * the stream is closed or reset.
+   */
+  private[this] class RemoteClosed(q: AsyncQueue[Frame])
+    extends StreamState with ResettableState {
+    def close(): Unit = q.fail(Reset.NoError, discard = false)
+    override def reset(rst: Reset): Unit = q.fail(rst, discard = true)
+  }
+  private[this] object RemoteClosed {
+    def unapply(rc: RemoteClosed): Boolean = true
+  }
+
+  /** The stream is fully closed. */
+  private[this] case class Closed(error: Reset) extends StreamState
+
+  /** The state of the remote side of a stream. */
+  private[this] sealed trait RemoteState extends ResettableState
+
+  /** A remote stream before the initial HEADERS frame has been received. */
+  private[this] class RemotePending(p: Promise[RemoteMsg]) extends RemoteState {
+    def setMessage(msg: RemoteMsg): Unit = p.setValue(msg)
+    override def reset(rst: Reset): Unit = p.setException(rst)
+  }
+  private[this] object RemotePending {
+    def unapply(rs: RemotePending): Boolean = true
+  }
+
+  /** A remote stream that has been initiated but not yet closed or reset. */
+  private[this] class RemoteStreaming(q: AsyncQueue[Frame]) extends RemoteState {
+    def toRemoteClosed: RemoteClosed = new RemoteClosed(q)
+    def offer(f: Frame): Boolean = q.offer(f)
+    def close(): Unit = q.fail(Reset.NoError, discard = false)
+    override def reset(rst: Reset): Unit = q.fail(rst, discard = true)
+  }
+  private[this] object RemoteStreaming {
+    def apply(q: AsyncQueue[Frame]): RemoteStreaming = new RemoteStreaming(q)
+    def unapply(rs: RemoteStreaming): Boolean = true
+  }
+
+  /** Helper to extract a RemoteState from a StreamState. */
+  private[this] object RemoteOpen {
+    def unapply(s: StreamState): Option[RemoteState] = s match {
+      case Open(r) => Some(r)
+      case LocalClosed(r) => Some(r)
+      case Closed(_) | RemoteClosed() => None
     }
+  }
+
+  /** Helper to match writable states. */
+  private[this] object LocalOpen {
+    def unapply(s: StreamState): Boolean = s match {
+      case Open(_) | RemoteClosed() => true
+      case Closed(_) | LocalClosed(_) => false
+    }
+  }
+
+  private[this] val remoteMsgP = new Promise[RemoteMsg]
+  def onRemoteMessage: Future[RemoteMsg] = remoteMsgP
+
+  // When the remote message--especially a client's repsonse--is
+  // canceled, close the transport, sending a RST_STREAM as
+  // appropriate.
+  remoteMsgP.setInterruptHandler {
+    case err: Reset =>
+      log.debug(err, "[%s] remote message interrupted", prefix)
+      localReset(err)
+
+    case Failure(Some(err: Reset)) =>
+      log.debug(err, "[%s] remote message interrupted", prefix)
+      localReset(err)
+
+    case f@Failure(_) if f.isFlagged(Failure.Interrupted) =>
+      log.debug(f, "[%s] remote message interrupted", prefix)
+      localReset(Reset.Cancel)
+
+    case f@Failure(_) if f.isFlagged(Failure.Rejected) =>
+      log.debug(f, "[%s] remote message interrupted", prefix)
+      localReset(Reset.Refused)
+
+    case e =>
+      log.debug(e, "[%s] remote message interrupted", prefix)
+      localReset(Reset.InternalError)
+  }
+
+  /**
+   * Because remote reads and local writes may occur concurrently,
+   * this state is stored in the `stateRef` atomic reference. Writes
+   * and reads are performed without locking stateRef (instead, callers )
+   */
+  private[this] val stateRef: AtomicReference[StreamState] =
+    new AtomicReference(Open(new RemotePending(remoteMsgP)))
+
+  /**
+   * Satisfied successfully when the stream is fully closed with no
+   * error.  An exception is raised with a Reset if the stream is
+   * closed prematurely.
+   */
+  def onReset: Future[Unit] = resetP
+  private[this] val resetP = new Promise[Unit]
+
+  def isClosed = stateRef.get match {
+    case Closed(_) => true
+    case _ => false
+  }
 
   protected[this] def mkRemoteMsg(headers: Http2Headers, stream: Stream): RemoteMsg
 
-  private[this] sealed trait RemoteState
-  private[this] case class RemoteInit(p: Promise[RemoteMsg]) extends RemoteState
-  private[this] case class RemoteStreaming(q: AsyncQueue[Frame]) extends RemoteState
-  private[this] object RemoteClosed extends RemoteState
+  def remoteReset(err: Reset): Unit =
+    if (tryReset(err)) resetP.setException(StreamError.Remote(err))
 
-  private[this] val _remoteMsgP = new Promise[RemoteMsg]
-  def remoteMsg: Future[RemoteMsg] = _remoteMsgP
-  private[this] val remoteState: AtomicReference[RemoteState] =
-    new AtomicReference(RemoteInit(_remoteMsgP))
+  def localReset(err: Reset): Unit =
+    if (tryReset(err)) resetP.setException(StreamError.Local(err))
+
+  @tailrec private[this] def tryReset(err: Reset): Boolean =
+    stateRef.get match {
+      case state: StreamState with ResettableState =>
+        if (stateRef.compareAndSet(state, Closed(err))) {
+          log.debug("[%s] resetting %s in %s", prefix, err, state)
+          state.reset(err)
+          true
+        } else tryReset(err)
+
+      case _ => false
+    }
+
+  @tailrec private[this] def closeLocal(): Unit =
+    stateRef.get match {
+      case Closed(_) =>
+
+      case state@LocalClosed(remote) =>
+        if (stateRef.compareAndSet(state, Closed(Reset.InternalError))) {
+          remote.reset(Reset.InternalError)
+          resetP.setException(new IllegalStateException("closing local from LocalClosed"))
+        } else closeLocal()
+
+      case state@Open(remote) =>
+        if (!stateRef.compareAndSet(state, LocalClosed(remote))) closeLocal()
+
+      case state@RemoteClosed() =>
+        if (stateRef.compareAndSet(state, Closed(Reset.NoError))) {
+          state.close()
+          resetP.setDone(); ()
+        } else closeLocal()
+    }
+
+  /*
+   * Reading a RemoteMsg from the remote.
+   */
 
   /**
-   * A Dispatcher reads frames from the remote and offers them into the stream.
+   * Offer a Netty Http2StreamFrame from the remote.
    *
-   * If an initial Headers frame is offered, the `remote` future is satisfied.
+   * `admitRemote` returns false to indicate that a frame could not be
+   * accepted.  This may occur, for example, when a message is
+   * received on a closed stream.
    */
-  @tailrec final def offerRemote(in: Http2StreamFrame): Boolean = remoteState.get match {
-    case s0@RemoteInit(p) =>
-      in match {
-        case f: Http2HeadersFrame if f.isEndStream =>
-          if (remoteState.compareAndSet(s0, RemoteClosed)) {
-            p.setValue(mkRemoteMsg(f.headers, Stream.Nil))
-            setRemoteClosed()
-            true
-          } else offerRemote(in)
+  @tailrec final def admitRemote(in: Http2StreamFrame): Boolean = {
+    val state = stateRef.get
+    log.trace("[%s] admitting %s in %s", prefix, in.name, state)
 
-        case f: Http2HeadersFrame =>
-          val outQ = new AsyncQueue[Frame]
-          if (remoteState.compareAndSet(s0, RemoteStreaming(outQ))) {
-            val msg = mkRemoteMsg(f.headers, Stream(outQ))
-            p.setValue(msg)
-            true
-          } else offerRemote(in)
+    def resetRemote(remote: ResettableState, rst: Reset): Boolean =
+      if (stateRef.compareAndSet(state, Closed(rst))) {
+        remote.reset(rst)
+        resetP.setException(StreamError.Remote(rst))
+        true
+      } else false
 
-        case f => false
-      }
+    def admitFrame(f: Frame, remote: RemoteStreaming): Boolean =
+      if (remote.offer(f)) {
+        statsReceiver.recordRemoteFrame(f)
+        true
+      } else false
 
-    case s0@RemoteStreaming(outQ) =>
-      val out = toFrame(in)
-      if (out.isEnd) {
-        if (remoteState.compareAndSet(s0, RemoteClosed)) {
-          setRemoteClosed()
-          statsReceiver.recordRemoteFrame(out)
-          outQ.offer(out)
-        } else offerRemote(in)
-      } else {
-        statsReceiver.recordRemoteFrame(out)
-        outQ.offer(out)
-      }
+    in match {
+      case rst: Http2ResetFrame =>
+        state match {
+          case Closed(_) => false
 
-    case RemoteClosed => false
+          case RemoteOpen(remote) =>
+            if (resetRemote(remote, toReset(rst.errorCode))) {
+              statsReceiver.remoteResetCount.incr()
+              true
+            } else admitRemote(rst)
+
+          case state@RemoteClosed() =>
+            if (resetRemote(state, toReset(rst.errorCode))) {
+              statsReceiver.remoteResetCount.incr()
+              true
+            } else admitRemote(rst)
+        }
+
+      case hdrs: Http2HeadersFrame if hdrs.isEndStream =>
+        state match {
+          case Closed(_) => false
+
+          case state@RemoteClosed() =>
+            if (resetRemote(state, Reset.Closed)) true
+            else admitRemote(hdrs)
+
+          case Open(remote@RemotePending()) =>
+            val q = new AsyncQueue[Frame]
+            if (stateRef.compareAndSet(state, new RemoteClosed(q))) {
+              remote.setMessage(mkRemoteMsg(hdrs.headers, Stream.empty(q)))
+              true
+            } else admitRemote(hdrs)
+
+          case Open(remote@RemoteStreaming()) =>
+            if (stateRef.compareAndSet(state, remote.toRemoteClosed)) {
+              val f = toFrame(hdrs)
+              statsReceiver.recordRemoteFrame(f)
+              remote.offer(f)
+            } else admitRemote(hdrs)
+
+          case LocalClosed(remote@RemotePending()) =>
+            if (stateRef.compareAndSet(state, Closed(Reset.NoError))) {
+              remote.setMessage(mkRemoteMsg(hdrs.headers, NilStream))
+              resetP.setDone()
+              true
+            } else admitRemote(hdrs)
+
+          case LocalClosed(remote@RemoteStreaming()) =>
+            if (stateRef.compareAndSet(state, Closed(Reset.NoError))) {
+              val f = toFrame(hdrs)
+              if (remote.offer(f)) {
+                statsReceiver.recordRemoteFrame(f)
+                remote.close()
+                resetP.setDone()
+                true
+              } else false
+            } else admitRemote(hdrs)
+        }
+
+      case hdrs: Http2HeadersFrame =>
+        // A HEADERS frame without END_STREAM may only be received to
+        // initiate a message (i.e. when the remote is still pending).
+        state match {
+          case Closed(_) => false
+          case state@RemoteClosed() =>
+            if (resetRemote(state, Reset.Closed)) false
+            else admitRemote(hdrs)
+
+          case RemoteOpen(remote@RemoteStreaming()) =>
+            if (resetRemote(remote, Reset.InternalError)) false
+            else admitRemote(hdrs)
+
+          case Open(remote@RemotePending()) =>
+            val q = new AsyncQueue[Frame]
+            if (stateRef.compareAndSet(state, Open(RemoteStreaming(q)))) {
+              remote.setMessage(mkRemoteMsg(hdrs.headers, Stream(q)))
+              true
+            } else admitRemote(hdrs)
+
+          case LocalClosed(remote@RemotePending()) =>
+            val q = new AsyncQueue[Frame]
+            if (stateRef.compareAndSet(state, LocalClosed(RemoteStreaming(q)))) {
+              remote.setMessage(mkRemoteMsg(hdrs.headers, Stream(q)))
+              true
+            } else admitRemote(hdrs)
+        }
+
+      case data: Http2DataFrame =>
+        state match {
+          case Closed(_) => false
+
+          case state@RemoteClosed() =>
+            if (resetRemote(state, Reset.Closed)) false
+            else admitRemote(data)
+
+          case RemoteOpen(remote@RemotePending()) =>
+            if (resetRemote(remote, Reset.InternalError)) false
+            else admitRemote(data)
+
+          case Open(remote@RemoteStreaming()) =>
+            if (data.isEndStream) {
+              if (stateRef.compareAndSet(state, remote.toRemoteClosed)) {
+                if (admitFrame(toFrame(data), remote)) true
+                else throw new IllegalStateException("stream queue closed prematurely")
+              } else admitRemote(data)
+            } else {
+              if (admitFrame(toFrame(data), remote)) true
+              else admitRemote(data)
+            }
+
+          case LocalClosed(remote@RemoteStreaming()) =>
+            if (data.isEndStream) {
+              if (stateRef.compareAndSet(state, Closed(Reset.NoError))) {
+                if (admitFrame(toFrame(data), remote)) {
+                  remote.close()
+                  resetP.setDone()
+                  true
+                } else throw new IllegalStateException("stream queue closed prematurely")
+              } else admitRemote(data)
+            } else {
+              if (admitFrame(toFrame(data), remote)) true
+              else admitRemote(data)
+            }
+        }
+    }
   }
 
+  /** */
   private[this] def toFrame(f: Http2StreamFrame): Frame = f match {
     case f: Http2DataFrame => Netty4Message.Data(f, updateWindow)
     case f: Http2HeadersFrame if f.isEndStream => Netty4Message.Trailers(f.headers)
     case f => throw new IllegalArgumentException(s"invalid stream frame: ${f}")
   }
 
-  private[this] val mapFutureUnit = (_: Any) => Future.Unit
+  private[this] val updateWindow: Int => Future[Unit] =
+    incr => transport.updateWindow(streamId, incr)
 
-  def write(msg: LocalMs): Future[Future[Unit]] = msg.data match {
-    case Stream.Nil =>
-      writeHeaders(msg.headers, false).map(mapFutureUnit)
-    case data: Stream.Reader =>
-      writeHeaders(msg.headers, false).map { _ => writeStream(data) }
+  /**
+   * Write a `LocalMsg` to the remote.
+   *
+   * The outer future is satisfied initially to indicate that the
+   * local message has been initiated (i.e. its HEADERS have been
+   * sent). This first future is satisfied with a second future. The
+   * second future is satisfied when the full local stream has been
+   * written to the remote.
+   *
+   * If any write fails or is canceled, the entire stream is reset.
+   *
+   * If the stream is reset, writes are canceled.
+   */
+  def write(msg: LocalMsg): Future[Future[Unit]] = {
+    val headersF = writeHeaders(msg.headers, msg.stream.isEmpty)
+    val streamF = headersF.map(_ => writeStream(msg.stream))
+
+    val writeF = streamF.flatten
+    onReset.onFailure(writeF.raise(_))
+    writeF.onSuccess(closeLocalOnComplete)
+    writeF.onFailure(resetOnFailure)
+
+    streamF
   }
 
-  def writeHeaders(hdrs: Headers, eos: Boolean = false): Future[Unit] = {
-    val tx = transport.write(streamId, hdrs, eos)
-    if (eos) tx.ensure(setLocalClosed())
-    tx
+  private[this] val closeLocalOnComplete: Unit => Unit = _ => closeLocal()
+
+  private[this] val resetOnFailure: PartialFunction[Throwable, Unit] = {
+    case StreamError.Remote(e) =>
+      val rst = e match {
+        case rst: Reset => rst
+        case _ => Reset.Cancel
+      }
+      log.debug(e, "[%s] remote write failed: %s", prefix, rst)
+      remoteReset(rst)
+
+    case StreamError.Local(e) =>
+      val rst = e match {
+        case rst: Reset => rst
+        case _ => Reset.Cancel
+      }
+      log.debug(e, "[%s] stream read failed: %s", prefix, rst)
+      localReset(rst)
+
+    case e =>
+      log.error(e, "[%s] unexpected error", prefix)
+      localReset(Reset.InternalError)
   }
+
+  private[this] def writeHeaders(hdrs: Headers, eos: Boolean): Future[Unit] =
+    stateRef.get match {
+      case Closed(rst) => Future.exception(StreamError.Remote(rst))
+      case LocalClosed(_) => Future.exception(new IllegalStateException("writing on closed stream"))
+      case LocalOpen() => resetOnCancel(transport.write(streamId, hdrs, eos))
+    }
 
   /** Write a request stream to the underlying transport */
-  def writeStream(reader: Stream.Reader): Future[Unit] = {
-    require(!isLocalClosed)
-    if (reader.isEmpty) Future.Unit
-    else {
-      lazy val loop: Boolean => Future[Unit] = { eos =>
-        if (eos) Future.Unit
-        else reader.read().flatMap(writeFrame).flatMap(loop)
-      }
-      reader.read().flatMap(writeFrame).flatMap(loop)
-    }
+  private[this] def writeStream(stream: Stream): Future[Unit] = {
+    def loop(): Future[Unit] =
+      stream.read().rescue(wrapLocalEx)
+        .flatMap(writeFrame)
+        .before(loop())
+
+    resetOnCancel(loop())
   }
 
-  private[this] val writeFrame: Frame => Future[Boolean] = { f =>
-    statsReceiver.recordLocalFrame(f)
-    val writeF = f match {
-      case data: Frame.Data =>
-        transport.write(streamId, data)
-          .before(data.release())
-          .map(_ => data.isEnd)
-
-      case tlrs: Frame.Trailers =>
-        transport.write(streamId, tlrs)
-          .before(tlrs.release())
-          .before(Future.True)
+  private[this] def resetOnCancel[T](f: Future[T]): Future[T] = {
+    val p = new Promise[T]
+    p.setInterruptHandler {
+      case e =>
+        localReset(Reset.Cancel)
+        f.raise(e)
     }
-    if (f.isEnd) writeF.ensure(setLocalClosed())
-    writeF
+    f.proxyTo(p)
+    p
   }
 
-  protected[this] def prefix: String
-
-  private[this] val updateWindow: Int => Future[Unit] = { incr =>
-    transport.updateWindow(streamId, incr)
+  private[this] val writeFrame: Frame => Future[Unit] = { frame =>
+    stateRef.get match {
+      case Closed(rst) => Future.exception(StreamError.Remote(rst))
+      case LocalClosed(_) => Future.exception(new IllegalStateException("writing on closed stream"))
+      case LocalOpen() =>
+        statsReceiver.recordLocalFrame(frame)
+        transport.write(streamId, frame).rescue(wrapRemoteEx)
+          .before(frame.release().rescue(wrapLocalEx))
+    }
   }
 }
 
 object Netty4StreamTransport {
   private val log = Logger.get(getClass.getName)
 
+  private val wrapLocalEx: PartialFunction[Throwable, Future[Nothing]] = {
+    case e@StreamError.Local(_) => Future.exception(e)
+    case e@StreamError.Remote(_) => Future.exception(e)
+    case e => Future.exception(StreamError.Local(e))
+  }
+
+  private def wrapRemoteEx: PartialFunction[Throwable, Future[Nothing]] = {
+    case e@StreamError.Local(_) => Future.exception(e)
+    case e@StreamError.Remote(_) => Future.exception(e)
+    case e => Future.exception(StreamError.Remote(e))
+  }
+
+  private object NilStream extends Stream {
+    override def isEmpty = true
+    override def onEnd = Future.Unit
+    override def read(): Future[Frame] = Future.exception(Reset.NoError)
+  }
+
+  private def toReset(code: Long): Reset =
+    Http2Error.valueOf(code) match {
+      case Http2Error.NO_ERROR => Reset.NoError
+      case Http2Error.INTERNAL_ERROR => Reset.InternalError
+      case Http2Error.ENHANCE_YOUR_CALM => Reset.EnhanceYourCalm
+      case Http2Error.REFUSED_STREAM => Reset.Refused
+      case Http2Error.STREAM_CLOSED => Reset.Closed
+      case Http2Error.CANCEL => Reset.Cancel
+      case err => throw new IllegalArgumentException(s"invalid stream error: ${err}")
+    }
+
   class StatsReceiver(underlying: FStatsReceiver) {
     private[this] val local = underlying.scope("local")
     private[this] val localDataBytes = local.stat("data", "bytes")
+    private[this] val localDataFrames = local.counter("data", "frames")
     private[this] val localTrailersCount = local.counter("trailers")
+    val localResetCount = local.counter("reset")
     val recordLocalFrame: Frame => Unit = {
-      case d: Frame.Data => localDataBytes.add(d.buf.length)
+      case d: Frame.Data =>
+        localDataFrames.incr()
+        localDataBytes.add(d.buf.length)
       case t: Frame.Trailers => localTrailersCount.incr()
     }
 
     private[this] val remote = underlying.scope("remote")
     private[this] val remoteDataBytes = remote.stat("data", "bytes")
+    private[this] val remoteDataFrames = remote.counter("data", "frames")
     private[this] val remoteTrailersCount = remote.counter("trailers")
+    val remoteResetCount = remote.counter("reset")
     val recordRemoteFrame: Frame => Unit = {
-      case d: Frame.Data => remoteDataBytes.add(d.buf.length)
-      case t: Frame.Trailers => remoteTrailersCount.incr()
+      case d: Frame.Data =>
+        remoteDataFrames.incr()
+        remoteDataBytes.add(d.buf.length)
+      case _: Frame.Trailers => remoteTrailersCount.incr()
     }
 
   }
@@ -196,7 +569,8 @@ object Netty4StreamTransport {
     override protected[this] val statsReceiver: StatsReceiver
   ) extends Netty4StreamTransport[Request, Response] {
 
-    override protected[this] def prefix: String = s"client: stream $streamId"
+    override protected[this] val prefix =
+      s"C L:${transport.localAddress} R:${transport.remoteAddress} S:${streamId}"
 
     override protected[this] def mkRemoteMsg(headers: Http2Headers, stream: Stream): Response =
       Response(Netty4Message.Headers(headers), stream)
@@ -208,7 +582,8 @@ object Netty4StreamTransport {
     override protected[this] val statsReceiver: StatsReceiver
   ) extends Netty4StreamTransport[Response, Request] {
 
-    override protected[this] def prefix: String = s"server: stream $streamId"
+    override protected[this] val prefix =
+      s"S L:${transport.localAddress} R:${transport.remoteAddress} S:${streamId}"
 
     override protected[this] def mkRemoteMsg(headers: Http2Headers, stream: Stream): Request =
       Request(Netty4Message.Headers(headers), stream)

--- a/router/h2/src/main/scala/com/twitter/finagle/buoyant/h2/netty4/Netty4StreamTransport.scala
+++ b/router/h2/src/main/scala/com/twitter/finagle/buoyant/h2/netty4/Netty4StreamTransport.scala
@@ -414,6 +414,9 @@ private[h2] trait Netty4StreamTransport[LocalMsg <: Message, RemoteMsg <: Messag
   private[this] val updateWindow: Int => Future[Unit] =
     incr => transport.updateWindow(streamId, incr)
 
+  val writeAll: LocalMsg => Future[Unit] =
+    msg => write(msg).flatten
+
   /**
    * Write a `LocalMsg` to the remote.
    *

--- a/router/h2/src/main/scala/com/twitter/finagle/buoyant/h2/netty4/Netty4StreamTransport.scala
+++ b/router/h2/src/main/scala/com/twitter/finagle/buoyant/h2/netty4/Netty4StreamTransport.scala
@@ -414,9 +414,6 @@ private[h2] trait Netty4StreamTransport[LocalMsg <: Message, RemoteMsg <: Messag
   private[this] val updateWindow: Int => Future[Unit] =
     incr => transport.updateWindow(streamId, incr)
 
-  val writeAll: LocalMsg => Future[Unit] =
-    msg => write(msg).flatten
-
   /**
    * Write a `LocalMsg` to the remote.
    *

--- a/router/h2/src/main/scala/com/twitter/finagle/buoyant/h2/netty4/Netty4StreamTransport.scala
+++ b/router/h2/src/main/scala/com/twitter/finagle/buoyant/h2/netty4/Netty4StreamTransport.scala
@@ -429,9 +429,9 @@ private[h2] trait Netty4StreamTransport[LocalMsg <: Message, RemoteMsg <: Messag
    */
   def write(msg: LocalMsg): Future[Future[Unit]] = {
     val headersF = writeHeaders(msg.headers, msg.stream.isEmpty)
-    val streamF = headersF.map(_ => writeStream(msg.stream))
+    val streamFF = headersF.map(_ => writeStream(msg.stream))
 
-    val writeF = streamF.flatten
+    val writeF = streamFF.flatten
     onReset.onFailure(writeF.raise(_))
     writeF.respond {
       case Return(_) =>
@@ -457,7 +457,8 @@ private[h2] trait Netty4StreamTransport[LocalMsg <: Message, RemoteMsg <: Messag
         log.error(e, "[%s] unexpected error", prefix)
         localReset(Reset.InternalError)
     }
-    streamF
+
+    streamFF
   }
 
   private[this] def writeHeaders(hdrs: Headers, eos: Boolean): Future[Unit] =

--- a/router/h2/src/main/scala/io/buoyant/router/H2.scala
+++ b/router/h2/src/main/scala/io/buoyant/router/H2.scala
@@ -10,7 +10,7 @@ import com.twitter.finagle.client.{StackClient, StdStackClient, Transporter}
 import com.twitter.finagle.server.{Listener, StackServer, StdStackServer}
 import com.twitter.finagle.service.StatsFilter
 import com.twitter.finagle.transport.Transport
-import com.twitter.util.{Closable, Future, Monitor}
+import com.twitter.util.{Closable, Future}
 import io.netty.handler.codec.http2.Http2Frame
 import java.net.SocketAddress
 
@@ -36,8 +36,6 @@ object H2 extends Client[Request, Response]
     val default = Identifier(params => nil)
   }
 
-  private[this] val ResetMonitor = Monitor.mk { case _: Reset => true }
-
   /*
    * Client
    */
@@ -48,8 +46,7 @@ object H2 extends Client[Request, Response]
         .insertAfter(StatsFilter.role, h2.StreamStatsFilter.module)
 
     val defaultParams = StackClient.defaultParams +
-      param.ProtocolLibrary("h2") +
-      param.Monitor(ResetMonitor)
+      param.ProtocolLibrary("h2")
   }
 
   case class Client(
@@ -102,8 +99,7 @@ object H2 extends Client[Request, Response]
       StackRouter.Client.mkStack(H2.client.stack)
 
     val defaultParams = StackRouter.defaultParams +
-      param.ProtocolLibrary("h2") +
-      param.Monitor(ResetMonitor)
+      param.ProtocolLibrary("h2")
   }
 
   case class Router(
@@ -138,8 +134,7 @@ object H2 extends Client[Request, Response]
       .insertAfter(StatsFilter.role, h2.StreamStatsFilter.module)
 
     val defaultParams = StackServer.defaultParams +
-      param.ProtocolLibrary("h2") +
-      param.Monitor(ResetMonitor)
+      param.ProtocolLibrary("h2")
   }
 
   case class Server(

--- a/router/h2/src/test/scala/com/twitter/finagle/buoyant/h2/netty4/Netty4ClientDispatcherTest.scala
+++ b/router/h2/src/test/scala/com/twitter/finagle/buoyant/h2/netty4/Netty4ClientDispatcherTest.scala
@@ -9,17 +9,19 @@ import com.twitter.io.Buf
 import com.twitter.util.{Future, Promise, Time}
 import io.buoyant.test.FunSuite
 import io.netty.handler.codec.http2._
+import java.net.SocketAddress
 import scala.collection.immutable.Queue
 
 class Netty4ClientDispatchTest extends FunSuite {
+  setLogLevel(com.twitter.logging.Level.OFF)
 
   test("dispatches multiple concurrent requests on underlying transport") {
     val recvq, sentq = new AsyncQueue[Http2Frame]
     val closeP = new Promise[Throwable]
     val transport = new Transport[Http2Frame, Http2Frame] {
       def status = ???
-      def localAddress = ???
-      def remoteAddress = ???
+      def localAddress = new SocketAddress {}
+      def remoteAddress = new SocketAddress {}
       def peerCertificate = ???
       def read(): Future[Http2Frame] = recvq.poll()
       def write(f: Http2Frame): Future[Unit] = {
@@ -52,12 +54,12 @@ class Netty4ClientDispatchTest extends FunSuite {
       hs.method("sup")
       hs.path("/")
       hs.authority("auf")
-      val data = new Stream.Reader {
-        def onEnd = req0EndP
-        def read() = req0q.poll()
-        def reset(exn: Throwable) = req0q.fail(exn)
+      val stream = new Stream {
+        override val isEmpty = false
+        override def onEnd = req0EndP
+        override def read() = req0q.poll()
       }
-      Netty4Message.Request(hs, data)
+      Netty4Message.Request(hs, stream)
     }
     val rsp0f = dispatcher(req0)
     assert(!rsp0f.isDefined)
@@ -68,7 +70,7 @@ class Netty4ClientDispatchTest extends FunSuite {
       hs.method("sup")
       hs.path("/")
       hs.authority("auf")
-      Netty4Message.Request(hs, Stream.Nil)
+      Netty4Message.Request(hs, Stream.empty())
     }
     val rsp1f = dispatcher(req1)
     assert(!rsp1f.isDefined)
@@ -99,6 +101,7 @@ class Netty4ClientDispatchTest extends FunSuite {
       val buf = Buf.Utf8("how's it goin?")
       Frame.Data(buf, false, () => releaser(buf.length))
     }))
+
     // We receive a response for req1 first:
     assert(recvq.offer({
       val hs = new DefaultHttp2Headers
@@ -106,14 +109,10 @@ class Netty4ClientDispatchTest extends FunSuite {
       new DefaultHttp2HeadersFrame(hs, false).setStreamId(5)
     }))
 
-    assert(!rsp0f.isDefined)
-    // assert(rsp1f.isDefined)
+    assert(rsp0f.poll == None)
+    assert(rsp1f.isDefined)
     val rsp1 = await(rsp1f)
     assert(rsp1.status == Status.Cowabunga)
-    val data1 = rsp1.data match {
-      case Stream.Nil => fail("empty stream")
-      case r: Stream.Reader => r
-    }
 
     // We receive a response for req1 first:
     assert(recvq.offer({
@@ -124,10 +123,7 @@ class Netty4ClientDispatchTest extends FunSuite {
     assert(rsp0f.isDefined)
     val rsp0 = await(rsp0f)
     assert(rsp0.status == Status.Cowabunga)
-    val data0 = rsp0.data match {
-      case Stream.Nil => fail("empty stream")
-      case r: Stream.Reader => r
-    }
+    assert(rsp0.stream.nonEmpty)
 
     assert(recvq.offer({
       val buf = Buf.Utf8("sup")
@@ -138,10 +134,10 @@ class Netty4ClientDispatchTest extends FunSuite {
       new DefaultHttp2DataFrame(BufAsByteBuf.Owned(buf), true).setStreamId(5)
     }))
 
-    val d0f = data0.read()
+    val d0f = rsp0.stream.read()
     assert(d0f.isDefined)
 
-    val d1f = data1.read()
+    val d1f = rsp1.stream.read()
     assert(d1f.isDefined)
 
     await(d0f) match {
@@ -152,7 +148,7 @@ class Netty4ClientDispatchTest extends FunSuite {
       case f =>
         fail(s"unexpected frame: $f")
     }
-    assert(data0.onEnd.isDefined)
+    assert(rsp0.stream.onEnd.isDefined)
 
     await(d1f) match {
       case f: Frame.Data =>
@@ -162,6 +158,6 @@ class Netty4ClientDispatchTest extends FunSuite {
       case f =>
         fail(s"unexpected frame: $f")
     }
-    assert(data1.onEnd.isDefined)
+    assert(rsp1.stream.onEnd.isDefined)
   }
 }

--- a/router/h2/src/test/scala/com/twitter/finagle/buoyant/h2/netty4/Netty4StreamTransportTest.scala
+++ b/router/h2/src/test/scala/com/twitter/finagle/buoyant/h2/netty4/Netty4StreamTransportTest.scala
@@ -2,93 +2,26 @@ package com.twitter.finagle.buoyant.h2
 package netty4
 
 import com.twitter.concurrent.AsyncQueue
+import com.twitter.finagle.Failure
 import com.twitter.finagle.netty4.BufAsByteBuf
 import com.twitter.finagle.stats.InMemoryStatsReceiver
 import com.twitter.io.Buf
-import com.twitter.util.{Future, Promise, Time}
-import io.buoyant.test.Awaits
+import com.twitter.util.{Future, Promise, Time, Throw}
+import io.buoyant.test.FunSuite
 import io.netty.buffer.ByteBuf
 import io.netty.handler.codec.http2._
-import org.scalatest.FunSuite
+import java.net.SocketAddress
+import java.util.concurrent.atomic.AtomicBoolean
 import scala.collection.immutable.Queue
 
-class Netty4StreamTransportTest extends FunSuite with Awaits {
+class Netty4StreamTransportTest extends FunSuite {
+  setLogLevel(com.twitter.logging.Level.OFF)
 
-  test("client: request writeHeaders") {
-    val id = 4
-    var frame: Option[Http2Frame] = None
-    val writer = new Netty4H2Writer {
-      def close(d: Time) = ???
-      def write(f: Http2Frame) = {
-        frame = Some(f)
-        Future.Unit
-      }
-    }
-    val stats = new InMemoryStatsReceiver
-    val tstats = new Netty4StreamTransport.StatsReceiver(stats)
-    val stream = Netty4StreamTransport.client(id, writer, tstats)
-
-    val headers: Headers = {
-      val hs = new DefaultHttp2Headers
-      hs.scheme("http")
-      hs.method("get")
-      hs.path("/")
-      hs.authority("a")
-      Netty4Message.Headers(hs)
-    }
-    val w = stream.writeHeaders(headers, true)
-    assert(w.isDefined)
-    frame match {
-      case Some(f: Http2HeadersFrame) =>
-        assert(f.isEndStream)
-        assert(f.headers.scheme() == "http")
-        assert(f.headers.method() == "get")
-        assert(f.headers.path() == "/")
-        assert(f.headers.authority() == "a")
-      case Some(f) => fail(s"unexpected frame: ${f.name}")
-      case None => fail("frame not written")
-    }
-  }
-
-  test("client: request writeStream") {
-    val id = 6
-    var writeq = Queue.empty[Http2Frame]
-    val writer = new Netty4H2Writer {
-      def close(d: Time) = ???
-      def write(f: Http2Frame) = {
-        writeq = writeq :+ f
-        Future.Unit
-      }
-    }
-    val stats = new InMemoryStatsReceiver
-    val tstats = new Netty4StreamTransport.StatsReceiver(stats)
-    val stream = Netty4StreamTransport.client(id, writer, tstats)
-
-    val sendq = new AsyncQueue[Frame]
-    val endP = new Promise[Unit]
-    val data = new Stream.Reader {
-      def onEnd = endP
-      def read() = sendq.poll()
-      def reset(exn: Throwable) = ???
-    }
-    val w = stream.writeStream(data)
-    assert(!w.isDefined)
-
-    val heyo = Buf.Utf8("heyo")
-    assert(sendq.offer(Frame.Data(heyo, false)))
-    assert(writeq.head ==
-      new DefaultHttp2DataFrame(BufAsByteBuf.Owned(heyo), false).setStreamId(id))
-    writeq = writeq.tail
-
-    assert(sendq.offer(Frame.Data(heyo, true)))
-    assert(writeq.head ==
-      new DefaultHttp2DataFrame(BufAsByteBuf.Owned(heyo), true).setStreamId(id))
-    writeq = writeq.tail
-  }
-
-  test("client: response without accumulation") {
+  test("client: response") {
     val id = 8
     val writer = new Netty4H2Writer {
+      override def localAddress = new SocketAddress {}
+      override def remoteAddress = new SocketAddress {}
       def close(d: Time) = ???
       def write(f: Http2Frame) = ???
     }
@@ -96,10 +29,10 @@ class Netty4StreamTransportTest extends FunSuite with Awaits {
     val tstats = new Netty4StreamTransport.StatsReceiver(stats)
     val stream = Netty4StreamTransport.client(id, writer, tstats)
 
-    val rspf = stream.remoteMsg
+    val rspf = stream.onRemoteMessage
     assert(!rspf.isDefined)
 
-    stream.offerRemote(new DefaultHttp2HeadersFrame({
+    stream.admitRemote(new DefaultHttp2HeadersFrame({
       val hs = new DefaultHttp2Headers
       hs.status("222")
       hs
@@ -107,20 +40,17 @@ class Netty4StreamTransportTest extends FunSuite with Awaits {
 
     assert(rspf.isDefined)
     val rsp = await(rspf)
-    val data = rsp.data match {
-      case Stream.Nil => fail("empty stream")
-      case r: Stream.Reader => r
-    }
-    val endf = data.onEnd
+    val endf = rsp.stream.onEnd
     assert(!endf.isDefined)
     assert(rsp.status == Status.Cowabunga)
+    assert(rsp.stream.nonEmpty)
 
-    val dataf = data.read()
+    val dataf = rsp.stream.read()
     assert(!dataf.isDefined)
 
     val buf = Buf.Utf8("space ghost coast to coast")
-    stream.offerRemote(new DefaultHttp2DataFrame(BufAsByteBuf.Owned(buf)).setStreamId(id))
-    stream.offerRemote({
+    stream.admitRemote(new DefaultHttp2DataFrame(BufAsByteBuf.Owned(buf)).setStreamId(id))
+    stream.admitRemote({
       val hs = new DefaultHttp2Headers
       hs.set("trailers", "yea")
       new DefaultHttp2HeadersFrame(hs, true).setStreamId(id)
@@ -133,7 +63,7 @@ class Netty4StreamTransportTest extends FunSuite with Awaits {
         fail(s"unexpected frame: $frame")
     }
 
-    val trailf = data.read()
+    val trailf = rsp.stream.read()
     assert(trailf.isDefined)
     await(trailf) match {
       case trailers: Frame.Trailers =>
@@ -143,23 +73,239 @@ class Netty4StreamTransportTest extends FunSuite with Awaits {
     }
   }
 
+  test("client: upstream reset while waiting on downstream response") {
+    val id = 8
+    val closed = new AtomicBoolean(false)
+    var written = Queue.empty[Http2Frame]
+    val writer = new Netty4H2Writer {
+      override def localAddress = new SocketAddress {}
+      override def remoteAddress = new SocketAddress {}
+      override def close(d: Time) =
+        if (closed.compareAndSet(false, true)) Future.Unit
+        else Future.exception(new Exception("double close"))
+
+      override def write(f: Http2Frame) = synchronized {
+        written = written :+ f
+        Future.Unit
+      }
+    }
+    val stats = new InMemoryStatsReceiver
+    val tstats = new Netty4StreamTransport.StatsReceiver(stats)
+    val stream = Netty4StreamTransport.client(id, writer, tstats)
+
+    val rspF = stream.onRemoteMessage
+
+    assert(synchronized(written).isEmpty)
+    assert(!rspF.isDefined)
+    assert(!stream.isClosed)
+    assert(!stream.onReset.isDefined)
+    assert(!closed.get)
+
+    await(stream.write(Request("http", Method.Get, "host", "/path", Stream.empty())))
+    assert(synchronized(written).length == 1)
+    assert(synchronized(written).last.isInstanceOf[Http2HeadersFrame])
+    assert(!rspF.isDefined)
+    assert(!stream.isClosed)
+    assert(!stream.onReset.isDefined)
+    assert(!closed.get)
+
+    assert(stream.admitRemote(new DefaultHttp2ResetFrame(Http2Error.CANCEL).setStreamId(id)))
+    assert(rspF.isDefined)
+    assert(await(rspF.liftToTry) == Throw(Reset.Cancel))
+    assert(stream.isClosed)
+    assert(stream.onReset.isDefined)
+    assert(await(stream.onReset.liftToTry) == Throw(StreamError.Remote(Reset.Cancel)))
+    assert(synchronized(written).length == 1)
+    assert(!closed.get)
+  }
+
+  test("client: upstream reset while request and response streams are open") {
+    val id = 8
+    val closed = new AtomicBoolean(false)
+    var written = Queue.empty[Http2Frame]
+    val writer = new Netty4H2Writer {
+      override def localAddress = new SocketAddress {}
+      override def remoteAddress = new SocketAddress {}
+      override def close(d: Time) =
+        if (closed.compareAndSet(false, true)) Future.Unit
+        else Future.exception(new Exception("double close"))
+
+      override def write(f: Http2Frame) = synchronized {
+        written = written :+ f
+        Future.Unit
+      }
+    }
+    val stats = new InMemoryStatsReceiver
+    val tstats = new Netty4StreamTransport.StatsReceiver(stats)
+    val stream = Netty4StreamTransport.client(id, writer, tstats)
+
+    val rspF = stream.onRemoteMessage
+
+    assert(synchronized(written).isEmpty)
+    assert(!rspF.isDefined)
+    assert(!stream.isClosed)
+    assert(!stream.onReset.isDefined)
+    assert(!closed.get)
+
+    val localStream = Stream()
+    await(stream.write(Request("http", Method.Get, "host", "/path", localStream)))
+    assert(synchronized(written).length == 1)
+    assert(synchronized(written).last.isInstanceOf[Http2HeadersFrame])
+    assert(!rspF.isDefined)
+    assert(!stream.isClosed)
+    assert(!stream.onReset.isDefined)
+    assert(!closed.get)
+
+    assert(stream.admitRemote({
+      val hs = new DefaultHttp2Headers
+      hs.status("200")
+      new DefaultHttp2HeadersFrame(hs, true).setStreamId(id)
+    }))
+    assert(synchronized(written).length == 1)
+    assert(rspF.isDefined)
+    val rsp = await(rspF)
+    assert(rsp.status == Status.Ok)
+    assert(rsp.stream.isEmpty)
+    assert(!stream.isClosed)
+    assert(!stream.onReset.isDefined)
+    assert(!closed.get)
+
+    assert(stream.admitRemote(new DefaultHttp2ResetFrame(Http2Error.CANCEL).setStreamId(id)))
+    assert(stream.isClosed)
+    assert(stream.onReset.isDefined)
+    assert(await(stream.onReset.liftToTry) == Throw(StreamError.Remote(Reset.Cancel)))
+    assert(synchronized(written).length == 1)
+    assert(!closed.get)
+  }
+
+  test("client: upstream reset after response complete") {
+    val id = 8
+    val closed = new AtomicBoolean(false)
+    var written = Queue.empty[Http2Frame]
+    val writer = new Netty4H2Writer {
+      override def localAddress = new SocketAddress { override def toString = "client" }
+      override def remoteAddress = new SocketAddress { override def toString = "server" }
+      override def close(d: Time) =
+        if (closed.compareAndSet(false, true)) Future.Unit
+        else Future.exception(new Exception("double close"))
+
+      override def write(f: Http2Frame) = synchronized {
+        written = written :+ f
+        Future.Unit
+      }
+    }
+    val stats = new InMemoryStatsReceiver
+    val tstats = new Netty4StreamTransport.StatsReceiver(stats)
+    val stream = Netty4StreamTransport.client(id, writer, tstats)
+
+    val rspF = stream.onRemoteMessage
+    assert(synchronized(written).isEmpty)
+    assert(!rspF.isDefined)
+    assert(!stream.onReset.isDefined)
+    assert(!closed.get)
+
+    assert(stream.admitRemote({
+      val hs = new DefaultHttp2Headers
+      hs.status("200")
+      new DefaultHttp2HeadersFrame(hs, true).setStreamId(id)
+    }))
+    assert(rspF.isDefined)
+    val rsp = await(rspF)
+    assert(rsp.status == Status.Ok)
+    assert(rsp.stream.isEmpty)
+
+    val reqStream = Stream()
+    val streamF = await(stream.write(Request("http", Method.Get, "host", "/path", reqStream)))
+
+    assert(synchronized(written).length == 1)
+    assert(synchronized(written).last.isInstanceOf[Http2HeadersFrame])
+    assert(!stream.isClosed)
+    assert(!stream.onReset.isDefined)
+    assert(!closed.get)
+
+    await(reqStream.write(Frame.Data(Buf.Utf8("upshut"), eos = false)))
+    assert(synchronized(written).length == 2)
+    assert(synchronized(written).last.isInstanceOf[Http2DataFrame])
+    assert(!stream.isClosed)
+    assert(!stream.onReset.isDefined)
+    assert(!closed.get)
+
+    assert(!streamF.isDefined)
+    log.debug("resetting request stream")
+    reqStream.reset(Reset.InternalError)
+    assert(synchronized(written).length == 2)
+    assert(await(streamF.liftToTry) == Throw(StreamError.Local(Reset.InternalError)))
+
+    assert(await(stream.onReset.liftToTry) == Throw(StreamError.Local(Reset.InternalError)))
+    assert(stream.isClosed)
+    assert(!closed.get)
+  }
+
+  test("client: canceled response causes downstream reset") {
+    val id = 8
+    val closed = new AtomicBoolean(false)
+    var written = Queue.empty[Http2Frame]
+    val writer = new Netty4H2Writer {
+      override def localAddress = new SocketAddress {}
+      override def remoteAddress = new SocketAddress {}
+      override def close(d: Time) =
+        if (closed.compareAndSet(false, true)) Future.Unit
+        else Future.exception(new Exception("double close"))
+
+      override def write(f: Http2Frame) = synchronized {
+        written = written :+ f
+        Future.Unit
+      }
+    }
+    val stats = new InMemoryStatsReceiver
+    val tstats = new Netty4StreamTransport.StatsReceiver(stats)
+    val stream = Netty4StreamTransport.client(id, writer, tstats)
+
+    val rspF = stream.onRemoteMessage
+    assert(synchronized(written).isEmpty)
+    assert(!rspF.isDefined)
+    assert(!stream.isClosed)
+    assert(!stream.onReset.isDefined)
+    assert(!closed.get)
+
+    val streamF = await(stream.write(Request("http", Method.Get, "host", "/path", Stream.empty())))
+    assert(synchronized(written).length == 1)
+    assert(synchronized(written).last.isInstanceOf[Http2HeadersFrame])
+    assert(!rspF.isDefined)
+    assert(!stream.isClosed)
+    assert(!stream.onReset.isDefined)
+    assert(!closed.get)
+
+    assert(!streamF.isDefined)
+    rspF.raise(Failure("shut up").flagged(Failure.Interrupted))
+    assert(synchronized(written).length == 1)
+    assert(rspF.isDefined)
+    assert(await(rspF.liftToTry) == Throw(Reset.Cancel))
+    assert(stream.isClosed)
+    assert(stream.onReset.isDefined)
+    assert(await(stream.onReset.liftToTry) == Throw(StreamError.Local(Reset.Cancel)))
+    assert(!closed.get)
+  }
+
   test("server: provides a remote request") {
     val writer = new Netty4H2Writer {
+      override def localAddress = new SocketAddress {}
+      override def remoteAddress = new SocketAddress {}
       def close(d: Time) = ???
       def write(f: Http2Frame) = ???
     }
     val stream = Netty4StreamTransport.server(3, writer)
-    val reqf = stream.remoteMsg
+    val reqf = stream.onRemoteMessage
     assert(!reqf.isDefined)
 
-    stream.offerRemote({
+    assert(stream.admitRemote({
       val hs = new DefaultHttp2Headers
       hs.scheme("h2")
       hs.method("SUP")
       hs.path("/")
       hs.authority("auf")
       new DefaultHttp2HeadersFrame(hs, false).setStreamId(3)
-    })
+    }))
 
     assert(reqf.isDefined)
     val req = await(reqf)
@@ -167,14 +313,12 @@ class Netty4StreamTransportTest extends FunSuite with Awaits {
     assert(req.method == Method("SUP"))
     assert(req.path == "/")
     assert(req.authority == "auf")
-    val data = req.data match {
-      case Stream.Nil => fail("empty stream")
-      case d: Stream.Reader => d
-    }
 
-    val d0f = data.read()
+    val d0f = req.stream.read()
     assert(!d0f.isDefined)
-    stream.offerRemote(new DefaultHttp2DataFrame(BufAsByteBuf.Owned(Buf.Utf8("data")), false).setStreamId(3))
+    assert(stream.admitRemote({
+      new DefaultHttp2DataFrame(BufAsByteBuf.Owned(Buf.Utf8("data")), false).setStreamId(3)
+    }))
     assert(d0f.isDefined)
     await(d0f) match {
       case f: Frame.Data =>
@@ -184,13 +328,13 @@ class Netty4StreamTransportTest extends FunSuite with Awaits {
         fail(s"unexpected frame: $f")
     }
 
-    val d1f = data.read()
+    val d1f = req.stream.read()
     assert(!d1f.isDefined)
-    stream.offerRemote({
+    assert(stream.admitRemote({
       val hs = new DefaultHttp2Headers
       hs.set("trailers", "chya")
       new DefaultHttp2HeadersFrame(hs, true)
-    })
+    }))
     assert(d1f.isDefined)
     await(d1f) match {
       case f: Frame.Trailers =>
@@ -204,6 +348,8 @@ class Netty4StreamTransportTest extends FunSuite with Awaits {
   test("server: writes a response on the underlying transport") {
     var writeq = Queue.empty[Http2Frame]
     val writer = new Netty4H2Writer {
+      override def localAddress = new SocketAddress {}
+      override def remoteAddress = new SocketAddress {}
       def close(d: Time) = ???
       def write(f: Http2Frame) = {
         writeq = writeq :+ f
@@ -247,4 +393,168 @@ class Netty4StreamTransportTest extends FunSuite with Awaits {
     writeq = writeq.tail
   }
 
+  test("client: downstream reset while request and response streams are open") {
+    val id = 6
+    val closed = new AtomicBoolean(false)
+    var written = Queue.empty[Http2Frame]
+    val writer = new Netty4H2Writer {
+      override def localAddress = new SocketAddress {}
+      override def remoteAddress = new SocketAddress {}
+      override def close(d: Time) =
+        if (closed.compareAndSet(false, true)) Future.Unit
+        else Future.exception(new Exception("double close"))
+
+      override def write(f: Http2Frame) = synchronized {
+        written = written :+ f
+        Future.Unit
+      }
+    }
+    val stats = new InMemoryStatsReceiver
+    val tstats = new Netty4StreamTransport.StatsReceiver(stats)
+    val stream = Netty4StreamTransport.server(id, writer, tstats)
+
+    val reqF = stream.onRemoteMessage
+
+    assert(synchronized(written).isEmpty)
+    assert(!reqF.isDefined)
+    assert(!stream.isClosed)
+    assert(!stream.onReset.isDefined)
+    assert(!closed.get)
+
+    assert(stream.admitRemote({
+      val hs = new DefaultHttp2Headers
+      hs.scheme("h2")
+      hs.method("SUP")
+      hs.path("/")
+      hs.authority("auf")
+      new DefaultHttp2HeadersFrame(hs, false).setStreamId(3)
+    }))
+    assert(reqF.isDefined)
+    assert(synchronized(written).isEmpty)
+    assert(!stream.isClosed)
+    assert(!stream.onReset.isDefined)
+    assert(!closed.get)
+
+    assert(stream.admitRemote(new DefaultHttp2ResetFrame(Http2Error.CANCEL).setStreamId(id)))
+    assert(synchronized(written).isEmpty)
+    assert(stream.isClosed)
+    assert(stream.onReset.isDefined)
+    assert(await(stream.onReset.liftToTry) == Throw(StreamError.Remote(Reset.Cancel)))
+    assert(!closed.get)
+  }
+
+  test("server: downstream reset while streaming response") {
+    val id = 6
+    val closed = new AtomicBoolean(false)
+    var written = Queue.empty[Http2Frame]
+    val writer = new Netty4H2Writer {
+      override def localAddress = new SocketAddress {}
+      override def remoteAddress = new SocketAddress {}
+      override def close(d: Time) =
+        if (closed.compareAndSet(false, true)) Future.Unit
+        else Future.exception(new Exception("double close"))
+
+      override def write(f: Http2Frame) = synchronized {
+        written = written :+ f
+        Future.Unit
+      }
+    }
+    val stats = new InMemoryStatsReceiver
+    val tstats = new Netty4StreamTransport.StatsReceiver(stats)
+    val stream = Netty4StreamTransport.server(id, writer, tstats)
+
+    val reqF = stream.onRemoteMessage
+
+    assert(synchronized(written).isEmpty)
+    assert(!reqF.isDefined)
+    assert(!stream.isClosed)
+    assert(!stream.onReset.isDefined)
+    assert(!closed.get)
+
+    assert(stream.admitRemote({
+      val hs = new DefaultHttp2Headers
+      hs.scheme("h2")
+      hs.method("SUP")
+      hs.path("/")
+      hs.authority("auf")
+      new DefaultHttp2HeadersFrame(hs, false).setStreamId(3)
+    }))
+    assert(reqF.isDefined)
+    assert(synchronized(written).isEmpty)
+    assert(!stream.isClosed)
+    assert(!stream.onReset.isDefined)
+    assert(!closed.get)
+
+    await(stream.write(Response(Status.Ok, Stream.empty())))
+    assert(synchronized(written).length == 1)
+    assert(synchronized(written).last.isInstanceOf[Http2HeadersFrame])
+    assert(!stream.isClosed)
+    assert(!stream.onReset.isDefined)
+    assert(!closed.get)
+
+    assert(stream.admitRemote(new DefaultHttp2ResetFrame(Http2Error.CANCEL).setStreamId(id)))
+    assert(synchronized(written).length == 1)
+    assert(stream.isClosed)
+    assert(stream.onReset.isDefined)
+    assert(await(stream.onReset.liftToTry) == Throw(StreamError.Remote(Reset.Cancel)))
+    assert(!closed.get)
+  }
+
+  test("server: downstream reset while streaming request") {
+    val id = 6
+    val closed = new AtomicBoolean(false)
+    var written = Queue.empty[Http2Frame]
+    val writer = new Netty4H2Writer {
+      override def localAddress = new SocketAddress {}
+      override def remoteAddress = new SocketAddress {}
+      override def close(d: Time) =
+        if (closed.compareAndSet(false, true)) Future.Unit
+        else Future.exception(new Exception("double close"))
+
+      override def write(f: Http2Frame) = synchronized {
+        written = written :+ f
+        Future.Unit
+      }
+    }
+    val stats = new InMemoryStatsReceiver
+    val tstats = new Netty4StreamTransport.StatsReceiver(stats)
+    val stream = Netty4StreamTransport.server(id, writer, tstats)
+
+    val reqF = stream.onRemoteMessage
+
+    assert(synchronized(written).isEmpty)
+    assert(!reqF.isDefined)
+    assert(!stream.isClosed)
+    assert(!stream.onReset.isDefined)
+    assert(!closed.get)
+
+    assert(stream.admitRemote({
+      val hs = new DefaultHttp2Headers
+      hs.scheme("h2")
+      hs.method("SUP")
+      hs.path("/")
+      hs.authority("auf")
+      new DefaultHttp2HeadersFrame(hs, true).setStreamId(3)
+    }))
+    assert(reqF.isDefined)
+    assert(synchronized(written).isEmpty)
+    assert(!stream.isClosed)
+    assert(!stream.onReset.isDefined)
+    assert(!closed.get)
+
+    val rspStream = Stream()
+    await(stream.write(Response(Status.Ok, rspStream)))
+    assert(synchronized(written).length == 1)
+    assert(synchronized(written).last.isInstanceOf[Http2HeadersFrame])
+    assert(!stream.isClosed)
+    assert(!stream.onReset.isDefined)
+    assert(!closed.get)
+
+    assert(stream.admitRemote(new DefaultHttp2ResetFrame(Http2Error.CANCEL).setStreamId(id)))
+    assert(synchronized(written).length == 1)
+    assert(stream.isClosed)
+    assert(stream.onReset.isDefined)
+    assert(await(stream.onReset.liftToTry) == Throw(StreamError.Remote(Reset.Cancel)))
+    assert(!closed.get)
+  }
 }

--- a/router/h2/src/test/scala/io/buoyant/router/h2/DupRequestTest.scala
+++ b/router/h2/src/test/scala/io/buoyant/router/h2/DupRequestTest.scala
@@ -12,10 +12,10 @@ class DupRequestTest extends FunSuite with Awaits {
   test("changes in service don't impact original") {
     val service = DupRequest.filter.andThen(Service.mk[Request, Response] { req =>
       req.headers.set("badness", "true")
-      Future.value(Response(Status.Ok, Stream.Nil))
+      Future.value(Response(Status.Ok, Stream.empty()))
     })
 
-    val req = Request("http", Method.Get, "hihost", "/", Stream.Nil)
+    val req = Request("http", Method.Get, "hihost", "/", Stream.empty())
     await(service(req))
     assert(!req.headers.contains("badness"))
   }


### PR DESCRIPTION
### Background

The HTTP2 protocol defines RST_STREAM frames to support request-level cancelation and GO_AWAY frames to signal connection-level interruption. This distinction is especially germane to proxies like linkerd since we want to allow long-lived multiplexed connections between endpoints while also allowing request-level cancelation (to support timeouts/deadlines, etc).

### Problem

linkerd's HTTP2 support isn't at all well-conditioned to request cancelation or connection loss (#728). For instance, if a linkerd instance loses its connection to a remote server, the client-side of an active stream may close, but the upstream-server-side of a stream will be left open indefinitely. Similar behavior is exhibited when a remote explicitly issues a RST_STREAM frame.

Furthermore, clients that disconnect are not properly evicted from load balancers because the ClientDispatcher Service does not alter its `status` after connection loss. (#785)

### Solution

Because resets may occur at any stage of a Stream's lifecycle, several changes are required. As much as possible, we try to rely on finagle primitives like Future-cancelation to achieve the desired behavior.

The `h2.Stream` API has been altered substantially: the `Stream.Reader` and `Stream.Nil` types have been unified as a `Stream`. Stream consumers that care about resets & closures must call `Stream.read()` until a failure is encountered. Stream producers (i.e. `Netty4StreamTransport`) must close or reset the stream appropriately.

`Netty4StreamTransport` has been substantially refactored to more explicitly model the HTTP2 state machine.  It ensures that canceled and failed writes are propagated as resets, and that resets cancel writes and prevent receipt of remote frames.

`Netty4ClientDispatcher` and `Netty4ServerDispatcher` have been substantially simplified, moving a good portion of common stream-multiplexing logic to `Netty4DispatcherBase`. Dispatchers now ensure that a GO_AWAY frame or connection loss actively triggers stream cancelation.

Various dedicated `Reset`, `GoAway`, and `StreamError` types have been introduced to model failures appropriately.

Fixes #728 #785