### PR TITLE
Add "originator" router parameter

### DIFF
--- a/linkerd/core/src/main/scala/io/buoyant/linkerd/Router.scala
+++ b/linkerd/core/src/main/scala/io/buoyant/linkerd/Router.scala
@@ -10,13 +10,13 @@ import com.twitter.finagle.naming.NameInterpreter
 import com.twitter.finagle.service._
 import com.twitter.util.{Closable, Duration}
 import io.buoyant.namer.{InterpreterConfig, DefaultInterpreterConfig}
-import io.buoyant.router.{ClassifiedRetries, RoutingFactory}
+import io.buoyant.router.{ClassifiedRetries, Originator, RoutingFactory}
 
 /**
  * A router configuration builder api.
  *
  * Each router must have a [[ProtocolInitializer protocol]] that
- * assists in the parsing and intialization of a router and its
+ * assists in the parsing and initialization of a router and its
  * services.
  *
  * `params` contains all params configured on this router, including
@@ -97,6 +97,7 @@ trait RouterConfig {
 
   var baseDtab: Option[Dtab] = None
   var failFast: Option[Boolean] = None
+  var originator: Option[Boolean] = None
   var timeoutMs: Option[Int] = None
   var dstPrefix: Option[String] = None
 
@@ -183,6 +184,7 @@ trait RouterConfig {
   def routerParams = (Stack.Params.empty + defaultBudget)
     .maybeWith(baseDtab.map(dtab => RoutingFactory.BaseDtab(() => dtab)))
     .maybeWith(failFast.map(FailFastFactory.FailFast(_)))
+    .maybeWith(originator.map(Originator.Param(_)))
     .maybeWith(timeoutMs.map(timeout => TimeoutFilter.Param(timeout.millis)))
     .maybeWith(dstPrefix.map(pfx => RoutingFactory.DstPrefix(Path.read(pfx))))
     .maybeWith(bindingCache.map(_.capacity))

--- a/linkerd/core/src/test/scala/io/buoyant/linkerd/RouterTest.scala
+++ b/linkerd/core/src/test/scala/io/buoyant/linkerd/RouterTest.scala
@@ -6,7 +6,7 @@ import com.twitter.finagle.buoyant.DstBindingFactory
 import com.twitter.finagle.service.TimeoutFilter
 import io.buoyant.config.Parser
 import io.buoyant.namer.{ConfiguredNamersInterpreter, InterpreterInitializer, TestInterpreterInitializer, TestInterpreter}
-import io.buoyant.router.RoutingFactory
+import io.buoyant.router.{Originator, RoutingFactory}
 import io.buoyant.test.Exceptions
 import java.net.InetAddress
 import org.scalatest.FunSuite
@@ -171,5 +171,14 @@ servers:
     assert(capacity.trees == 999)
     assert(capacity.bounds == 998)
     assert(capacity.clients == DstBindingFactory.Capacity.default.clients)
+  }
+
+  test("with originator") {
+    val yaml =
+      """|protocol: plain
+         |originator: true
+         |""".stripMargin
+    val originator = parseConfig(yaml).routerParams[Originator.Param]
+    assert(originator.originator)
   }
 }

--- a/linkerd/docs/routers.md
+++ b/linkerd/docs/routers.md
@@ -23,6 +23,7 @@ routers:
     /host                => /#/io.l5d.fs;
     /walruses/http/1.1/* => /host;
   failFast: false
+  originator: true
   timeoutMs: 10000
   bindingTimeoutMs: 5000
   responseClassifier: io.l5d.nonRetryable5XX
@@ -39,6 +40,7 @@ bindingCache | see [binding cache](#binding-cache) | Binding cache size configur
 client | an empty object | An object of [client params](#basic-client-params).
 dstPrefix | protocol dependent | A path prefix to be used on request destinations.
 failFast | `false` | If `true`, connection failures are punished more aggressively. Should not be used with small destination pools.
+originator | `false` | If `true`, indicates that this router is the first hop for linker-to-linker requests, and reflects that in the router's stats. Useful for deduping linker-to-linker stats.
 interpreter | default interpreter | An [interpreter object](#interpreter) determining what module will be used to process destinations.
 label | the value of *protocol* | The name of the router (in stats and the admin ui)
 response Classifier | `io.l5d.nonRetryable5XX` | A (sometimes protocol-specific) [response classifier](#http-response-classifiers) that determines which responses should be considered failures and, of those, which should be considered [retryable](#retries).

--- a/linkerd/examples/acceptance-test.yaml
+++ b/linkerd/examples/acceptance-test.yaml
@@ -44,6 +44,7 @@ namers:
 routers:
 - protocol: http
   label: int
+  originator: true
   dstPrefix: /http
   interpreter:
     kind: io.l5d.fs
@@ -86,6 +87,7 @@ routers:
 # TODO: test thrift traffic
 - protocol: thrift
   label: /host/thrift-framed
+  originator: true
   baseDtab: |
     /host        => /#/io.l5d.fs;
     /thrift/echo => /host/thrift-framed;
@@ -108,6 +110,7 @@ routers:
 
 - protocol: thrift
   label: /host/thrift-buffered
+  originator: false
   baseDtab: |
     /host   => /#/io.l5d.fs;
     /thrift => /host/thrift-buffered;

--- a/router/core/src/main/scala/io/buoyant/router/Originator.scala
+++ b/router/core/src/main/scala/io/buoyant/router/Originator.scala
@@ -1,0 +1,23 @@
+package io.buoyant.router
+
+import com.twitter.finagle.Stack
+
+/**
+  * Originator.Param is a boolean stack param that is used to configure a
+  * [[io.buoyant.router.Router Router]]. If the param is set to true, it
+  * indicates that the router is the first hop in a linker-to-linker request,
+  * and the router's stats are updated to reflect that.
+  *
+  * @see com.twitter.finagle.Stack.Param
+  */
+object Originator {
+  case class Param(originator: Boolean) {
+    def mk(): (Param, Stack.Param[Param]) =
+      (this, Param.param)
+  }
+
+  object Param {
+    implicit val param: Stack.Param[Param] =
+      Stack.Param(Param(false))
+  }
+}


### PR DESCRIPTION
Adds a new parameter for configuring routers: originator. If the
originator parameter is set to true, it indicates that this router is
the first hop in a linker-to-linker request. Routers that are configured
as originators will emit an additional stat (rt/label/originator == 1.0)
that can be used to deduplicate stats that are produced by 2 different
routers in the process of a serving 1 linker-to-linker request.