### PR TITLE
[h2] Add a generic Trailers constructor

### DIFF
--- a/router/h2/src/main/scala/com/twitter/finagle/buoyant/h2/Message.scala
+++ b/router/h2/src/main/scala/com/twitter/finagle/buoyant/h2/Message.scala
@@ -55,7 +55,7 @@ object Headers {
    * another header implementation that can be translated by
    * transports.
    */
-  private class Impl(orig: Seq[(String, String)]) extends Headers {
+  private[h2] class Impl(orig: Seq[(String, String)]) extends Headers {
     private[this] var current: Seq[(String, String)] = orig
     def toSeq = synchronized(current)
     override def toString = s"""Headers(${toSeq.mkString(", ")})"""

--- a/router/h2/src/main/scala/com/twitter/finagle/buoyant/h2/Stream.scala
+++ b/router/h2/src/main/scala/com/twitter/finagle/buoyant/h2/Stream.scala
@@ -199,4 +199,24 @@ object Frame {
     final override def isEnd = true
   }
 
+  object Trailers {
+
+    private class Impl(orig: Seq[(String, String)])
+      extends Headers.Impl(orig) with Trailers {
+
+      private[this] val promise = new Promise[Unit]
+      def release(): Future[Unit] = {
+        promise.updateIfEmpty(Return.Unit)
+        Future.Unit
+      }
+      def onRelease: Future[Unit] = promise
+    }
+
+    def apply(pairs: Seq[(String, String)]): Trailers =
+      new Impl(pairs)
+
+    def apply(hd: (String, String), tl: (String, String)*): Trailers =
+      apply(hd +: tl)
+  }
+
 }


### PR DESCRIPTION
Currently there's no easy way to build a Trailers frame from application code.
(There is a netty-specific builder, but that is and should only be visible
within the netty codec.)

This change introduces a generic `Frame.Trailers(hdrs: Seq[(String, String)])`
constructor that's usable from application code (or a gRPC iplementation ;)