### PR TITLE
Add headerPath config option to header identifier

### DIFF
--- a/linkerd/docs/protocol-http.md
+++ b/linkerd/docs/protocol-http.md
@@ -172,7 +172,8 @@ urlPath | N/A | A path from the URL whose number of segments is set in the ident
 kind: `io.l5d.header`
 
 With this identifier, HTTP requests are turned into names based only on the
-value of an HTTP header.
+value of an HTTP header.  The value of the HTTP header is interpreted as a path and therefore must
+start with a `/`.
 
 #### Identifier Configuration:
 
@@ -192,21 +193,60 @@ routers:
 Key | Default Value | Description
 --- | ------------- | -----------
 header | `l5d-name` | The name of the HTTP header to use
-headerPath | `true` | If true, parse the header value as a full path.  If false, parse the header value as a single path segment.
 
 #### Identifier Path Parameters:
 
 > Dtab Path Format
 
 ```
-  / dstPrefix [*headerValue ] (if headerPath is true)
-  / dstPrefix / [headerValue] (if headerPath is false)
+  / dstPrefix [*headerValue ]
 ```
 
 Key | Default Value | Description
 --- | ------------- | -----------
 dstPrefix | `http` | The `dstPrefix` as set in the routers block.
 headerValue | N/A | The value of the HTTP header as a path.
+
+<a name="header-token-identifier"></a>
+### Header Token Identifier
+
+kind: `io.l5d.header.token`
+
+With this identifier, HTTP requests are turned into names based only on the
+value of an HTTP header.  The name is a path with one segment and the value of that segment is
+taken from the HTTP header.
+
+#### Identifier Configuration:
+
+> With this configuration, the value of the `my-header` HTTP header will be used
+as the logical name.
+
+```yaml
+routers:
+- protocol: http
+  identifier:
+    kind: io.l5d.header.token
+    header: my-header
+  servers:
+  - port: 5000
+```
+
+Key | Default Value | Description
+--- | ------------- | -----------
+header | `Host` | The name of the HTTP header to use
+
+#### Identifier Path Parameters:
+
+> Dtab Path Format
+
+```
+  / dstPrefix / [headerValue]
+```
+
+Key | Default Value | Description
+--- | ------------- | -----------
+dstPrefix | `http` | The `dstPrefix` as set in the routers block.
+headerValue | N/A | The value of the HTTP header as a path segment.
 
 <a name="static-identifier"></a>
 ### Static Identifier

--- a/linkerd/docs/protocol-http.md
+++ b/linkerd/docs/protocol-http.md
@@ -84,7 +84,7 @@ With this identifier, HTTP requests are turned into logical names using a
 combination of `Host` header, method, and (optionally) URI. `Host`
 header value is lower-cased as per `RFC 2616`.
 
-#### Namer Configuration:
+#### Identifier Configuration:
 
 > Configuration example
 
@@ -99,7 +99,7 @@ Key | Default Value | Description
 httpUriInDst | `false` | If `true` http paths are appended to destinations. This allows a form of path-prefix routing. This option is **not** recommended as performance implications may be severe; Use the [path identifier](#path-identifier) instead.
 
 
-#### Namer Path Parameters:
+#### Identifier Path Parameters:
 
 > Dtab Path Format for HTTP/1.1
 
@@ -129,7 +129,7 @@ With this identifier, HTTP requests are turned into names based only on the
 path component of the URL, using a configurable number of "/" separated
 segments from the start of their HTTP path.
 
-#### Namer Configuration:
+#### Identifier Configuration:
 
 > With this configuration, a request to `:5000/true/love/waits.php` will be
 mapped to `/http/true/love` and will be routed based on this name by the
@@ -153,7 +153,7 @@ Key | Default Value | Description
 segments | `1` | Number of segments from the path that are appended to destinations.
 consume | `false` | Whether to additionally strip the consumed segments from the HTTP request proxied to the final destination service. This only affects the request sent to the destination service; it does not affect identification or routing.
 
-#### Namer Path Parameters:
+#### Identifier Path Parameters:
 
 > Dtab Path Format
 
@@ -172,10 +172,9 @@ urlPath | N/A | A path from the URL whose number of segments is set in the ident
 kind: `io.l5d.header`
 
 With this identifier, HTTP requests are turned into names based only on the
-value of an HTTP header.  If the header value is a valid path, that path is
-used.  Otherwise, the header value is converted to a path with one path segment.
+value of an HTTP header.
 
-#### Namer Configuration:
+#### Identifier Configuration:
 
 > With this configuration, the value of the `my-header` HTTP header will be used
 as the logical name.
@@ -193,13 +192,15 @@ routers:
 Key | Default Value | Description
 --- | ------------- | -----------
 header | `l5d-name` | The name of the HTTP header to use
+headerPath | `true` | If true, parse the header value as a full path.  If false, parse the header value as a single path segment.
 
-#### Namer Path Parameters:
+#### Identifier Path Parameters:
 
 > Dtab Path Format
 
 ```
-  / dstPrefix [/ *headerValue ]
+  / dstPrefix [*headerValue ] (if headerPath is true)
+  / dstPrefix / [headerValue] (if headerPath is false)
 ```
 
 Key | Default Value | Description
@@ -214,7 +215,7 @@ kind: `io.l5d.static`
 
 This identifier always assigns the same static name to all requests.
 
-#### Namer Configuration:
+#### Identifier Configuration:
 
 ```yaml
 routers:
@@ -228,7 +229,7 @@ Key  | Default Value | Description
 ---- | ------------- | -----------
 path | _required_    | The name to assign to all requests
 
-#### Namer Path Parameters
+#### Identifier Path Parameters
 
 > Dtab Path Format
 

--- a/linkerd/examples/http.yaml
+++ b/linkerd/examples/http.yaml
@@ -9,10 +9,12 @@ namers:
 routers:
 - protocol: http
   label: netty3
+  identifier:
+    kind: io.l5d.header
   baseDtab: |
     /srv => /#/io.l5d.fs;
     /host => /srv;
-    /http/1.1/* => /host;
+    /http/* => /host;
   servers:
   - port: 4140
     ip: 0.0.0.0
@@ -25,10 +27,12 @@ routers:
 
 - protocol: http
   label: netty4
+  identifier:
+    kind: io.l5d.header.token
   baseDtab: |
     /srv => /#/io.l5d.fs;
     /host => /srv;
-    /http/1.1/* => /host;
+    /http => /host;
   servers:
   - port: 4141
     ip: 0.0.0.0

--- a/linkerd/protocol/http/src/main/resources/META-INF/services/io.buoyant.linkerd.IdentifierInitializer
+++ b/linkerd/protocol/http/src/main/resources/META-INF/services/io.buoyant.linkerd.IdentifierInitializer
@@ -1,4 +1,5 @@
 io.buoyant.linkerd.protocol.http.HeaderIdentifierInitializer
+io.buoyant.linkerd.protocol.http.HeaderTokenIdentifierInitializer
 io.buoyant.linkerd.protocol.http.MethodAndHostIdentifierInitializer
 io.buoyant.linkerd.protocol.http.PathIdentifierInitializer
 io.buoyant.linkerd.protocol.http.StaticIdentifierInitializer

--- a/linkerd/protocol/http/src/main/scala/io/buoyant/linkerd/protocol/http/HeaderIdentifierConfig.scala
+++ b/linkerd/protocol/http/src/main/scala/io/buoyant/linkerd/protocol/http/HeaderIdentifierConfig.scala
@@ -20,8 +20,7 @@ object HeaderIdentifierConfig {
 }
 
 case class HeaderIdentifierConfig(
-  header: Option[String] = None,
-  headerPath: Option[Boolean] = None
+  header: Option[String] = None
 ) extends HttpIdentifierConfig {
 
   @JsonIgnore
@@ -31,7 +30,7 @@ case class HeaderIdentifierConfig(
   ) = HeaderIdentifier(
     prefix,
     header.getOrElse(HeaderIdentifierConfig.defaultHeader),
-    headerPath.getOrElse(true), // TODO: consider defaulting this to false in the future
+    headerPath = true,
     baseDtab
   )
 }

--- a/linkerd/protocol/http/src/main/scala/io/buoyant/linkerd/protocol/http/HeaderIdentifierConfig.scala
+++ b/linkerd/protocol/http/src/main/scala/io/buoyant/linkerd/protocol/http/HeaderIdentifierConfig.scala
@@ -19,8 +19,10 @@ object HeaderIdentifierConfig {
   val defaultHeader = Headers.Prefix + "name"
 }
 
-class HeaderIdentifierConfig extends HttpIdentifierConfig {
-  var header: Option[String] = None
+case class HeaderIdentifierConfig(
+  header: Option[String] = None,
+  headerPath: Option[Boolean] = None
+) extends HttpIdentifierConfig {
 
   @JsonIgnore
   override def newIdentifier(
@@ -29,6 +31,7 @@ class HeaderIdentifierConfig extends HttpIdentifierConfig {
   ) = HeaderIdentifier(
     prefix,
     header.getOrElse(HeaderIdentifierConfig.defaultHeader),
+    headerPath.getOrElse(true), // TODO: consider defaulting this to false in the future
     baseDtab
   )
 }

--- a/linkerd/protocol/http/src/main/scala/io/buoyant/linkerd/protocol/http/HeaderTokenIdentifierConfig.scala
+++ b/linkerd/protocol/http/src/main/scala/io/buoyant/linkerd/protocol/http/HeaderTokenIdentifierConfig.scala
@@ -1,0 +1,35 @@
+package io.buoyant.linkerd.protocol.http
+
+import com.fasterxml.jackson.annotation.JsonIgnore
+import com.twitter.finagle.{Dtab, Path}
+import io.buoyant.linkerd.IdentifierInitializer
+import io.buoyant.linkerd.protocol.HttpIdentifierConfig
+import io.buoyant.router.http.HeaderIdentifier
+
+class HeaderTokenIdentifierInitializer extends IdentifierInitializer {
+  val configClass = classOf[HeaderTokenIdentifierConfig]
+  override val configId = HeaderTokenIdentifierConfig.kind
+}
+
+object HeaderTokenIdentifierInitializer extends HeaderTokenIdentifierInitializer
+
+object HeaderTokenIdentifierConfig {
+  val kind = "io.l5d.header.token"
+  val defaultHeader = "Host"
+}
+
+case class HeaderTokenIdentifierConfig(
+  header: Option[String] = None
+) extends HttpIdentifierConfig {
+
+  @JsonIgnore
+  override def newIdentifier(
+    prefix: Path,
+    baseDtab: () => Dtab = () => Dtab.base
+  ) = HeaderIdentifier(
+    prefix,
+    header.getOrElse(HeaderTokenIdentifierConfig.defaultHeader),
+    headerPath = false,
+    baseDtab
+  )
+}

--- a/linkerd/protocol/http/src/test/scala/io/buoyant/linkerd/protocol/http/HeaderIdentifierConfigTest.scala
+++ b/linkerd/protocol/http/src/test/scala/io/buoyant/linkerd/protocol/http/HeaderIdentifierConfigTest.scala
@@ -54,4 +54,21 @@ class HeaderIdentifierConfigTest extends FunSuite with Awaits {
     )
   }
 
+  test("header segment") {
+    val yaml = s"""
+                  |kind: io.l5d.header
+                  |headerPath: false
+      """.stripMargin
+
+    val mapper = Parser.objectMapper(yaml, Iterable(Seq(HeaderIdentifierInitializer)))
+    val config = mapper.readValue[HttpIdentifierConfig](yaml).asInstanceOf[HeaderIdentifierConfig]
+    val identifier = config.newIdentifier(Path.empty)
+    val req = Request()
+    req.headerMap.set("l5d-name", "foo")
+    assert(
+      await(identifier(req)).asInstanceOf[IdentifiedRequest[Request]].dst ==
+        Dst.Path(Path.read("/foo"))
+    )
+  }
+
 }

--- a/linkerd/protocol/http/src/test/scala/io/buoyant/linkerd/protocol/http/HeaderTokenIdentifierConfigTest.scala
+++ b/linkerd/protocol/http/src/test/scala/io/buoyant/linkerd/protocol/http/HeaderTokenIdentifierConfigTest.scala
@@ -11,46 +11,46 @@ import io.buoyant.router.RoutingFactory.IdentifiedRequest
 import io.buoyant.test.Awaits
 import org.scalatest.FunSuite
 
-class HeaderIdentifierConfigTest extends FunSuite with Awaits {
+class HeaderTokenIdentifierConfigTest extends FunSuite with Awaits {
   test("sanity") {
     // ensure it doesn't totally blowup
-    val _ = new HeaderIdentifierConfig().newIdentifier(Path.empty)
+    val _ = new HeaderTokenIdentifierConfig().newIdentifier(Path.empty)
   }
 
   test("service registration") {
-    assert(LoadService[IdentifierInitializer].exists(_.isInstanceOf[HeaderIdentifierInitializer]))
+    assert(LoadService[IdentifierInitializer].exists(_.isInstanceOf[HeaderTokenIdentifierInitializer]))
   }
 
   test("parse config") {
     val yaml = s"""
-                  |kind: io.l5d.header
+                  |kind: io.l5d.header.token
                   |header: my-header
       """.stripMargin
 
-    val mapper = Parser.objectMapper(yaml, Iterable(Seq(HeaderIdentifierInitializer)))
-    val config = mapper.readValue[HttpIdentifierConfig](yaml).asInstanceOf[HeaderIdentifierConfig]
+    val mapper = Parser.objectMapper(yaml, Iterable(Seq(HeaderTokenIdentifierInitializer)))
+    val config = mapper.readValue[HttpIdentifierConfig](yaml).asInstanceOf[HeaderTokenIdentifierConfig]
     val identifier = config.newIdentifier(Path.empty)
     val req = Request()
-    req.headerMap.set("my-header", "/one/two/three")
+    req.headerMap.set("my-header", "foo")
     assert(
       await(identifier(req)).asInstanceOf[IdentifiedRequest[Request]].dst ==
-        Dst.Path(Path.read("/one/two/three"))
+        Dst.Path(Path.read("/foo"))
     )
   }
 
   test("default header") {
     val yaml = s"""
-                  |kind: io.l5d.header
+                  |kind: io.l5d.header.token
       """.stripMargin
 
-    val mapper = Parser.objectMapper(yaml, Iterable(Seq(HeaderIdentifierInitializer)))
-    val config = mapper.readValue[HttpIdentifierConfig](yaml).asInstanceOf[HeaderIdentifierConfig]
+    val mapper = Parser.objectMapper(yaml, Iterable(Seq(HeaderTokenIdentifierInitializer)))
+    val config = mapper.readValue[HttpIdentifierConfig](yaml).asInstanceOf[HeaderTokenIdentifierConfig]
     val identifier = config.newIdentifier(Path.empty)
     val req = Request()
-    req.headerMap.set("l5d-name", "/one/two/three")
+    req.headerMap.set("Host", "foo")
     assert(
       await(identifier(req)).asInstanceOf[IdentifiedRequest[Request]].dst ==
-        Dst.Path(Path.read("/one/two/three"))
+        Dst.Path(Path.read("/foo"))
     )
   }
 }

--- a/router/http/src/main/scala/io/buoyant/router/http/HeaderIdentifier.scala
+++ b/router/http/src/main/scala/io/buoyant/router/http/HeaderIdentifier.scala
@@ -10,6 +10,7 @@ import io.buoyant.router.RoutingFactory.{UnidentifiedRequest, IdentifiedRequest,
 case class HeaderIdentifier(
   prefix: Path,
   header: String,
+  headerPath: Boolean,
   baseDtab: () => Dtab = () => Dtab.base
 ) extends RoutingFactory.Identifier[Request] {
 
@@ -17,7 +18,7 @@ case class HeaderIdentifier(
     req.headerMap.get(header) match {
       case Some(value) =>
         val identified = Try {
-          val path = Path.read(value)
+          val path = if (headerPath) Path.read(value) else Path.Utf8(value)
           val dst = Dst.Path(prefix ++ path, baseDtab(), Dtab.local)
           new IdentifiedRequest(dst, req)
         }

--- a/router/http/src/test/scala/io/buoyant/router/http/HeaderIdentifierTest.scala
+++ b/router/http/src/test/scala/io/buoyant/router/http/HeaderIdentifierTest.scala
@@ -10,7 +10,7 @@ import org.scalatest.FunSuite
 class HeaderIdentifierTest extends FunSuite with Awaits with Exceptions {
 
   test("use path from header") {
-    val identifier = HeaderIdentifier(Path.Utf8("http"), "my-header")
+    val identifier = HeaderIdentifier(Path.Utf8("http"), "my-header", headerPath = true)
     val req = Request()
     req.headerMap.set("my-header", "/a/b/c")
     assert(
@@ -20,8 +20,18 @@ class HeaderIdentifierTest extends FunSuite with Awaits with Exceptions {
   }
 
   test("header is absent") {
-    val identifier = HeaderIdentifier(Path.Utf8("http"), "my-header")
+    val identifier = HeaderIdentifier(Path.Utf8("http"), "my-header", headerPath = true)
     val req = Request()
     assert(await(identifier(req)).isInstanceOf[UnidentifiedRequest[Request]])
+  }
+
+  test("header segment") {
+    val identifier = HeaderIdentifier(Path.Utf8("http"), "my-header", headerPath = false)
+    val req = Request()
+    req.headerMap.set("my-header", "foo")
+    assert(
+      await(identifier(req)).asInstanceOf[IdentifiedRequest[Request]].dst ==
+        Dst.Path(Path.read("/http/foo"))
+    )
   }
 }


### PR DESCRIPTION
Fixes #719 

If headerPath is true (default), parse the header as a full path.
If headerPath is false, parse the header as a single path segment.