### PR TITLE
Add client failureAccrual configuration object

### DIFF
--- a/linkerd/core/src/main/scala/io/buoyant/linkerd/FailureAccrualInitializer.scala
+++ b/linkerd/core/src/main/scala/io/buoyant/linkerd/FailureAccrualInitializer.scala
@@ -1,0 +1,37 @@
+package io.buoyant.linkerd
+
+import com.fasterxml.jackson.annotation.{JsonIgnore, JsonTypeInfo}
+import com.twitter.conversions.time._
+import com.twitter.finagle.service.{Backoff, FailureAccrualFactory}
+import com.twitter.finagle.service.exp.FailureAccrualPolicy
+import com.twitter.util.Duration
+import io.buoyant.config.ConfigInitializer
+
+abstract class FailureAccrualInitializer extends ConfigInitializer
+
+@JsonTypeInfo(use = JsonTypeInfo.Id.NAME, include = JsonTypeInfo.As.PROPERTY, property = "kind")
+trait FailureAccrualConfig {
+  @JsonIgnore
+  def policy: () => FailureAccrualPolicy
+
+  val backoff: Option[BackoffConfig]
+
+  @JsonIgnore
+  val backoffOrDefault =
+    backoff.map(_.mk).getOrElse(FailureAccrualConfig.defaultBackoff)
+}
+
+object FailureAccrualConfig {
+  // Settings here mirror Finagle's FailureAccrualFactory.defaultPolicy, but are provided
+  // in linkerd to make it easier to reason about the default failure accrual settings
+  private val defaultConsecutiveFailures = 5
+
+  private val defaultBackoff: Stream[Duration] =
+    Backoff.equalJittered(5.seconds, 300.seconds)
+
+  private val defaultPolicy =
+    () => FailureAccrualPolicy.consecutiveFailures(defaultConsecutiveFailures, defaultBackoff)
+
+  def param(config: Option[FailureAccrualConfig]): FailureAccrualFactory.Param =
+    FailureAccrualFactory.Param(config.map(_.policy).getOrElse(defaultPolicy))
+}

--- a/linkerd/core/src/main/scala/io/buoyant/linkerd/FailureAccrualInitializer.scala
+++ b/linkerd/core/src/main/scala/io/buoyant/linkerd/FailureAccrualInitializer.scala
@@ -14,7 +14,7 @@ trait FailureAccrualConfig {
   @JsonIgnore
   def policy: () => FailureAccrualPolicy
 
-  val backoff: Option[BackoffConfig]
+  var backoff: Option[BackoffConfig] = None
 
   @JsonIgnore
   val backoffOrDefault =
@@ -26,7 +26,7 @@ object FailureAccrualConfig {
   // in linkerd to make it easier to reason about the default failure accrual settings
   private val defaultConsecutiveFailures = 5
 
-  private val defaultBackoff: Stream[Duration] =
+  private[linkerd] val defaultBackoff: Stream[Duration] =
     Backoff.equalJittered(5.seconds, 300.seconds)
 
   private val defaultPolicy =

--- a/linkerd/core/src/main/scala/io/buoyant/linkerd/FailureAccrualInitializer.scala
+++ b/linkerd/core/src/main/scala/io/buoyant/linkerd/FailureAccrualInitializer.scala
@@ -26,7 +26,7 @@ object FailureAccrualConfig {
   // in linkerd to make it easier to reason about the default failure accrual settings
   private val defaultConsecutiveFailures = 5
 
-  private[linkerd] val defaultBackoff: Stream[Duration] =
+  private val defaultBackoff: Stream[Duration] =
     Backoff.equalJittered(5.seconds, 300.seconds)
 
   private val defaultPolicy =

--- a/linkerd/core/src/main/scala/io/buoyant/linkerd/Linker.scala
+++ b/linkerd/core/src/main/scala/io/buoyant/linkerd/Linker.scala
@@ -43,10 +43,11 @@ object Linker {
     identifier: Seq[IdentifierInitializer] = Nil,
     classifier: Seq[ResponseClassifierInitializer] = Nil,
     telemetry: Seq[TelemeterInitializer] = Nil,
-    announcer: Seq[AnnouncerInitializer] = Nil
+    announcer: Seq[AnnouncerInitializer] = Nil,
+    failureAccrual: Seq[FailureAccrualInitializer] = Nil
   ) {
     def iter: Iterable[Seq[ConfigInitializer]] =
-      Seq(protocol, namer, interpreter, tlsClient, tracer, identifier, transformer, classifier, telemetry, announcer)
+      Seq(protocol, namer, interpreter, tlsClient, tracer, identifier, transformer, classifier, telemetry, announcer, failureAccrual)
 
     def all: Seq[ConfigInitializer] = iter.flatten.toSeq
 
@@ -67,7 +68,8 @@ object Linker {
     LoadService[IdentifierInitializer],
     LoadService[ResponseClassifierInitializer],
     LoadService[TelemeterInitializer],
-    LoadService[AnnouncerInitializer]
+    LoadService[AnnouncerInitializer],
+    LoadService[FailureAccrualInitializer]
   )
 
   def parse(

--- a/linkerd/docs/failure_accrual.md
+++ b/linkerd/docs/failure_accrual.md
@@ -1,0 +1,70 @@
+# Failure Accrual
+
+```yaml
+routers:
+- ...
+  client:
+    failureAccrual:
+      kind: io.l5d.successRate
+      sr: 0.9
+      requests: 1000
+      backoff:
+        kind: jittered
+        minMs: 5000
+        maxMs: 300000
+```
+
+linkerd uses failure accrual to track the number of requests that have failed to
+a given node, and it will backoff sending requets to any nodes whose failures
+have exceeded a given threshold. Both the failure threshold and the backoff
+behavior are configurable. By default, if linkerd observes 5 consecutive
+failures from a node, it will mark the node as dead and only attempt to resend
+it traffic in increasing intervals between 5 seconds and 5 minutes.
+
+<aside class="success">
+  Learn more about failure accrual via <a target="_blank" href="https://twitter.github.io/finagle/guide/Clients.html#failure-accrual">Finagle's documentation</a>
+</aside>
+
+Key | Default Value | Description
+--- | ------------- | -----------
+kind | _required_ | Either [`io.l5d.consecutiveFailures`](#consecutive-failures), [`io.l5d.successRate`](#success-rate) or [`io.l5d.successRateWindowed`](#success-rate-windowed).
+backoff | See [retry backoff](#retry-backoff-parameters) | Object that determines which backoff algorithm should be used.
+
+## Consecutive Failures
+
+kind: `io.l5d.consecutiveFailures`
+
+Observes the number of consecutive failures to each node, and backs off sending
+requests to nodes that have exceeded the specified number of failures.
+
+Key | Default Value | Description
+--- | ------------- | -----------
+failures | _required_ | Number of consecutive failures.
+
+## Success Rate
+
+kind: `io.l5d.successRate`
+
+Computes an exponentially-weighted moving average success rate for each node,
+and backs off sending requests to nodes that have fallen below the specified
+success rate. The window size for computing success rate is constrained to a
+fixed number of requests.
+
+Key | Default Value | Description
+--- | ------------- | -----------
+sr | _required_ | Target success rate.
+requests | _required_ | Number of requests over which success rate is computed.
+
+## Success Rate (windowed)
+
+kind: `io.l5d.successRateWindowed`
+
+Computes an exponentially-weighted moving average success rate for each node,
+and backs off sending requests to nodes that have fallen below the specified
+success rate. The window size for computing success rate is constrained to a
+fixed time window.
+
+Key | Default Value | Description
+--- | ------------- | -----------
+sr | _required_ | Target success rate.
+window | _required_ | Number of seconds over which success rate is computed.

--- a/linkerd/docs/failure_accrual.md
+++ b/linkerd/docs/failure_accrual.md
@@ -6,7 +6,7 @@ routers:
   client:
     failureAccrual:
       kind: io.l5d.successRate
-      sr: 0.9
+      successRate: 0.9
       requests: 1000
       backoff:
         kind: jittered
@@ -21,14 +21,18 @@ behavior are configurable. By default, if linkerd observes 5 consecutive
 failures from a node, it will mark the node as dead and only attempt to resend
 it traffic in increasing intervals between 5 seconds and 5 minutes.
 
-<aside class="success">
-  Learn more about failure accrual via <a target="_blank" href="https://twitter.github.io/finagle/guide/Clients.html#failure-accrual">Finagle's documentation</a>
+<aside class="notice">
+  These parameters are available to failure accrual policies regardless of kind. Each policy may also have kind-specific parameters.
 </aside>
 
 Key | Default Value | Description
 --- | ------------- | -----------
 kind | _required_ | Either [`io.l5d.consecutiveFailures`](#consecutive-failures), [`io.l5d.successRate`](#success-rate) or [`io.l5d.successRateWindowed`](#success-rate-windowed).
-backoff | See [retry backoff](#retry-backoff-parameters) | Object that determines which backoff algorithm should be used.
+backoff | jittered backoff from 5s to 300s | A [backoff policy](#retry-budget-parameters) that determines how long to wait before resending traffic.
+
+<aside class="success">
+  Learn more about failure accrual via <a target="_blank" href="https://twitter.github.io/finagle/guide/Clients.html#failure-accrual">Finagle's documentation</a>
+</aside>
 
 ## Consecutive Failures
 
@@ -52,7 +56,7 @@ fixed number of requests.
 
 Key | Default Value | Description
 --- | ------------- | -----------
-sr | _required_ | Target success rate.
+successRate | _required_ | Target success rate.
 requests | _required_ | Number of requests over which success rate is computed.
 
 ## Success Rate (windowed)
@@ -66,5 +70,5 @@ fixed time window.
 
 Key | Default Value | Description
 --- | ------------- | -----------
-sr | _required_ | Target success rate.
+successRate | _required_ | Target success rate.
 window | _required_ | Number of seconds over which success rate is computed.

--- a/linkerd/docs/routers.md
+++ b/linkerd/docs/routers.md
@@ -37,7 +37,7 @@ announcers | an empty list | A list of service discovery [announcers](#announcer
 baseDtab | an empty dtab | Sets the base delegation table. See [dtabs](https://linkerd.io/doc/dtabs/) for more.
 bindingTimeoutMs | 10 seconds | The maximum amount of time in milliseconds to spend binding a path.
 bindingCache | see [binding cache](#binding-cache) | Binding cache size configuration.
-client | an empty object | An object of [client params](#basic-client-params).
+client | an empty object | An object of [client params](#client-parameters).
 dstPrefix | protocol dependent | A path prefix to be used on request destinations.
 failFast | `false` | If `true`, connection failures are punished more aggressively. Should not be used with small destination pools.
 originator | `false` | If `true`, indicates that this router is the first hop for linker-to-linker requests, and reflects that in the router's stats. Useful for deduping linker-to-linker stats.
@@ -117,6 +117,9 @@ client:
       kind: jittered
       minMs: 10
       maxMs: 10000
+  failureAccrual:
+    kind: io.l5d.consecutiveFailures
+    failures: 10
 ```
 
 Key | Default Value | Description
@@ -125,6 +128,7 @@ hostConnectionPool | An empty object | see [hostConnectionPool](#host-connection
 tls | no tls | The router will make requests using TLS if this parameter is provided.  It must be a [client TLS](#client-tls) object.
 loadBalancer | [p2c](#power-of-two-choices-least-loaded) | A [load balancer](#load-balancer) object.
 retries | see [retries](#retries) | A [retry policy](#retries) for all clients created by this router.
+failureAccrual | see [failure accrual](#failure-accrual) | a [failure accrual policy](#failure-accrual) for all clients created by this router.
 
 #### Host Connection Pool
 

--- a/linkerd/docs/routers.md
+++ b/linkerd/docs/routers.md
@@ -128,7 +128,7 @@ hostConnectionPool | An empty object | see [hostConnectionPool](#host-connection
 tls | no tls | The router will make requests using TLS if this parameter is provided.  It must be a [client TLS](#client-tls) object.
 loadBalancer | [p2c](#power-of-two-choices-least-loaded) | A [load balancer](#load-balancer) object.
 retries | see [retries](#retries) | A [retry policy](#retries) for all clients created by this router.
-failureAccrual | see [failure accrual](#failure-accrual) | a [failure accrual policy](#failure-accrual) for all clients created by this router.
+failureAccrual | 5 consecutive failures | a [failure accrual policy](#failure-accrual) for all clients created by this router.
 
 #### Host Connection Pool
 

--- a/linkerd/examples/acceptance-test.yaml
+++ b/linkerd/examples/acceptance-test.yaml
@@ -74,6 +74,9 @@ routers:
       maxSize: 20
       idleTimeMs: 10000
       maxWaiters: 15
+    failureAccrual:
+      kind: io.l5d.consecutiveFailures
+      failures: 10
   servers:
   - port: 4140
     ip: 0.0.0.0
@@ -102,6 +105,12 @@ routers:
       kind: ewma
       maxEffort: 10
       decayTimeMs: 10000
+    failureAccrual:
+      kind: io.l5d.consecutiveFailures
+      failures: 20
+      backoff:
+        kind: constant
+        ms: 10000
   servers:
   - port: 4141
     ip: 0.0.0.0
@@ -123,6 +132,10 @@ routers:
     thriftProtocol: compact
     loadBalancer:
       kind: heap
+    failureAccrual:
+      kind: io.l5d.successRate
+      sr: 0.9
+      requests: 100
   servers:
   - port: 4142
     ip: 0.0.0.0
@@ -146,6 +159,14 @@ routers:
       highLoad: 2.0
       smoothWindowMs: 5000
       minAperture: 5
+    failureAccrual:
+      kind: io.l5d.successRate
+      sr: 0.8
+      requests: 200
+      backoff:
+        kind: jittered
+        minMs: 10000
+        maxMs: 100000
   servers:
   - port: 4143
     ip: 0.0.0.0
@@ -165,6 +186,10 @@ routers:
       kind: io.l5d.static
       commonName: foo
       caCertPath: /foo/caCert.pem
+    failureAccrual:
+      kind: io.l5d.successRateWindowed
+      sr: 0.9
+      window: 30
   servers:
   - port: 4144
     ip: 0.0.0.0
@@ -192,6 +217,14 @@ routers:
       names:
       - prefix: "/#/io.l5d.fs/{service}"
         commonNamePattern: "{service}"
+    failureAccrual:
+      kind: io.l5d.successRateWindowed
+      sr: 0.8
+      window: 40
+      backoff:
+        kind: jittered
+        minMs: 20000
+        maxMs: 200000
   servers:
   - port: 4145
     ip: 0.0.0.0

--- a/linkerd/examples/acceptance-test.yaml
+++ b/linkerd/examples/acceptance-test.yaml
@@ -134,7 +134,7 @@ routers:
       kind: heap
     failureAccrual:
       kind: io.l5d.successRate
-      sr: 0.9
+      successRate: 0.9
       requests: 100
   servers:
   - port: 4142
@@ -161,7 +161,7 @@ routers:
       minAperture: 5
     failureAccrual:
       kind: io.l5d.successRate
-      sr: 0.8
+      successRate: 0.8
       requests: 200
       backoff:
         kind: jittered
@@ -188,7 +188,7 @@ routers:
       caCertPath: /foo/caCert.pem
     failureAccrual:
       kind: io.l5d.successRateWindowed
-      sr: 0.9
+      successRate: 0.9
       window: 30
   servers:
   - port: 4144
@@ -219,7 +219,7 @@ routers:
         commonNamePattern: "{service}"
     failureAccrual:
       kind: io.l5d.successRateWindowed
-      sr: 0.8
+      successRate: 0.8
       window: 40
       backoff:
         kind: jittered

--- a/linkerd/failure-accrual/src/main/resources/META-INF/services/io.buoyant.linkerd.FailureAccrualInitializer
+++ b/linkerd/failure-accrual/src/main/resources/META-INF/services/io.buoyant.linkerd.FailureAccrualInitializer
@@ -1,0 +1,3 @@
+io.buoyant.linkerd.failureAccrual.ConsecutiveFailuresInitializer
+io.buoyant.linkerd.failureAccrual.SuccessRateInitializer
+io.buoyant.linkerd.failureAccrual.SuccessRateWindowedInitializer

--- a/linkerd/failure-accrual/src/main/scala/io/buoyant/linkerd/failureAccrual/ConsecutiveFailuresInitializer.scala
+++ b/linkerd/failure-accrual/src/main/scala/io/buoyant/linkerd/failureAccrual/ConsecutiveFailuresInitializer.scala
@@ -2,7 +2,7 @@ package io.buoyant.linkerd.failureAccrual
 
 import com.fasterxml.jackson.annotation.JsonIgnore
 import com.twitter.finagle.service.exp.FailureAccrualPolicy
-import io.buoyant.linkerd.{BackoffConfig, FailureAccrualConfig, FailureAccrualInitializer}
+import io.buoyant.linkerd.{FailureAccrualConfig, FailureAccrualInitializer}
 
 class ConsecutiveFailuresInitializer extends FailureAccrualInitializer {
   val configClass = classOf[ConsecutiveFailuresConfig]
@@ -11,10 +11,7 @@ class ConsecutiveFailuresInitializer extends FailureAccrualInitializer {
 
 object ConsecutiveFailuresInitializer extends ConsecutiveFailuresInitializer
 
-case class ConsecutiveFailuresConfig(
-  failures: Int,
-  backoff: Option[BackoffConfig]
-) extends FailureAccrualConfig {
+case class ConsecutiveFailuresConfig(failures: Int) extends FailureAccrualConfig {
   @JsonIgnore
   override def policy =
     () => FailureAccrualPolicy.consecutiveFailures(failures, backoffOrDefault)

--- a/linkerd/failure-accrual/src/main/scala/io/buoyant/linkerd/failureAccrual/ConsecutiveFailuresInitializer.scala
+++ b/linkerd/failure-accrual/src/main/scala/io/buoyant/linkerd/failureAccrual/ConsecutiveFailuresInitializer.scala
@@ -1,0 +1,21 @@
+package io.buoyant.linkerd.failureAccrual
+
+import com.fasterxml.jackson.annotation.JsonIgnore
+import com.twitter.finagle.service.exp.FailureAccrualPolicy
+import io.buoyant.linkerd.{BackoffConfig, FailureAccrualConfig, FailureAccrualInitializer}
+
+class ConsecutiveFailuresInitializer extends FailureAccrualInitializer {
+  val configClass = classOf[ConsecutiveFailuresConfig]
+  override def configId = "io.l5d.consecutiveFailures"
+}
+
+object ConsecutiveFailuresInitializer extends ConsecutiveFailuresInitializer
+
+case class ConsecutiveFailuresConfig(
+  failures: Int,
+  backoff: Option[BackoffConfig]
+) extends FailureAccrualConfig {
+  @JsonIgnore
+  override def policy =
+    () => FailureAccrualPolicy.consecutiveFailures(failures, backoffOrDefault)
+}

--- a/linkerd/failure-accrual/src/main/scala/io/buoyant/linkerd/failureAccrual/SuccessRateInitializer.scala
+++ b/linkerd/failure-accrual/src/main/scala/io/buoyant/linkerd/failureAccrual/SuccessRateInitializer.scala
@@ -1,0 +1,22 @@
+package io.buoyant.linkerd.failureAccrual
+
+import com.fasterxml.jackson.annotation.JsonIgnore
+import com.twitter.finagle.service.exp.FailureAccrualPolicy
+import io.buoyant.linkerd.{BackoffConfig, FailureAccrualConfig, FailureAccrualInitializer}
+
+class SuccessRateInitializer extends FailureAccrualInitializer {
+  val configClass = classOf[SuccessRateConfig]
+  override def configId = "io.l5d.successRate"
+}
+
+object SuccessRateInitializer extends SuccessRateInitializer
+
+case class SuccessRateConfig(
+  sr: Double,
+  requests: Int,
+  backoff: Option[BackoffConfig]
+) extends FailureAccrualConfig {
+  @JsonIgnore
+  override def policy =
+    () => FailureAccrualPolicy.successRate(sr, requests, backoffOrDefault)
+}

--- a/linkerd/failure-accrual/src/main/scala/io/buoyant/linkerd/failureAccrual/SuccessRateInitializer.scala
+++ b/linkerd/failure-accrual/src/main/scala/io/buoyant/linkerd/failureAccrual/SuccessRateInitializer.scala
@@ -2,7 +2,7 @@ package io.buoyant.linkerd.failureAccrual
 
 import com.fasterxml.jackson.annotation.JsonIgnore
 import com.twitter.finagle.service.exp.FailureAccrualPolicy
-import io.buoyant.linkerd.{BackoffConfig, FailureAccrualConfig, FailureAccrualInitializer}
+import io.buoyant.linkerd.{FailureAccrualConfig, FailureAccrualInitializer}
 
 class SuccessRateInitializer extends FailureAccrualInitializer {
   val configClass = classOf[SuccessRateConfig]
@@ -11,12 +11,8 @@ class SuccessRateInitializer extends FailureAccrualInitializer {
 
 object SuccessRateInitializer extends SuccessRateInitializer
 
-case class SuccessRateConfig(
-  sr: Double,
-  requests: Int,
-  backoff: Option[BackoffConfig]
-) extends FailureAccrualConfig {
+case class SuccessRateConfig(successRate: Double, requests: Int) extends FailureAccrualConfig {
   @JsonIgnore
   override def policy =
-    () => FailureAccrualPolicy.successRate(sr, requests, backoffOrDefault)
+    () => FailureAccrualPolicy.successRate(successRate, requests, backoffOrDefault)
 }

--- a/linkerd/failure-accrual/src/main/scala/io/buoyant/linkerd/failureAccrual/SuccessRateWindowedInitializer.scala
+++ b/linkerd/failure-accrual/src/main/scala/io/buoyant/linkerd/failureAccrual/SuccessRateWindowedInitializer.scala
@@ -1,0 +1,23 @@
+package io.buoyant.linkerd.failureAccrual
+
+import com.fasterxml.jackson.annotation.JsonIgnore
+import com.twitter.conversions.time._
+import com.twitter.finagle.service.exp.FailureAccrualPolicy
+import io.buoyant.linkerd.{BackoffConfig, FailureAccrualConfig, FailureAccrualInitializer}
+
+class SuccessRateWindowedInitializer extends FailureAccrualInitializer {
+  val configClass = classOf[SuccessRateWindowedConfig]
+  override def configId = "io.l5d.successRateWindowed"
+}
+
+object SuccessRateWindowedInitializer extends SuccessRateWindowedInitializer
+
+case class SuccessRateWindowedConfig(
+  sr: Double,
+  window: Int,
+  backoff: Option[BackoffConfig]
+) extends FailureAccrualConfig {
+  @JsonIgnore
+  override def policy =
+    () => FailureAccrualPolicy.successRateWithinDuration(sr, window.seconds, backoffOrDefault)
+}

--- a/linkerd/failure-accrual/src/main/scala/io/buoyant/linkerd/failureAccrual/SuccessRateWindowedInitializer.scala
+++ b/linkerd/failure-accrual/src/main/scala/io/buoyant/linkerd/failureAccrual/SuccessRateWindowedInitializer.scala
@@ -3,7 +3,7 @@ package io.buoyant.linkerd.failureAccrual
 import com.fasterxml.jackson.annotation.JsonIgnore
 import com.twitter.conversions.time._
 import com.twitter.finagle.service.exp.FailureAccrualPolicy
-import io.buoyant.linkerd.{BackoffConfig, FailureAccrualConfig, FailureAccrualInitializer}
+import io.buoyant.linkerd.{FailureAccrualConfig, FailureAccrualInitializer}
 
 class SuccessRateWindowedInitializer extends FailureAccrualInitializer {
   val configClass = classOf[SuccessRateWindowedConfig]
@@ -13,11 +13,11 @@ class SuccessRateWindowedInitializer extends FailureAccrualInitializer {
 object SuccessRateWindowedInitializer extends SuccessRateWindowedInitializer
 
 case class SuccessRateWindowedConfig(
-  sr: Double,
-  window: Int,
-  backoff: Option[BackoffConfig]
+  successRate: Double,
+  window: Int
 ) extends FailureAccrualConfig {
   @JsonIgnore
   override def policy =
-    () => FailureAccrualPolicy.successRateWithinDuration(sr, window.seconds, backoffOrDefault)
+    () =>
+      FailureAccrualPolicy.successRateWithinDuration(successRate, window.seconds, backoffOrDefault)
 }

--- a/linkerd/failure-accrual/src/test/scala/io/buoyant/linkerd/failureAccrual/consecutiveFailuresTest.scala
+++ b/linkerd/failure-accrual/src/test/scala/io/buoyant/linkerd/failureAccrual/consecutiveFailuresTest.scala
@@ -2,15 +2,16 @@ package io.buoyant.linkerd.failureAccrual
 
 import com.twitter.finagle.service.exp.FailureAccrualPolicy
 import com.twitter.finagle.util.LoadService
-import io.buoyant.linkerd.{ConstantBackoffConfig, FailureAccrualInitializer}
+import io.buoyant.linkerd.{FailureAccrualConfig, FailureAccrualInitializer}
 import io.buoyant.test.FunSuite
 
 class ConsecutiveFailuresTest extends FunSuite {
   test("sanity") {
     val failures = 2
-    val backoff = ConstantBackoffConfig(5000)
-    val config = ConsecutiveFailuresConfig(failures, Some(backoff))
+    val config = ConsecutiveFailuresConfig(failures)
     assert(config.policy().isInstanceOf[FailureAccrualPolicy])
+    assert(config.failures == failures)
+    assert(config.backoff.map(_.mk) == Some(FailureAccrualConfig.defaultBackoff))
   }
 
   test("service registration") {

--- a/linkerd/failure-accrual/src/test/scala/io/buoyant/linkerd/failureAccrual/consecutiveFailuresTest.scala
+++ b/linkerd/failure-accrual/src/test/scala/io/buoyant/linkerd/failureAccrual/consecutiveFailuresTest.scala
@@ -2,7 +2,7 @@ package io.buoyant.linkerd.failureAccrual
 
 import com.twitter.finagle.service.exp.FailureAccrualPolicy
 import com.twitter.finagle.util.LoadService
-import io.buoyant.linkerd.{FailureAccrualConfig, FailureAccrualInitializer}
+import io.buoyant.linkerd.FailureAccrualInitializer
 import io.buoyant.test.FunSuite
 
 class ConsecutiveFailuresTest extends FunSuite {
@@ -11,7 +11,6 @@ class ConsecutiveFailuresTest extends FunSuite {
     val config = ConsecutiveFailuresConfig(failures)
     assert(config.policy().isInstanceOf[FailureAccrualPolicy])
     assert(config.failures == failures)
-    assert(config.backoff.map(_.mk) == Some(FailureAccrualConfig.defaultBackoff))
   }
 
   test("service registration") {

--- a/linkerd/failure-accrual/src/test/scala/io/buoyant/linkerd/failureAccrual/consecutiveFailuresTest.scala
+++ b/linkerd/failure-accrual/src/test/scala/io/buoyant/linkerd/failureAccrual/consecutiveFailuresTest.scala
@@ -1,0 +1,19 @@
+package io.buoyant.linkerd.failureAccrual
+
+import com.twitter.finagle.service.exp.FailureAccrualPolicy
+import com.twitter.finagle.util.LoadService
+import io.buoyant.linkerd.{ConstantBackoffConfig, FailureAccrualInitializer}
+import io.buoyant.test.FunSuite
+
+class ConsecutiveFailuresTest extends FunSuite {
+  test("sanity") {
+    val failures = 2
+    val backoff = ConstantBackoffConfig(5000)
+    val config = ConsecutiveFailuresConfig(failures, Some(backoff))
+    assert(config.policy().isInstanceOf[FailureAccrualPolicy])
+  }
+
+  test("service registration") {
+    assert(LoadService[FailureAccrualInitializer].exists(_.isInstanceOf[ConsecutiveFailuresInitializer]))
+  }
+}

--- a/linkerd/failure-accrual/src/test/scala/io/buoyant/linkerd/failureAccrual/successRateTest.scala
+++ b/linkerd/failure-accrual/src/test/scala/io/buoyant/linkerd/failureAccrual/successRateTest.scala
@@ -2,16 +2,18 @@ package io.buoyant.linkerd.failureAccrual
 
 import com.twitter.finagle.service.exp.FailureAccrualPolicy
 import com.twitter.finagle.util.LoadService
-import io.buoyant.linkerd.{ConstantBackoffConfig, FailureAccrualInitializer}
+import io.buoyant.linkerd.{FailureAccrualConfig, FailureAccrualInitializer}
 import io.buoyant.test.FunSuite
 
 class SuccessRateTest extends FunSuite {
   test("sanity") {
-    val sr = 0.6
+    val successRate = 0.6
     val requests = 3
-    val backoff = ConstantBackoffConfig(5000)
-    val config = SuccessRateConfig(sr, requests, Some(backoff))
+    val config = SuccessRateConfig(successRate, requests)
     assert(config.policy().isInstanceOf[FailureAccrualPolicy])
+    assert(config.successRate == successRate)
+    assert(config.requests == requests)
+    assert(config.backoff.map(_.mk) == Some(FailureAccrualConfig.defaultBackoff))
   }
 
   test("service registration") {

--- a/linkerd/failure-accrual/src/test/scala/io/buoyant/linkerd/failureAccrual/successRateTest.scala
+++ b/linkerd/failure-accrual/src/test/scala/io/buoyant/linkerd/failureAccrual/successRateTest.scala
@@ -1,0 +1,20 @@
+package io.buoyant.linkerd.failureAccrual
+
+import com.twitter.finagle.service.exp.FailureAccrualPolicy
+import com.twitter.finagle.util.LoadService
+import io.buoyant.linkerd.{ConstantBackoffConfig, FailureAccrualInitializer}
+import io.buoyant.test.FunSuite
+
+class SuccessRateTest extends FunSuite {
+  test("sanity") {
+    val sr = 0.6
+    val requests = 3
+    val backoff = ConstantBackoffConfig(5000)
+    val config = SuccessRateConfig(sr, requests, Some(backoff))
+    assert(config.policy().isInstanceOf[FailureAccrualPolicy])
+  }
+
+  test("service registration") {
+    assert(LoadService[FailureAccrualInitializer].exists(_.isInstanceOf[SuccessRateInitializer]))
+  }
+}

--- a/linkerd/failure-accrual/src/test/scala/io/buoyant/linkerd/failureAccrual/successRateTest.scala
+++ b/linkerd/failure-accrual/src/test/scala/io/buoyant/linkerd/failureAccrual/successRateTest.scala
@@ -2,7 +2,7 @@ package io.buoyant.linkerd.failureAccrual
 
 import com.twitter.finagle.service.exp.FailureAccrualPolicy
 import com.twitter.finagle.util.LoadService
-import io.buoyant.linkerd.{FailureAccrualConfig, FailureAccrualInitializer}
+import io.buoyant.linkerd.FailureAccrualInitializer
 import io.buoyant.test.FunSuite
 
 class SuccessRateTest extends FunSuite {
@@ -13,7 +13,6 @@ class SuccessRateTest extends FunSuite {
     assert(config.policy().isInstanceOf[FailureAccrualPolicy])
     assert(config.successRate == successRate)
     assert(config.requests == requests)
-    assert(config.backoff.map(_.mk) == Some(FailureAccrualConfig.defaultBackoff))
   }
 
   test("service registration") {

--- a/linkerd/failure-accrual/src/test/scala/io/buoyant/linkerd/failureAccrual/successRateWindowedTest.scala
+++ b/linkerd/failure-accrual/src/test/scala/io/buoyant/linkerd/failureAccrual/successRateWindowedTest.scala
@@ -1,0 +1,20 @@
+package io.buoyant.linkerd.failureAccrual
+
+import com.twitter.finagle.service.exp.FailureAccrualPolicy
+import com.twitter.finagle.util.LoadService
+import io.buoyant.linkerd.{ConstantBackoffConfig, FailureAccrualInitializer}
+import io.buoyant.test.FunSuite
+
+class SuccessRateWindowedTest extends FunSuite {
+  test("sanity") {
+    val sr = 0.4
+    val window = 3
+    val backoff = ConstantBackoffConfig(5000)
+    val config = SuccessRateWindowedConfig(sr, window, Some(backoff))
+    assert(config.policy().isInstanceOf[FailureAccrualPolicy])
+  }
+
+  test("service registration") {
+    assert(LoadService[FailureAccrualInitializer].exists(_.isInstanceOf[SuccessRateWindowedInitializer]))
+  }
+}

--- a/linkerd/failure-accrual/src/test/scala/io/buoyant/linkerd/failureAccrual/successRateWindowedTest.scala
+++ b/linkerd/failure-accrual/src/test/scala/io/buoyant/linkerd/failureAccrual/successRateWindowedTest.scala
@@ -2,16 +2,18 @@ package io.buoyant.linkerd.failureAccrual
 
 import com.twitter.finagle.service.exp.FailureAccrualPolicy
 import com.twitter.finagle.util.LoadService
-import io.buoyant.linkerd.{ConstantBackoffConfig, FailureAccrualInitializer}
+import io.buoyant.linkerd.{FailureAccrualConfig, FailureAccrualInitializer}
 import io.buoyant.test.FunSuite
 
 class SuccessRateWindowedTest extends FunSuite {
   test("sanity") {
-    val sr = 0.4
+    val successRate = 0.4
     val window = 3
-    val backoff = ConstantBackoffConfig(5000)
-    val config = SuccessRateWindowedConfig(sr, window, Some(backoff))
+    val config = SuccessRateWindowedConfig(successRate, window)
     assert(config.policy().isInstanceOf[FailureAccrualPolicy])
+    assert(config.successRate == successRate)
+    assert(config.window == window)
+    assert(config.backoff.map(_.mk) == Some(FailureAccrualConfig.defaultBackoff))
   }
 
   test("service registration") {

--- a/linkerd/failure-accrual/src/test/scala/io/buoyant/linkerd/failureAccrual/successRateWindowedTest.scala
+++ b/linkerd/failure-accrual/src/test/scala/io/buoyant/linkerd/failureAccrual/successRateWindowedTest.scala
@@ -2,7 +2,7 @@ package io.buoyant.linkerd.failureAccrual
 
 import com.twitter.finagle.service.exp.FailureAccrualPolicy
 import com.twitter.finagle.util.LoadService
-import io.buoyant.linkerd.{FailureAccrualConfig, FailureAccrualInitializer}
+import io.buoyant.linkerd.FailureAccrualInitializer
 import io.buoyant.test.FunSuite
 
 class SuccessRateWindowedTest extends FunSuite {
@@ -13,7 +13,6 @@ class SuccessRateWindowedTest extends FunSuite {
     assert(config.policy().isInstanceOf[FailureAccrualPolicy])
     assert(config.successRate == successRate)
     assert(config.window == window)
-    assert(config.backoff.map(_.mk) == Some(FailureAccrualConfig.defaultBackoff))
   }
 
   test("service registration") {

--- a/project/LinkerdBuild.scala
+++ b/project/LinkerdBuild.scala
@@ -416,6 +416,10 @@ object LinkerdBuild extends Base {
       .withLibs("io.netty" % "netty-tcnative-boringssl-static" % "1.1.33.Fork23")
       .withTests()
 
+    val failureAccrual = projectDir("linkerd/failure-accrual")
+      .dependsOn(core)
+      .withTests()
+
     object Protocol {
 
       val h2 = projectDir("linkerd/protocol/h2")
@@ -537,12 +541,13 @@ object LinkerdBuild extends Base {
       Announcer.serversets,
       Telemetry.core, Telemetry.tracelog,
       Tracer.zipkin,
-      tls
+      tls,
+      failureAccrual
     )
 
     val all = projectDir("linkerd")
       .settings(aggregateSettings)
-      .aggregate(admin, core, main, configCore, Namer.all, Protocol.all, Tracer.all, Announcer.all, tls)
+      .aggregate(admin, core, main, configCore, Namer.all, Protocol.all, Tracer.all, Announcer.all, tls, failureAccrual)
       .configs(Minimal, Bundle)
       // Minimal cofiguration includes a runtime, HTTP routing and the
       // fs service discovery.
@@ -655,6 +660,7 @@ object LinkerdBuild extends Base {
   val linkerdAnnouncer = Linkerd.Announcer.all
   val linkerdAnnouncerServersets = Linkerd.Announcer.serversets
   val linkerdTls = Linkerd.tls
+  val linkerdFailureAccrual = Linkerd.failureAccrual
 
   // Unified documentation via the sbt-unidoc plugin
   val all = project("all", file("."))


### PR DESCRIPTION
Adding a new client configuration key -- `failureAccrual` -- which supports configuring a failure accrual policy for all clients created by the configured router. I've exposed failured accrual as a plugin interface, and have provided 3 implementations based on what is provided by finagle: consecutive failures, success rate by count, and success rate by time. Fixes #468.