### PR TITLE
Fix incorrect router request graph in dashboard

### DIFF
--- a/admin/src/main/resources/io/buoyant/admin/js/combined_client_graph.js
+++ b/admin/src/main/resources/io/buoyant/admin/js/combined_client_graph.js
@@ -8,7 +8,7 @@ var CombinedClientGraph = (function() {
   function currentClients(routerName, metrics) {
     var clientQuery = Query.clientQuery().withRouter(routerName).withMetric("connects").build();
     return _.map(Query.filter(clientQuery, metrics), function(metric) {
-        var match = metric.name.match(clientQuery)
+        var match = metric.match(clientQuery)
         return match[2];
     });
   }
@@ -60,7 +60,8 @@ var CombinedClientGraph = (function() {
         // where the first values from /metrics are very large [linkerd#485]
         count++;
       } else {
-        var clients = currentClients(routerName, data.specific);
+        var metrics = _.map(data.specific, function(metric) { return metric.name; });
+        var clients = currentClients(routerName, metrics);
         var filteredData = Query.filter(query.withClients(clients).build(), data.specific);
         chart.updateMetrics(filteredData);
       }

--- a/admin/src/main/resources/io/buoyant/admin/js/combined_client_graph.js
+++ b/admin/src/main/resources/io/buoyant/admin/js/combined_client_graph.js
@@ -39,7 +39,7 @@ var CombinedClientGraph = (function() {
       timeseriesParams
     );
 
-    var clients = _.map(routers.clients(routerName), function(client) { return client.label; });
+    var clients = _.map(routers.clients(routerName), 'label');
 
     var desiredMetrics = _.map(Query.filter(query.withClients(clients).build(), metricsCollector.getCurrentMetrics()), clientToMetric);
     chart.setMetrics(desiredMetrics, timeseriesParams, true);
@@ -51,7 +51,7 @@ var CombinedClientGraph = (function() {
         // where the first values from /metrics are very large [linkerd#485]
         count++;
       } else {
-        var clients = _.map(routers.clients(routerName), function(client) { return client.label; });
+        var clients = _.map(routers.clients(routerName), 'label');
         var filteredData = Query.filter(query.withClients(clients).build(), data.specific);
         chart.updateMetrics(filteredData);
       }

--- a/admin/src/main/resources/io/buoyant/admin/js/router_clients.js
+++ b/admin/src/main/resources/io/buoyant/admin/js/router_clients.js
@@ -19,7 +19,7 @@ var RouterClients = (function() {
 
   return function (metricsCollector, routers, $clientEl, routerName, clientTemplate, metricPartial, clientContainerTemplate, colors) {
     var clientToColor = assignColorsToClients(colors, routers.clients(routerName));
-    var combinedClientGraph = CombinedClientGraph(metricsCollector, routerName, $clientEl.find(".router-graph"), clientToColor);
+    var combinedClientGraph = CombinedClientGraph(metricsCollector, routers, routerName, $clientEl.find(".router-graph"), clientToColor);
     var clients = routers.clients(routerName);
 
     var expandClients = shouldExpandClients(clients.length);


### PR DESCRIPTION
In a pervious change, we switched from using the "request" stat to the "connects" stat for discovering clients from metrics.  I believe this had the consequence of no longer displaying the requests data on the router graph.

This change makes the computation of that data a two step process:
1. Get a list of clients by looking for the "connects" stat
2. Get the "requests" metrics for those clients

Unfortunately, this means that the list of clients must be continuously recomputed in case it changes.