### PR TITLE
Fix growing regex in admin dashboard

### DIFF
--- a/admin/src/main/resources/io/buoyant/admin/js/combined_client_graph.js
+++ b/admin/src/main/resources/io/buoyant/admin/js/combined_client_graph.js
@@ -7,7 +7,6 @@ var CombinedClientGraph = (function() {
 
   return function(metricsCollector, routers, routerName, $root, colors) {
     var clientColors = colors;
-    var query = Query.clientQuery().withRouter(routerName).withMetric("requests");
 
     function timeseriesParams(name) {
       return {
@@ -41,7 +40,8 @@ var CombinedClientGraph = (function() {
 
     var clients = _.map(routers.clients(routerName), 'label');
 
-    var desiredMetrics = _.map(Query.filter(query.withClients(clients).build(), metricsCollector.getCurrentMetrics()), clientToMetric);
+    var query = Query.clientQuery().withRouter(routerName).withClients(clients).withMetric("requests").build();
+    var desiredMetrics = _.map(Query.filter(query, metricsCollector.getCurrentMetrics()), clientToMetric);
     chart.setMetrics(desiredMetrics, timeseriesParams, true);
 
     var count = 0;
@@ -52,7 +52,8 @@ var CombinedClientGraph = (function() {
         count++;
       } else {
         var clients = _.map(routers.clients(routerName), 'label');
-        var filteredData = Query.filter(query.withClients(clients).build(), data.specific);
+        var query = Query.clientQuery().withRouter(routerName).withClients(clients).withMetric("requests").build();
+        var filteredData = Query.filter(query, data.specific);
         chart.updateMetrics(filteredData);
       }
     };


### PR DESCRIPTION
# Problem

query objects are mutable and will grow with each invocation of `withClients`.  This caused the regular expression to grow without bound over time and cause strange behavior in the dashboard.

# Solution

Rebuild the query from scratch each time to avoid unbounded growth.