### PR TITLE
Reformat scaladoc comment

### DIFF
--- a/router/core/src/main/scala/io/buoyant/router/Originator.scala
+++ b/router/core/src/main/scala/io/buoyant/router/Originator.scala
@@ -3,13 +3,13 @@ package io.buoyant.router
 import com.twitter.finagle.Stack
 
 /**
-  * Originator.Param is a boolean stack param that is used to configure a
-  * [[io.buoyant.router.Router Router]]. If the param is set to true, it
-  * indicates that the router is the first hop in a linker-to-linker request,
-  * and the router's stats are updated to reflect that.
-  *
-  * @see com.twitter.finagle.Stack.Param
-  */
+ * Originator.Param is a boolean stack param that is used to configure a
+ * [[io.buoyant.router.Router Router]]. If the param is set to true, it
+ * indicates that the router is the first hop in a linker-to-linker request,
+ * and the router's stats are updated to reflect that.
+ *
+ * @see com.twitter.finagle.Stack.Param
+ */
 object Originator {
   case class Param(originator: Boolean) {
     def mk(): (Param, Stack.Param[Param]) =


### PR DESCRIPTION
I introduced a comment formatting issue as part of #849 (sorry!), which is being auto-corrected by scalariform. Committing the scalariform correction.