### PR TITLE
marathon: add ip-per-task support

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -2,6 +2,8 @@
 
 * Fix localhost transformer when used on systems with unresolvable hostname.
 * Add `io.l5d.namerd.http` interpreter which uses namerd's streaming HTTP api
+* Marathon:
+  * Support "ip per task" feature
 
 ## 0.8.4 2016-12-05
 

--- a/marathon/src/main/scala/io/buoyant/marathon/v2/AppIdNamer.scala
+++ b/marathon/src/main/scala/io/buoyant/marathon/v2/AppIdNamer.scala
@@ -4,7 +4,6 @@ import com.twitter.finagle.{Addr, Name, Namer, NameTree, Path}
 import com.twitter.finagle.util.DefaultTimer
 import com.twitter.finagle.tracing.Trace
 import com.twitter.util._
-import java.net.SocketAddress
 
 object AppIdNamer {
   object Closed extends Throwable


### PR DESCRIPTION
In marathon 0.14.0 introduced the "ip per task" feature, which very useful  with docker native network solutions (weave, calico or fan). But currently, linkerd marathon integration doesn't know about it and uses only port mapping marathon services. 

This PL adds support "ip per task", which handle `task.ipAddresses` and `app. ipAddress.discovery.ports` fields from marathon responses.