### PR TITLE
Dedup clients in the admin dashboard

### DIFF
--- a/admin/src/main/resources/io/buoyant/admin/js/combined_client_graph.js
+++ b/admin/src/main/resources/io/buoyant/admin/js/combined_client_graph.js
@@ -7,11 +7,11 @@ var CombinedClientGraph = (function() {
 
   return function(metricsCollector, routerName, $root, colors) {
     var clientColors = colors;
-    var query = Query.clientQuery().withRouter(routerName).withMetric("requests").build();
+    var query = Query.clientQuery().withRouter(routerName).withMetric("connects").build();
 
     function timeseriesParams(name) {
       return {
-        strokeStyle: clientColors[name.match(Query.clientQuery().build())[2]].color,
+        strokeStyle: clientColors[name.match(Query.clientQuery().withMetric("connects").build())[2]].color,
         lineWidth: 2
       };
     }

--- a/admin/src/main/resources/io/buoyant/admin/js/routers.js
+++ b/admin/src/main/resources/io/buoyant/admin/js/routers.js
@@ -36,7 +36,7 @@
  */
 var Routers = (function() {
 
-  var clientRE = Query.clientQuery().withMetric("requests").build(),
+  var clientRE = Query.clientQuery().withMetric("connects").build(),
       serverRE = Query.serverQuery().withMetric("requests").build();
 
   var mkColor = function() {


### PR DESCRIPTION
Fixes https://github.com/BuoyantIO/linkerd/issues/850

We use the "connects" metric instead of "requests" when discovering clients from the metrcis payload since this metric is not present in the per-path metrics.