### PR TITLE
Improve commentary; reuse code in stream transport tests.

### DIFF
--- a/router/h2/src/main/scala/com/twitter/finagle/buoyant/h2/netty4/Netty4H2Writer.scala
+++ b/router/h2/src/main/scala/com/twitter/finagle/buoyant/h2/netty4/Netty4H2Writer.scala
@@ -49,16 +49,9 @@ private[netty4] trait Netty4H2Writer extends H2Transport.Writer {
     write(frame)
   }
 
-  override def reset(id: Int, err: Reset): Future[Unit] = {
+  override def reset(id: Int, rst: Reset): Future[Unit] = {
     require(id > 0)
-    val code = err match {
-      case Reset.Cancel => Http2Error.CANCEL
-      case Reset.EnhanceYourCalm => Http2Error.ENHANCE_YOUR_CALM
-      case Reset.InternalError => Http2Error.INTERNAL_ERROR
-      case Reset.NoError => Http2Error.NO_ERROR
-      case Reset.Refused => Http2Error.REFUSED_STREAM
-      case Reset.Closed => Http2Error.STREAM_CLOSED
-    }
+    val code = Netty4Message.toNetty(rst)
     val frame = new DefaultHttp2ResetFrame(code).setStreamId(id)
     write(frame)
   }

--- a/router/h2/src/main/scala/com/twitter/finagle/buoyant/h2/netty4/Netty4ServerDispatcher.scala
+++ b/router/h2/src/main/scala/com/twitter/finagle/buoyant/h2/netty4/Netty4ServerDispatcher.scala
@@ -76,7 +76,7 @@ class Netty4ServerDispatcher(
   private[this] def serveStream(st: Netty4StreamTransport[Response, Request]) = {
     // Note: `remoteMsg` should be satisfied immediately, since the
     // headers frame will have just been admitted to the stream.
-    val serveF = st.onRemoteMessage.flatMap(serve).flatMap(st.write(_).flatten)
+    val serveF = st.onRecvMessage.flatMap(serve).flatMap(st.send(_).flatten)
 
     // When the stream is reset, ensure that the cancelation is
     // propagated downstream.
@@ -117,7 +117,7 @@ class Netty4ServerDispatcher(
   override protected[this] def demuxNewStream(f: Http2StreamFrame): Future[Unit] = f match {
     case frame: Http2HeadersFrame =>
       val st = newStreamTransport(frame.streamId)
-      if (st.admitRemote(frame)) serveStream(st)
+      if (st.recv(frame)) serveStream(st)
       Future.Unit
 
     case frame =>

--- a/router/h2/src/main/scala/com/twitter/finagle/buoyant/h2/netty4/Netty4StreamTransport.scala
+++ b/router/h2/src/main/scala/com/twitter/finagle/buoyant/h2/netty4/Netty4StreamTransport.scala
@@ -37,7 +37,7 @@ import scala.util.control.NoStackTrace
  * stream. This information is used by i.e. dispatchers to determine
  * whether a reset frame must be written.
  */
-private[h2] trait Netty4StreamTransport[LocalMsg <: Message, RemoteMsg <: Message] {
+private[h2] trait Netty4StreamTransport[SendMsg <: Message, RecvMsg <: Message] {
   import Netty4StreamTransport._
 
   /** The HTTP/2 STREAM_ID of this stream. */
@@ -50,7 +50,7 @@ private[h2] trait Netty4StreamTransport[LocalMsg <: Message, RemoteMsg <: Messag
 
   protected[this] def statsReceiver: StatsReceiver
 
-  protected[this] def mkRemoteMsg(headers: Http2Headers, stream: Stream): RemoteMsg
+  protected[this] def mkRecvMsg(headers: Http2Headers, stream: Stream): RecvMsg
 
   /*
    * A stream's state is represented by the `StreamState` ADT,
@@ -75,26 +75,40 @@ private[h2] trait Netty4StreamTransport[LocalMsg <: Message, RemoteMsg <: Messag
    *                       |        |
    *                       +--------+
    *
-   *
    * (Note that SERVER_PUSH is not supported or represented in this
    * version of the state diagram).
    */
 
-  /** Helper: a state that supports Reset.  (All but Closed) */
-  private[this] trait ResettableState {
-    def reset(rst: Reset): Unit
-  }
-
   private[this] sealed trait StreamState
 
-  /** The stream is open in both directions. */
+  /**
+   * The stream is open in both directions.
+   *
+   * When the StreamTransport is initialized (because a dispatcher has
+   * a stream frame it needs to dispatch), it starts in the `Open`
+   * state, because the stream exists and neither the remote nor local
+   * halves of the stream have been closed (i.e. by sending a frame
+   * with END_STREAM set).
+   *
+   * Since the local half of the stream is written from the dispatcher
+   * to the transport, we simply track whether this has completed.
+   *
+   * The remote half of the connection is represented with by a
+   * [[RemoteState]] so that received frames may be passed inbound to
+   * the application: first, by satisfying the `onRemoteMessage`
+   * Future with [[RemotePending]], and then by offering data and
+   * trailer frames to [[RemoteStreaming]].
+   */
   private[this] case class Open(remote: RemoteState) extends StreamState with ResettableState {
+    /**
+     * Act on a stream reset by failing a pending or streaming remote.
+     */
     override def reset(rst: Reset): Unit = remote.reset(rst)
   }
 
   /**
-   * The local message has been fully sent, but the remote message is
-   * still being received.
+   * The `SendMsg` has been entirely sent, and the `RecvMsg` is still
+   * being received.
    */
   private[this] case class LocalClosed(remote: RemoteState)
     extends StreamState with ResettableState {
@@ -102,11 +116,13 @@ private[h2] trait Netty4StreamTransport[LocalMsg <: Message, RemoteMsg <: Messag
   }
 
   /**
-   * The full remote message has been received and the LocalMsg is
-   * still being sent.
+   * The `RecvMsg` has been entirely received, and the `SendMsg` is still
+   * being sent.
    *
-   * The remote frame queue is preserved so that it may be failed when
-   * the stream is closed or reset.
+   * Though the remote half is closed, it may reset the local half of
+   * the stream.  This is achieved by failing the stream's underlying
+   * queue so that the consumer of a stream fails `read()` with a
+   * reset.
    */
   private[this] class RemoteClosed(q: AsyncQueue[Frame])
     extends StreamState with ResettableState {
@@ -117,15 +133,16 @@ private[h2] trait Netty4StreamTransport[LocalMsg <: Message, RemoteMsg <: Messag
     def unapply(rc: RemoteClosed): Boolean = true
   }
 
-  /** The stream is fully closed. */
+  /** Both `RecvMsg` and `SendMsg` have been entirely sent. */
   private[this] case class Closed(error: Reset) extends StreamState
 
   /** The state of the remote side of a stream. */
   private[this] sealed trait RemoteState extends ResettableState
 
-  /** A remote stream before the initial HEADERS frame has been received. */
-  private[this] class RemotePending(p: Promise[RemoteMsg]) extends RemoteState {
-    def setMessage(h: Http2Headers, s: Stream): Unit = p.setValue(mkRemoteMsg(h, s))
+  /** A remote stream before the initial HEADERS frames have been received. */
+  private[this] class RemotePending(p: Promise[RecvMsg]) extends RemoteState {
+    def future: Future[RecvMsg] = p
+    def setMessage(h: Http2Headers, s: Stream): Unit = p.setValue(mkRecvMsg(h, s))
     override def reset(rst: Reset): Unit = p.setException(rst)
   }
   private[this] object RemotePending {
@@ -161,42 +178,47 @@ private[h2] trait Netty4StreamTransport[LocalMsg <: Message, RemoteMsg <: Messag
     }
   }
 
-  private[this] val remoteMsgP = new Promise[RemoteMsg]
-  def onRemoteMessage: Future[RemoteMsg] = remoteMsgP
-
-  // When the remote message--especially a client's repsonse--is
-  // canceled, close the transport, sending a RST_STREAM as
-  // appropriate.
-  remoteMsgP.setInterruptHandler {
-    case err: Reset =>
-      log.debug(err, "[%s] remote message interrupted", prefix)
-      localReset(err)
-
-    case Failure(Some(err: Reset)) =>
-      log.debug(err, "[%s] remote message interrupted", prefix)
-      localReset(err)
-
-    case f@Failure(_) if f.isFlagged(Failure.Interrupted) =>
-      log.debug(f, "[%s] remote message interrupted", prefix)
-      localReset(Reset.Cancel)
-
-    case f@Failure(_) if f.isFlagged(Failure.Rejected) =>
-      log.debug(f, "[%s] remote message interrupted", prefix)
-      localReset(Reset.Refused)
-
-    case e =>
-      log.debug(e, "[%s] remote message interrupted", prefix)
-      localReset(Reset.InternalError)
-  }
-
   /**
    * Because remote reads and local writes may occur concurrently,
    * this state is stored in the `stateRef` atomic reference. Writes
    * and reads are performed without locking (at the expense of
    * retrying on collision).
    */
-  private[this] val stateRef: AtomicReference[StreamState] =
+  private[this] val stateRef: AtomicReference[StreamState] = {
+    val remoteMsgP = new Promise[RecvMsg]
+
+    // When the remote message--especially a client's repsonse--is
+    // canceled, close the transport, sending a RST_STREAM as
+    // appropriate.
+    remoteMsgP.setInterruptHandler {
+      case err: Reset =>
+        log.debug(err, "[%s] remote message interrupted", prefix)
+        localReset(err)
+
+      case Failure(Some(err: Reset)) =>
+        log.debug(err, "[%s] remote message interrupted", prefix)
+        localReset(err)
+
+      case f@Failure(_) if f.isFlagged(Failure.Interrupted) =>
+        log.debug(f, "[%s] remote message interrupted", prefix)
+        localReset(Reset.Cancel)
+
+      case f@Failure(_) if f.isFlagged(Failure.Rejected) =>
+        log.debug(f, "[%s] remote message interrupted", prefix)
+        localReset(Reset.Refused)
+
+      case e =>
+        log.debug(e, "[%s] remote message interrupted", prefix)
+        localReset(Reset.InternalError)
+    }
+
     new AtomicReference(Open(new RemotePending(remoteMsgP)))
+  }
+
+  val onRecvMessage: Future[RecvMsg] = stateRef.get match {
+    case Open(rp@RemotePending()) => rp.future
+    case s => sys.error(s"unexpected initailzation state: $s")
+  }
 
   /**
    * Satisfied successfully when the stream is fully closed with no
@@ -250,17 +272,17 @@ private[h2] trait Netty4StreamTransport[LocalMsg <: Message, RemoteMsg <: Messag
     }
 
   /*
-   * Reading a RemoteMsg from the remote.
+   * Reading an RecvMsg from the remote.
    */
 
   /**
    * Offer a Netty Http2StreamFrame from the remote.
    *
-   * `admitRemote` returns false to indicate that a frame could not be
+   * `recv` returns false to indicate that a frame could not be
    * accepted.  This may occur, for example, when a message is
    * received on a closed stream.
    */
-  @tailrec final def admitRemote(in: Http2StreamFrame): Boolean = {
+  @tailrec final def recv(in: Http2StreamFrame): Boolean = {
     val state = stateRef.get
     log.trace("[%s] admitting %s in %s", prefix, in.name, state)
 
@@ -271,7 +293,7 @@ private[h2] trait Netty4StreamTransport[LocalMsg <: Message, RemoteMsg <: Messag
         true
       } else false
 
-    def admitFrame(f: Frame, remote: RemoteStreaming): Boolean =
+    def recvFrame(f: Frame, remote: RemoteStreaming): Boolean =
       if (remote.offer(f)) {
         statsReceiver.recordRemoteFrame(f)
         true
@@ -286,13 +308,13 @@ private[h2] trait Netty4StreamTransport[LocalMsg <: Message, RemoteMsg <: Messag
             if (resetRemote(remote, toReset(rst.errorCode))) {
               statsReceiver.remoteResetCount.incr()
               true
-            } else admitRemote(rst)
+            } else recv(rst)
 
           case state@RemoteClosed() =>
             if (resetRemote(state, toReset(rst.errorCode))) {
               statsReceiver.remoteResetCount.incr()
               true
-            } else admitRemote(rst)
+            } else recv(rst)
         }
 
       case hdrs: Http2HeadersFrame if hdrs.isEndStream =>
@@ -301,28 +323,28 @@ private[h2] trait Netty4StreamTransport[LocalMsg <: Message, RemoteMsg <: Messag
 
           case state@RemoteClosed() =>
             if (resetRemote(state, Reset.InternalError)) true
-            else admitRemote(hdrs)
+            else recv(hdrs)
 
           case Open(remote@RemotePending()) =>
             val q = new AsyncQueue[Frame](1)
             if (stateRef.compareAndSet(state, new RemoteClosed(q))) {
               remote.setMessage(hdrs.headers, Stream.empty(q))
               true
-            } else admitRemote(hdrs)
+            } else recv(hdrs)
 
           case Open(remote@RemoteStreaming()) =>
             if (stateRef.compareAndSet(state, remote.toRemoteClosed)) {
               val f = toFrame(hdrs)
               statsReceiver.recordRemoteFrame(f)
               remote.offer(f)
-            } else admitRemote(hdrs)
+            } else recv(hdrs)
 
           case LocalClosed(remote@RemotePending()) =>
             if (stateRef.compareAndSet(state, Closed(Reset.NoError))) {
               remote.setMessage(hdrs.headers, NilStream)
               resetP.setDone()
               true
-            } else admitRemote(hdrs)
+            } else recv(hdrs)
 
           case LocalClosed(remote@RemoteStreaming()) =>
             if (stateRef.compareAndSet(state, Closed(Reset.NoError))) {
@@ -333,7 +355,7 @@ private[h2] trait Netty4StreamTransport[LocalMsg <: Message, RemoteMsg <: Messag
                 resetP.setDone()
                 true
               } else false
-            } else admitRemote(hdrs)
+            } else recv(hdrs)
         }
 
       case hdrs: Http2HeadersFrame =>
@@ -343,25 +365,25 @@ private[h2] trait Netty4StreamTransport[LocalMsg <: Message, RemoteMsg <: Messag
           case Closed(_) => false
           case state@RemoteClosed() =>
             if (resetRemote(state, Reset.Closed)) false
-            else admitRemote(hdrs)
+            else recv(hdrs)
 
           case RemoteOpen(remote@RemoteStreaming()) =>
             if (resetRemote(remote, Reset.InternalError)) false
-            else admitRemote(hdrs)
+            else recv(hdrs)
 
           case Open(remote@RemotePending()) =>
             val q = new AsyncQueue[Frame]
             if (stateRef.compareAndSet(state, Open(RemoteStreaming(q)))) {
               remote.setMessage(hdrs.headers, Stream(q))
               true
-            } else admitRemote(hdrs)
+            } else recv(hdrs)
 
           case LocalClosed(remote@RemotePending()) =>
             val q = new AsyncQueue[Frame]
             if (stateRef.compareAndSet(state, LocalClosed(RemoteStreaming(q)))) {
               remote.setMessage(hdrs.headers, Stream(q))
               true
-            } else admitRemote(hdrs)
+            } else recv(hdrs)
         }
 
       case data: Http2DataFrame =>
@@ -370,35 +392,35 @@ private[h2] trait Netty4StreamTransport[LocalMsg <: Message, RemoteMsg <: Messag
 
           case state@RemoteClosed() =>
             if (resetRemote(state, Reset.Closed)) false
-            else admitRemote(data)
+            else recv(data)
 
           case RemoteOpen(remote@RemotePending()) =>
             if (resetRemote(remote, Reset.InternalError)) false
-            else admitRemote(data)
+            else recv(data)
 
           case Open(remote@RemoteStreaming()) =>
             if (data.isEndStream) {
               if (stateRef.compareAndSet(state, remote.toRemoteClosed)) {
-                if (admitFrame(toFrame(data), remote)) true
+                if (recvFrame(toFrame(data), remote)) true
                 else throw new IllegalStateException("stream queue closed prematurely")
-              } else admitRemote(data)
+              } else recv(data)
             } else {
-              if (admitFrame(toFrame(data), remote)) true
-              else admitRemote(data)
+              if (recvFrame(toFrame(data), remote)) true
+              else recv(data)
             }
 
           case LocalClosed(remote@RemoteStreaming()) =>
             if (data.isEndStream) {
               if (stateRef.compareAndSet(state, Closed(Reset.NoError))) {
-                if (admitFrame(toFrame(data), remote)) {
+                if (recvFrame(toFrame(data), remote)) {
                   remote.close()
                   resetP.setDone()
                   true
                 } else throw new IllegalStateException("stream queue closed prematurely")
-              } else admitRemote(data)
+              } else recv(data)
             } else {
-              if (admitFrame(toFrame(data), remote)) true
-              else admitRemote(data)
+              if (recvFrame(toFrame(data), remote)) true
+              else recv(data)
             }
         }
     }
@@ -413,7 +435,7 @@ private[h2] trait Netty4StreamTransport[LocalMsg <: Message, RemoteMsg <: Messag
   private[this] val updateWindow: Int => Future[Unit] = transport.updateWindow(streamId, _)
 
   /**
-   * Write a `LocalMsg` to the remote.
+   * Write a `SendMsg`-typed [[Message]] to the remote.
    *
    * The outer future is satisfied initially to indicate that the
    * local message has been initiated (i.e. its HEADERS have been
@@ -425,7 +447,7 @@ private[h2] trait Netty4StreamTransport[LocalMsg <: Message, RemoteMsg <: Messag
    *
    * If the stream is reset, writes are canceled.
    */
-  def write(msg: LocalMsg): Future[Future[Unit]] = {
+  def send(msg: SendMsg): Future[Future[Unit]] = {
     val headersF = writeHeaders(msg.headers, msg.stream.isEmpty)
     val streamFF = headersF.map(_ => writeStream(msg.stream))
 
@@ -500,7 +522,12 @@ private[h2] trait Netty4StreamTransport[LocalMsg <: Message, RemoteMsg <: Messag
 }
 
 object Netty4StreamTransport {
-  private val log = Logger.get(getClass.getName)
+  private lazy val log = Logger.get(getClass.getName)
+
+  /** Helper: a state that supports Reset.  (All but Closed) */
+  private trait ResettableState {
+    def reset(rst: Reset): Unit
+  }
 
   private val wrapLocalEx: PartialFunction[Throwable, Future[Nothing]] = {
     case e@StreamError.Local(_) => Future.exception(e)
@@ -569,7 +596,7 @@ object Netty4StreamTransport {
     override protected[this] val prefix =
       s"C L:${transport.localAddress} R:${transport.remoteAddress} S:${streamId}"
 
-    override protected[this] def mkRemoteMsg(headers: Http2Headers, stream: Stream): Response =
+    override protected[this] def mkRecvMsg(headers: Http2Headers, stream: Stream): Response =
       Response(Netty4Message.Headers(headers), stream)
   }
 
@@ -582,7 +609,7 @@ object Netty4StreamTransport {
     override protected[this] val prefix =
       s"S L:${transport.localAddress} R:${transport.remoteAddress} S:${streamId}"
 
-    override protected[this] def mkRemoteMsg(headers: Http2Headers, stream: Stream): Request =
+    override protected[this] def mkRecvMsg(headers: Http2Headers, stream: Stream): Request =
       Request(Netty4Message.Headers(headers), stream)
   }
 

--- a/router/h2/src/main/scala/com/twitter/finagle/buoyant/h2/netty4/Netty4StreamTransport.scala
+++ b/router/h2/src/main/scala/com/twitter/finagle/buoyant/h2/netty4/Netty4StreamTransport.scala
@@ -234,10 +234,18 @@ private[h2] trait Netty4StreamTransport[SendMsg <: Message, RecvMsg <: Message] 
   }
 
   def remoteReset(err: Reset): Unit =
-    if (tryReset(err)) resetP.setException(StreamError.Remote(err))
+    if (tryReset(err)) err match {
+      case Reset.NoError =>
+        resetP.setDone(); ()
+      case err => resetP.setException(StreamError.Remote(err))
+    }
 
   def localReset(err: Reset): Unit =
-    if (tryReset(err)) resetP.setException(StreamError.Local(err))
+    if (tryReset(err)) err match {
+      case Reset.NoError =>
+        resetP.setDone(); ()
+      case err => resetP.setException(StreamError.Local(err))
+    }
 
   @tailrec private[this] def tryReset(err: Reset): Boolean =
     stateRef.get match {

--- a/router/h2/src/main/scala/com/twitter/finagle/buoyant/h2/netty4/Netty4StreamTransport.scala
+++ b/router/h2/src/main/scala/com/twitter/finagle/buoyant/h2/netty4/Netty4StreamTransport.scala
@@ -271,10 +271,6 @@ private[h2] trait Netty4StreamTransport[SendMsg <: Message, RecvMsg <: Message] 
         } else closeLocal()
     }
 
-  /*
-   * Reading an RecvMsg from the remote.
-   */
-
   /**
    * Offer a Netty Http2StreamFrame from the remote.
    *

--- a/router/h2/src/test/scala/com/twitter/finagle/buoyant/h2/netty4/Netty4StreamTransportTest.scala
+++ b/router/h2/src/test/scala/com/twitter/finagle/buoyant/h2/netty4/Netty4StreamTransportTest.scala
@@ -17,8 +17,8 @@ import scala.collection.immutable.Queue
 class Netty4StreamTransportTest extends FunSuite {
   setLogLevel(com.twitter.logging.Level.OFF)
 
-  trait ClientCtx {
-    val id = 8
+  trait Ctx {
+    val id = 7
 
     val closed = new AtomicBoolean(false)
     def close(d: Time) =
@@ -32,16 +32,98 @@ class Netty4StreamTransportTest extends FunSuite {
     }
 
     def mkWriter() = new Netty4H2Writer {
-      override def localAddress = new SocketAddress { override def toString = "client" }
-      override def remoteAddress = new SocketAddress { override def toString = "server" }
-      def close(d: Time) = ClientCtx.this.close(d)
-      def write(f: Http2Frame) = ClientCtx.this.write(f)
+      override def localAddress = new SocketAddress { override def toString = "local" }
+      override def remoteAddress = new SocketAddress { override def toString = "remote" }
+      def close(d: Time) = Ctx.this.close(d)
+      def write(f: Http2Frame) = Ctx.this.write(f)
     }
 
-    lazy val stats = new InMemoryStatsReceiver
+    val stats = new InMemoryStatsReceiver
+  }
+
+  trait ClientCtx extends Ctx {
     def mkStreamTransport(): Netty4StreamTransport[Request, Response] = {
       val tstats = new Netty4StreamTransport.StatsReceiver(stats)
       Netty4StreamTransport.client(id, mkWriter(), tstats)
+    }
+
+    val transport = mkStreamTransport()
+    val rspF = transport.onRecvMessage
+
+    @volatile var receivedMsg = false
+
+    def assertRecvResponse(status: Int, eos: Boolean): Response = {
+      assert(transport.recv({
+        val hs = new DefaultHttp2Headers
+        hs.status(status.toString)
+        new DefaultHttp2HeadersFrame(hs, eos).setStreamId(id)
+      }))
+      eventually { assert(rspF.isDefined) }
+      receivedMsg = true
+      val rsp = await(rspF)
+      assert(rsp.status == Status.fromCode(status))
+      assert(rsp.stream.isEmpty == eos)
+      rsp
+    }
+
+    def assertRemoteReset(): Unit = {
+      val f = new DefaultHttp2ResetFrame(Http2Error.CANCEL).setStreamId(id)
+      assert(transport.recv(f))
+      eventually { assert(transport.isClosed) }
+
+      if (!receivedMsg) {
+        eventually { assert(rspF.isDefined) }
+        assert(await(rspF.liftToTry) == Throw(Reset.Cancel))
+      }
+
+      eventually { assert(transport.onReset.isDefined) }
+      assert(await(transport.onReset.liftToTry) == Throw(StreamError.Remote(Reset.Cancel)))
+    }
+
+  }
+
+  trait ServerCtx extends Ctx {
+    def mkStreamTransport(): Netty4StreamTransport[Response, Request] = {
+      val tstats = new Netty4StreamTransport.StatsReceiver(stats)
+      Netty4StreamTransport.server(id, mkWriter(), tstats)
+    }
+
+    val transport = mkStreamTransport()
+    val reqF = transport.onRecvMessage
+
+    @volatile var receivedMsg = false
+
+    def assertRecvRequest(eos: Boolean): Request = {
+      assert(transport.recv({
+        val hs = new DefaultHttp2Headers
+        hs.scheme("testscheme")
+        hs.method("TEST")
+        hs.path("/")
+        hs.authority("auf")
+        new DefaultHttp2HeadersFrame(hs, eos).setStreamId(id)
+      }))
+      eventually { assert(reqF.isDefined) }
+      receivedMsg = true
+      val req = await(reqF)
+      assert(req.scheme == "testscheme")
+      assert(req.method == Method("TEST"))
+      assert(req.path == "/")
+      assert(req.authority == "auf")
+      req
+    }
+
+    def assertRemoteReset(): Unit = {
+      val f = new DefaultHttp2ResetFrame(Http2Error.CANCEL).setStreamId(id)
+      assert(transport.recv(f))
+      eventually { assert(transport.isClosed) }
+
+      if (!receivedMsg) {
+        eventually { assert(reqF.isDefined) }
+        assert(await(reqF.liftToTry) == Throw(Reset.Cancel))
+      }
+
+      eventually { assert(transport.onReset.isDefined) }
+      assert(await(transport.onReset.liftToTry) == Throw(StreamError.Remote(Reset.Cancel)))
     }
   }
 
@@ -49,29 +131,26 @@ class Netty4StreamTransportTest extends FunSuite {
     val ctx = new ClientCtx {}
     import ctx._
 
-    val st = mkStreamTransport()
-    val rspf = st.onRemoteMessage
-    assert(!rspf.isDefined)
+    assert(!rspF.isDefined)
 
-    st.admitRemote(new DefaultHttp2HeadersFrame({
+    transport.recv(new DefaultHttp2HeadersFrame({
       val hs = new DefaultHttp2Headers
       hs.status("222")
       hs
     }))
 
-    assert(rspf.isDefined)
-    val rsp = await(rspf)
-    val endf = rsp.stream.onEnd
-    assert(!endf.isDefined)
-    assert(rsp.status == Status.Cowabunga)
+    assert(rspF.isDefined)
+    val rsp = await(rspF)
+    val endF = rsp.stream.onEnd
+    assert(!endF.isDefined)
     assert(rsp.stream.nonEmpty)
 
     val dataf = rsp.stream.read()
     assert(!dataf.isDefined)
 
     val buf = Buf.Utf8("space ghost coast to coast")
-    st.admitRemote(new DefaultHttp2DataFrame(BufAsByteBuf.Owned(buf)).setStreamId(id))
-    st.admitRemote({
+    transport.recv(new DefaultHttp2DataFrame(BufAsByteBuf.Owned(buf)).setStreamId(id))
+    transport.recv({
       val hs = new DefaultHttp2Headers
       hs.set("trailers", "yea")
       new DefaultHttp2HeadersFrame(hs, true).setStreamId(id)
@@ -94,240 +173,160 @@ class Netty4StreamTransportTest extends FunSuite {
     }
   }
 
-  test("client: upstream reset while waiting on downstream response") {
+  test("client: local reset while waiting on remote response") {
     val ctx = new ClientCtx {}
     import ctx._
 
-    val st = mkStreamTransport()
-    val rspF = st.onRemoteMessage
     val reqStream = Stream.empty()
-    await(st.write(Request("http", Method.Get, "host", "/path", reqStream)))
-    assert(!st.onReset.isDefined)
+    await(transport.send(Request("http", Method.Get, "host", "/path", reqStream)))
+    assert(!transport.onReset.isDefined)
 
     reqStream.reset(Reset.Cancel)
 
     eventually { assert(rspF.isDefined) }
     assert(await(rspF.liftToTry) == Throw(Reset.Cancel))
 
-    eventually { assert(st.onReset.isDefined) }
-    assert(await(st.onReset.liftToTry) == Throw(StreamError.Local(Reset.Cancel)))
-    assert(st.isClosed)
+    eventually { assert(transport.onReset.isDefined) }
+    assert(await(transport.onReset.liftToTry) == Throw(StreamError.Local(Reset.Cancel)))
+    assert(transport.isClosed)
 
     assert(!closed.get)
   }
 
-  test("client: upstream reset while request and response streams are open") {
+  test("client: local reset while streams is fully open") {
     val ctx = new ClientCtx {}
     import ctx._
 
-    val st = mkStreamTransport()
-    val rspF = st.onRemoteMessage
     val reqStream = Stream()
-    await(st.write(Request("http", Method.Get, "host", "/path", reqStream)))
+    await(transport.send(Request("http", Method.Get, "host", "/path", reqStream)))
     assert(!rspF.isDefined)
 
-    assert(st.admitRemote({
+    assert(transport.recv({
       val hs = new DefaultHttp2Headers
       hs.status("200")
       new DefaultHttp2HeadersFrame(hs, false).setStreamId(id)
     }))
     eventually { assert(rspF.isDefined) }
     val rsp = await(rspF)
-    assert(rsp.status == Status.Ok)
-    assert(rsp.stream.nonEmpty)
-    assert(!st.isClosed)
-    assert(!st.onReset.isDefined)
+    assert(!transport.isClosed)
+    assert(!transport.onReset.isDefined)
 
     reqStream.reset(Reset.Cancel)
 
-    eventually { assert(st.onReset.isDefined) }
-    assert(await(st.onReset.liftToTry) == Throw(StreamError.Local(Reset.Cancel)))
-    assert(st.isClosed)
+    eventually { assert(transport.onReset.isDefined) }
+    assert(await(transport.onReset.liftToTry) == Throw(StreamError.Local(Reset.Cancel)))
+    assert(transport.isClosed)
 
     assert(!closed.get)
   }
 
-  test("client: upstream reset after response complete") {
+  test("client: local reset with remote half closed") {
     val ctx = new ClientCtx {}
     import ctx._
 
-    val st = mkStreamTransport()
-    val rspF = st.onRemoteMessage
     assert(!rspF.isDefined)
-    assert(st.admitRemote({
+    assert(transport.recv({
       val hs = new DefaultHttp2Headers
       hs.status("200")
       new DefaultHttp2HeadersFrame(hs, true).setStreamId(id)
     }))
     assert(rspF.isDefined)
     val rsp = await(rspF)
-    assert(rsp.status == Status.Ok)
-    assert(rsp.stream.isEmpty)
-    assert(!st.onReset.isDefined)
-    assert(!st.isClosed)
+    assert(!transport.onReset.isDefined)
+    assert(!transport.isClosed)
 
     val reqStream = Stream()
-    val streamF = await(st.write(Request("http", Method.Get, "host", "/path", reqStream)))
+    val streamF = await(transport.send(Request("http", Method.Get, "host", "/path", reqStream)))
     await(reqStream.write(Frame.Data(Buf.Utf8("upshut"), eos = false)))
     assert(!streamF.isDefined)
-    assert(!st.isClosed)
-    assert(!st.onReset.isDefined)
+    assert(!transport.isClosed)
+    assert(!transport.onReset.isDefined)
 
     reqStream.reset(Reset.InternalError)
     assert(await(streamF.liftToTry) == Throw(StreamError.Local(Reset.InternalError)))
-    assert(await(st.onReset.liftToTry) == Throw(StreamError.Local(Reset.InternalError)))
-    assert(st.isClosed)
+    assert(await(transport.onReset.liftToTry) == Throw(StreamError.Local(Reset.InternalError)))
+    assert(transport.isClosed)
     assert(!closed.get)
   }
 
-  test("client: downstream reset before response") {
+  test("client: local reset before remote message") {
     val ctx = new ClientCtx {}
     import ctx._
 
-    val st = mkStreamTransport()
-    val rspF = st.onRemoteMessage
-    await(st.write(Request("http", Method.Get, "host", "/path", Stream.empty())))
+    val localStream = Stream.empty()
+    await(transport.send(Request("http", Method.Get, "host", "/path", localStream)))
     assert(!rspF.isDefined)
-    assert(!st.isClosed)
-    assert(!st.onReset.isDefined)
+    assert(!transport.isClosed)
+    assert(!transport.onReset.isDefined)
 
-    assert(st.admitRemote(new DefaultHttp2ResetFrame(Http2Error.CANCEL).setStreamId(id)))
-    assert(rspF.isDefined)
-    assert(await(rspF.liftToTry) == Throw(Reset.Cancel))
-    assert(st.isClosed)
-    assert(st.onReset.isDefined)
-    assert(await(st.onReset.liftToTry) == Throw(StreamError.Remote(Reset.Cancel)))
+    assertRemoteReset()
     assert(!closed.get)
   }
 
-  test("client: downstream reset while streaming response") {
+  test("client: remote reset before remote message") {
     val ctx = new ClientCtx {}
     import ctx._
 
-    val st = mkStreamTransport()
-    val rspF = st.onRemoteMessage
-    await(st.write(Request("http", Method.Get, "host", "/path", Stream.empty())))
+    await(transport.send(Request("http", Method.Get, "host", "/path", Stream.empty())))
+    assert(!rspF.isDefined)
+    assert(!transport.isClosed)
+    assert(!transport.onReset.isDefined)
+
+    assertRemoteReset()
+    assert(!closed.get)
+  }
+
+  test("client: remote reset while local half closed") {
+    val ctx = new ClientCtx {}
+    import ctx._
+
+    await(transport.send(Request("http", Method.Get, "host", "/path", Stream.empty())))
     assert(!rspF.isDefined)
 
-    assert(st.admitRemote({
-      val hs = new DefaultHttp2Headers
-      hs.status("200")
-      new DefaultHttp2HeadersFrame(hs, false).setStreamId(id)
-    }))
-    eventually { assert(rspF.isDefined) }
-    val rsp = await(rspF)
-    assert(rsp.status == Status.Ok)
-    assert(rsp.stream.nonEmpty)
-    assert(!st.onReset.isDefined)
-    assert(!st.isClosed)
+    val rsp = assertRecvResponse(200, eos = false)
+    assert(!transport.onReset.isDefined)
+    assert(!transport.isClosed)
 
     val readF = rsp.stream.read()
     assert(!readF.isDefined)
 
-    assert(st.admitRemote(new DefaultHttp2ResetFrame(Http2Error.CANCEL).setStreamId(id)))
-
-    eventually { assert(st.onReset.isDefined) }
-    assert(await(st.onReset.liftToTry) == Throw(StreamError.Remote(Reset.Cancel)))
-    assert(st.isClosed)
-
+    assertRemoteReset()
     eventually { assert(readF.isDefined) }
     assert(await(readF.liftToTry) == Throw(Reset.Cancel))
-
     assert(!closed.get)
   }
 
-  test("client: downstream reset while streaming request") {
+  test("client: remote reset while remote half closed") {
     val ctx = new ClientCtx {}
     import ctx._
 
-    val st = mkStreamTransport()
-    val rspF = st.onRemoteMessage
     val reqStream = Stream()
-    await(st.write(Request("http", Method.Get, "host", "/path", reqStream)))
+    await(transport.send(Request("http", Method.Get, "host", "/path", reqStream)))
     assert(!rspF.isDefined)
 
-    assert(st.admitRemote({
-      val hs = new DefaultHttp2Headers
-      hs.status("200")
-      new DefaultHttp2HeadersFrame(hs, true).setStreamId(id)
-    }))
-    eventually { assert(rspF.isDefined) }
-    val rsp = await(rspF)
-    assert(rsp.status == Status.Ok)
-    assert(rsp.stream.isEmpty)
-    assert(!st.onReset.isDefined)
-    assert(!st.isClosed)
+    val rsp = assertRecvResponse(200, eos = false)
+    assert(!transport.onReset.isDefined)
+    assert(!transport.isClosed)
 
     val readF = rsp.stream.read()
     assert(!readF.isDefined)
 
-    assert(st.admitRemote(new DefaultHttp2ResetFrame(Http2Error.CANCEL).setStreamId(id)))
-
-    eventually { assert(st.onReset.isDefined) }
-    assert(await(st.onReset.liftToTry) == Throw(StreamError.Remote(Reset.Cancel)))
-    assert(st.isClosed)
-
+    assertRemoteReset()
     eventually { assert(readF.isDefined) }
     assert(await(readF.liftToTry) == Throw(Reset.Cancel))
-
     assert(!closed.get)
-  }
-
-  trait ServerCtx {
-    val id = 7
-
-    val closed = new AtomicBoolean(false)
-    def close(d: Time) =
-      if (closed.compareAndSet(false, true)) Future.Unit
-      else Future.exception(new Exception("double close"))
-
-    var written = Queue.empty[Http2Frame]
-    def write(f: Http2Frame) = synchronized {
-      written = written :+ f
-      Future.Unit
-    }
-
-    def mkWriter() = new Netty4H2Writer {
-      override def localAddress = new SocketAddress { override def toString = "server" }
-      override def remoteAddress = new SocketAddress { override def toString = "client" }
-      def close(d: Time) = ServerCtx.this.close(d)
-      def write(f: Http2Frame) = ServerCtx.this.write(f)
-    }
-
-    lazy val stats = new InMemoryStatsReceiver
-    def mkStreamTransport(): Netty4StreamTransport[Response, Request] = {
-      val tstats = new Netty4StreamTransport.StatsReceiver(stats)
-      Netty4StreamTransport.server(id, mkWriter(), tstats)
-    }
   }
 
   test("server: provides a remote request") {
     val ctx = new ServerCtx {}
     import ctx._
 
-    val st = mkStreamTransport()
-    val reqf = st.onRemoteMessage
-    assert(!reqf.isDefined)
+    assert(!reqF.isDefined)
 
-    assert(st.admitRemote({
-      val hs = new DefaultHttp2Headers
-      hs.scheme("h2")
-      hs.method("SUP")
-      hs.path("/")
-      hs.authority("auf")
-      new DefaultHttp2HeadersFrame(hs, false).setStreamId(id)
-    }))
-
-    assert(reqf.isDefined)
-    val req = await(reqf)
-    assert(req.scheme == "h2")
-    assert(req.method == Method("SUP"))
-    assert(req.path == "/")
-    assert(req.authority == "auf")
-
+    val req = assertRecvRequest(eos = false)
     val d0f = req.stream.read()
     assert(!d0f.isDefined)
-    assert(st.admitRemote({
+    assert(transport.recv({
       val bb = BufAsByteBuf.Owned(Buf.Utf8("data"))
       new DefaultHttp2DataFrame(bb, false).setStreamId(id)
     }))
@@ -342,7 +341,7 @@ class Netty4StreamTransportTest extends FunSuite {
 
     val d1f = req.stream.read()
     assert(!d1f.isDefined)
-    assert(st.admitRemote({
+    assert(transport.recv({
       val hs = new DefaultHttp2Headers
       hs.set("trailers", "chya")
       new DefaultHttp2HeadersFrame(hs, true)
@@ -361,8 +360,6 @@ class Netty4StreamTransportTest extends FunSuite {
     val ctx = new ServerCtx {}
     import ctx._
 
-    val st = mkStreamTransport()
-
     val rspStreamQ = new AsyncQueue[Frame]
     val rspStream = Stream(rspStreamQ)
     val rsp = {
@@ -371,7 +368,7 @@ class Netty4StreamTransportTest extends FunSuite {
       Netty4Message.Response(hs, rspStream)
     }
 
-    val endF = await(st.write(rsp))
+    val endF = await(transport.send(rsp))
     assert(!endF.isDefined)
 
     ctx.synchronized {
@@ -405,190 +402,104 @@ class Netty4StreamTransportTest extends FunSuite {
     }
   }
 
-  test("server: downstream reset while request and response streams are open") {
+  test("server: local reset while fully open") {
     val ctx = new ServerCtx {}
     import ctx._
 
-    val st = mkStreamTransport()
-    val reqF = st.onRemoteMessage
-    assert(!reqF.isDefined)
-
-    assert(st.admitRemote({
-      val hs = new DefaultHttp2Headers
-      hs.scheme("h2")
-      hs.method("SUP")
-      hs.path("/")
-      hs.authority("auf")
-      new DefaultHttp2HeadersFrame(hs, false).setStreamId(id)
-    }))
-    eventually { assert(reqF.isDefined) }
+    val req = assertRecvRequest(eos = false)
 
     val rspStream = Stream()
-    val rspEndF = await(st.write(Response(Status.Ok, rspStream)))
-    assert(!st.isClosed)
-    assert(!st.onReset.isDefined)
+    val rspEndF = await(transport.send(Response(Status.Ok, rspStream)))
+    assert(!transport.isClosed)
+    assert(!transport.onReset.isDefined)
     assert(!rspEndF.isDefined)
 
     rspStream.reset(Reset.Cancel)
-    eventually { assert(st.onReset.isDefined) }
-    assert(await(st.onReset.liftToTry) == Throw(StreamError.Local(Reset.Cancel)))
-    assert(st.isClosed)
+    eventually { assert(transport.onReset.isDefined) }
+    assert(await(transport.onReset.liftToTry) == Throw(StreamError.Local(Reset.Cancel)))
+    assert(transport.isClosed)
 
     assert(!closed.get)
   }
 
-  test("server: downstream reset while streaming response") {
+  test("server: local reset while remote half closed") {
     val ctx = new ServerCtx {}
     import ctx._
 
-    val st = mkStreamTransport()
-    val reqF = st.onRemoteMessage
-    assert(!reqF.isDefined)
-
-    assert(st.admitRemote({
-      val hs = new DefaultHttp2Headers
-      hs.scheme("h2")
-      hs.method("SUP")
-      hs.path("/")
-      hs.authority("auf")
-      new DefaultHttp2HeadersFrame(hs, false).setStreamId(id)
-    }))
-    eventually { assert(reqF.isDefined) }
+    val req = assertRecvRequest(eos = false)
 
     val rspStream = Stream.empty()
-    await(st.write(Response(Status.Ok, rspStream)))
+    await(transport.send(Response(Status.Ok, rspStream)))
     ctx.synchronized {
       assert(written.length == 1)
       assert(written.last.isInstanceOf[Http2HeadersFrame])
     }
-    assert(!st.isClosed)
-    assert(!st.onReset.isDefined)
+    assert(!transport.isClosed)
+    assert(!transport.onReset.isDefined)
 
     rspStream.reset(Reset.Refused)
-    eventually { assert(st.onReset.isDefined) }
-    assert(await(st.onReset.liftToTry) == Throw(StreamError.Local(Reset.Refused)))
-    assert(st.isClosed)
+    eventually { assert(transport.onReset.isDefined) }
+    assert(await(transport.onReset.liftToTry) == Throw(StreamError.Local(Reset.Refused)))
+    assert(transport.isClosed)
 
     assert(!closed.get)
   }
 
-  test("server: downstream reset while streaming request") {
+  test("server: local reset while local half closed") {
     val ctx = new ServerCtx {}
     import ctx._
 
-    val st = mkStreamTransport()
-    val reqF = st.onRemoteMessage
-    assert(!reqF.isDefined)
+    val req = assertRecvRequest(eos = false)
 
-    assert(st.admitRemote({
-      val hs = new DefaultHttp2Headers
-      hs.scheme("h2")
-      hs.method("SUP")
-      hs.path("/")
-      hs.authority("auf")
-      new DefaultHttp2HeadersFrame(hs, true).setStreamId(id)
-    }))
-    eventually { assert(reqF.isDefined) }
-
-    val rspStream = Stream()
-    await(st.write(Response(Status.Ok, rspStream)))
-    assert(!st.isClosed)
-    assert(!st.onReset.isDefined)
+    val rspStream = Stream.empty()
+    await(transport.send(Response(Status.Ok, rspStream)))
+    assert(!transport.isClosed)
+    assert(!transport.onReset.isDefined)
 
     rspStream.reset(Reset.InternalError)
-    eventually { assert(st.onReset.isDefined) }
-    assert(await(st.onReset.liftToTry) == Throw(StreamError.Local(Reset.InternalError)))
-    assert(st.isClosed)
+    eventually { assert(transport.onReset.isDefined) }
+    assert(await(transport.onReset.liftToTry) == Throw(StreamError.Local(Reset.InternalError)))
+    assert(transport.isClosed)
 
     assert(!closed.get)
   }
 
-  test("server: upstream reset before response") {
+  test("server: remote reset before local message") {
     val ctx = new ServerCtx {}
     import ctx._
 
-    val st = mkStreamTransport()
-    val reqF = st.onRemoteMessage
-
-    assert(st.admitRemote({
-      val hs = new DefaultHttp2Headers
-      hs.scheme("h2")
-      hs.method("SUP")
-      hs.path("/")
-      hs.authority("auf")
-      new DefaultHttp2HeadersFrame(hs, true).setStreamId(id)
-    }))
-    eventually { assert(reqF.isDefined) }
+    val req = assertRecvRequest(eos = false)
 
     val rspStream = Stream()
-    await(st.write(Response(Status.Ok, rspStream)))
-    assert(!st.isClosed)
-    assert(!st.onReset.isDefined)
-
-    assert(st.admitRemote(new DefaultHttp2ResetFrame(Http2Error.CANCEL).setStreamId(id)))
-    eventually { assert(st.onReset.isDefined) }
-    assert(await(st.onReset.liftToTry) == Throw(StreamError.Remote(Reset.Cancel)))
-    assert(st.isClosed)
-
+    await(transport.send(Response(Status.Ok, rspStream)))
+    assert(!transport.isClosed)
+    assert(!transport.onReset.isDefined)
+    assertRemoteReset()
     assert(!closed.get)
   }
 
-  test("server: upstream reset while streaming response") {
+  test("server: remote reset while remote half closed") {
     val ctx = new ServerCtx {}
     import ctx._
 
-    val st = mkStreamTransport()
-    val reqF = st.onRemoteMessage
-
-    assert(st.admitRemote({
-      val hs = new DefaultHttp2Headers
-      hs.scheme("h2")
-      hs.method("SUP")
-      hs.path("/")
-      hs.authority("auf")
-      new DefaultHttp2HeadersFrame(hs, true).setStreamId(id)
-    }))
-    eventually { assert(reqF.isDefined) }
-
+    val req = assertRecvRequest(eos = false)
     val rspStream = Stream()
-    await(st.write(Response(Status.Ok, rspStream)))
-    assert(!st.isClosed)
-    assert(!st.onReset.isDefined)
-
-    assert(st.admitRemote(new DefaultHttp2ResetFrame(Http2Error.CANCEL).setStreamId(id)))
-    eventually { assert(st.onReset.isDefined) }
-    assert(await(st.onReset.liftToTry) == Throw(StreamError.Remote(Reset.Cancel)))
-    assert(st.isClosed)
-
+    await(transport.send(Response(Status.Ok, rspStream)))
+    assert(!transport.isClosed)
+    assert(!transport.onReset.isDefined)
+    assertRemoteReset()
     assert(!closed.get)
   }
 
-  test("server: upstream reset while streaming request") {
+  test("server: remote reset while local half closed") {
     val ctx = new ServerCtx {}
     import ctx._
 
-    val st = mkStreamTransport()
-    val reqF = st.onRemoteMessage
-
-    assert(st.admitRemote({
-      val hs = new DefaultHttp2Headers
-      hs.scheme("h2")
-      hs.method("SUP")
-      hs.path("/")
-      hs.authority("auf")
-      new DefaultHttp2HeadersFrame(hs, false).setStreamId(id)
-    }))
-    eventually { assert(reqF.isDefined) }
-
-    await(st.write(Response(Status.Ok, Stream.empty())))
-    assert(!st.isClosed)
-    assert(!st.onReset.isDefined)
-
-    assert(st.admitRemote(new DefaultHttp2ResetFrame(Http2Error.CANCEL).setStreamId(id)))
-    eventually { assert(st.onReset.isDefined) }
-    assert(await(st.onReset.liftToTry) == Throw(StreamError.Remote(Reset.Cancel)))
-    assert(st.isClosed)
-
+    val req = assertRecvRequest(eos = false)
+    await(transport.send(Response(Status.Ok, Stream.empty())))
+    assert(!transport.isClosed)
+    assert(!transport.onReset.isDefined)
+    assertRemoteReset()
     assert(!closed.get)
   }
 


### PR DESCRIPTION
Netty4StreamTransport is a bit dense, so this is an initial attempt to clarify
it somewhat.

The directionality in the bidirectional stream was easy to lose track of --
I've renamed `LocalMsg` and `RemoteMsg` to _SendMsg_ and _RecvMsg_
respectively; and the method names `write` and `admitRemote` have been renamed
_send_ and _recv_.

The stream `recv`s `RecvMsg`s from the _remote_ and `send`s `SendMsg`s from the
_local_ side of the stream.

I've tried to add commentary around Netty4StreamTransport's internal state
machine.  In trying to clarify this, I improved the scoping of the `RecvMsg`
promise by removing it from the instance scope and protecting it within the
`RemotePending` remote state.

Finally, I've extracted a bunch of common code from within
Netty4StreamTransportTest so the tests are easier to read.