### PR TITLE
Upgrade to finagle 6.41

### DIFF
--- a/consul/src/main/scala/io/buoyant/consul/v1/BaseApi.scala
+++ b/consul/src/main/scala/io/buoyant/consul/v1/BaseApi.scala
@@ -9,8 +9,9 @@ import com.twitter.finagle.stats.StatsReceiver
 import com.twitter.finagle.tracing.Trace
 import com.twitter.finagle.{Failure, Filter, http}
 import com.twitter.io.Buf
-import com.twitter.util._
+import com.twitter.util.{NonFatal => _, _}
 import io.buoyant.consul.log
+import scala.util.control.NonFatal
 
 trait BaseApi extends Closable {
   def client: Client

--- a/etcd/src/main/scala/io/buoyant/etcd/Key.scala
+++ b/etcd/src/main/scala/io/buoyant/etcd/Key.scala
@@ -5,7 +5,8 @@ import com.twitter.finagle.{Path, Service}
 import com.twitter.finagle.http._
 import com.twitter.finagle.service.Backoff
 import com.twitter.io.Buf
-import com.twitter.util._
+import com.twitter.util.{NonFatal => _, _}
+import scala.util.control.NonFatal
 
 case class BackoffsExhausted(key: Path, throwable: Throwable)
   extends Exception(key.show, throwable)

--- a/interpreter/namerd/src/main/scala/io/buoyant/namerd/iface/NamerdHttpInterpreterInitializer.scala
+++ b/interpreter/namerd/src/main/scala/io/buoyant/namerd/iface/NamerdHttpInterpreterInitializer.scala
@@ -8,8 +8,9 @@ import com.twitter.finagle.naming.NameInterpreter
 import com.twitter.finagle.param.HighResTimer
 import com.twitter.finagle.service._
 import com.twitter.logging.Logger
-import com.twitter.util.{NonFatal, Throw}
+import com.twitter.util.Throw
 import io.buoyant.namer.{InterpreterConfig, InterpreterInitializer}
+import scala.util.control.NonFatal
 
 /**
  * The namerd interpreter offloads the responsibilities of name resolution to

--- a/interpreter/namerd/src/main/scala/io/buoyant/namerd/iface/NamerdInterpreterInitializer.scala
+++ b/interpreter/namerd/src/main/scala/io/buoyant/namerd/iface/NamerdInterpreterInitializer.scala
@@ -8,10 +8,11 @@ import com.twitter.finagle.naming.NameInterpreter
 import com.twitter.finagle.param.HighResTimer
 import com.twitter.finagle.service._
 import com.twitter.logging.Logger
-import com.twitter.util._
+import com.twitter.util.{NonFatal => _, _}
 import io.buoyant.namer.{InterpreterConfig, InterpreterInitializer}
 import io.buoyant.namerd.iface.{thriftscala => thrift}
 import com.twitter.finagle.buoyant.TlsClientPrep
+import scala.util.control.NonFatal
 
 /**
  * The namerd interpreter offloads the responsibilities of name resolution to

--- a/k8s/src/main/scala/io/buoyant/k8s/Api.scala
+++ b/k8s/src/main/scala/io/buoyant/k8s/Api.scala
@@ -13,7 +13,7 @@ import com.twitter.util._
 object Api {
   val BufSize = 8 * 1024
 
-  val Closed = Failure("k8s observation released").flagged(Failure.Interrupted)
+  val Closed = Failure("k8s observation released", Failure.Interrupted)
   case class UnexpectedResponse(rsp: http.Response) extends Throwable
 
   /**

--- a/k8s/src/main/scala/io/buoyant/k8s/Watchable.scala
+++ b/k8s/src/main/scala/io/buoyant/k8s/Watchable.scala
@@ -9,9 +9,9 @@ import com.twitter.finagle.stats.StatsReceiver
 import com.twitter.finagle.tracing.Trace
 import com.twitter.io.Reader
 import com.twitter.util.TimeConversions._
-import com.twitter.util._
+import com.twitter.util.{NonFatal => _, _}
 import java.util.concurrent.atomic.AtomicReference
-import scala.reflect.runtime.universe.TypeTag
+import scala.util.control.NonFatal
 
 /**
  * An abstract class that encapsulates the ability to Watch a k8s [[Resource]].

--- a/linkerd/core/src/main/scala/io/buoyant/linkerd/Announcer.scala
+++ b/linkerd/core/src/main/scala/io/buoyant/linkerd/Announcer.scala
@@ -23,7 +23,7 @@ abstract class FutureAnnouncer extends Announcer {
     @volatile var deadline: Option[Time] = None
     val closeRef = new AtomicReference[Closable](Closable.make { d =>
       deadline = Some(d)
-      pending.raise(Failure("closed").flagged(Failure.Interrupted))
+      pending.raise(Failure("closed", Failure.Interrupted))
       Future.Unit
     })
     pending.respond {

--- a/linkerd/protocol/h2/src/main/scala/io/buoyant/linkerd/protocol/H2Config.scala
+++ b/linkerd/protocol/h2/src/main/scala/io/buoyant/linkerd/protocol/H2Config.scala
@@ -7,12 +7,13 @@ import com.fasterxml.jackson.databind.{DeserializationContext, JsonDeserializer,
 import com.twitter.finagle.{param, Path, Stack}
 import com.twitter.finagle.buoyant.h2.{Request, Response, LinkerdHeaders}
 import com.twitter.finagle.client.StackClient
-import com.twitter.util.{Monitor, NonFatal}
+import com.twitter.util.Monitor
 import com.fasterxml.jackson.annotation.{JsonIgnore, JsonTypeInfo}
 import io.buoyant.linkerd.protocol.h2.ResponseClassifiers
 import io.buoyant.router.{H2, ClassifiedRetries, RoutingFactory}
 import io.netty.handler.ssl.ApplicationProtocolNames
 import scala.collection.JavaConverters._
+import scala.util.control.NonFatal
 
 class H2Initializer extends ProtocolInitializer.Simple {
   val name = "h2"

--- a/linkerd/protocol/http/src/main/scala/io/buoyant/linkerd/protocol/http/ErrorResponder.scala
+++ b/linkerd/protocol/http/src/main/scala/io/buoyant/linkerd/protocol/http/ErrorResponder.scala
@@ -4,9 +4,9 @@ import com.twitter.finagle.{Service, ServiceFactory, SimpleFilter, Stack, Stacka
 import com.twitter.finagle.buoyant.linkerd._
 import com.twitter.finagle.http.{MediaType, Request, Response, Status}
 import com.twitter.logging.Logger
-import com.twitter.util.NonFatal
 import io.buoyant.router.RoutingFactory
 import java.net.URLEncoder
+import scala.util.control.NonFatal
 
 class ErrorResponder extends SimpleFilter[Request, Response] {
   private[this] val log = Logger.get("ErrorResponseFilter")

--- a/linkerd/tracer/zipkin/src/main/scala/io/buoyant/linkerd/tracer/ZipkinTracerInitializer.scala
+++ b/linkerd/tracer/zipkin/src/main/scala/io/buoyant/linkerd/tracer/ZipkinTracerInitializer.scala
@@ -2,18 +2,16 @@ package io.buoyant.linkerd.tracer
 
 import com.fasterxml.jackson.annotation.JsonIgnore
 import com.twitter.conversions.time._
-import com.twitter.finagle.builder.ClientBuilder
+import com.twitter.finagle._
 import com.twitter.finagle.client.DefaultPool
 import com.twitter.finagle.stats.{ClientStatsReceiver, NullStatsReceiver}
-import com.twitter.finagle.thrift.{Protocols, ThriftClientFramedCodec}
+import com.twitter.finagle.thrift.Protocols
 import com.twitter.finagle.tracing.{Record, Trace, TraceId, Tracer}
 import com.twitter.finagle.util.DefaultTimer
 import com.twitter.finagle.zipkin.core.Sampler
 import com.twitter.finagle.zipkin.thrift.{ScribeRawZipkinTracer, ZipkinTracer}
 import com.twitter.finagle.zipkin.thriftscala.Scribe
-import com.twitter.finagle.{Service, SimpleFilter}
 import io.buoyant.linkerd.{TracerConfig, TracerInitializer}
-import java.net.InetSocketAddress
 
 class ZipkinTracerInitializer extends TracerInitializer {
   val configClass = classOf[ZipkinConfig]
@@ -32,22 +30,15 @@ case class ZipkinConfig(
   override def newTracer(): Tracer = new Tracer {
     private[this] val underlying: Tracer = {
       // Cribbed heavily from com.twitter.finagle.zipkin.thrift.RawZipkinTracer
-      val transport = ClientBuilder()
-        .name("zipkin-tracer")
-        .hosts(new InetSocketAddress(host.getOrElse("localhost"), port.getOrElse(9410)))
-        .codec(ThriftClientFramedCodec())
-        .reportTo(ClientStatsReceiver)
-        .hostConnectionLimit(5)
+      val transport = Thrift.client
+        .withStatsReceiver(ClientStatsReceiver)
+        .withSessionPool.maxSize(5)
         .configured(DefaultPool.Param.param.default.copy(maxWaiters = 250))
         // reduce timeouts because trace requests should be fast
-        .timeout(100.millis)
-        .daemon(true)
-        // disable failure accrual so that we don't evict nodes when connections
-        // are saturated
-        .noFailureAccrual
-        // disable fail fast since we often be sending to a load balancer
-        .failFast(false)
-        .build()
+        .withRequestTimeout(100.millis)
+        .withSessionQualifier.noFailureAccrual
+        .withSessionQualifier.noFailFast
+        .newService(Name.bound(Address(host.getOrElse("localhost"), port.getOrElse(9410))), "zipkin-tracer")
 
       val client = new Scribe.FinagledClient(
         new TracelessFilter andThen transport,

--- a/linkerd/tracer/zipkin/src/main/scala/io/buoyant/linkerd/tracer/ZipkinTracerInitializer.scala
+++ b/linkerd/tracer/zipkin/src/main/scala/io/buoyant/linkerd/tracer/ZipkinTracerInitializer.scala
@@ -36,7 +36,10 @@ case class ZipkinConfig(
         .configured(DefaultPool.Param.param.default.copy(maxWaiters = 250))
         // reduce timeouts because trace requests should be fast
         .withRequestTimeout(100.millis)
+        // disable failure accrual so that we don't evict nodes when connections
+        // are saturated
         .withSessionQualifier.noFailureAccrual
+        // disable fail fast since we often be sending to a load balancer
         .withSessionQualifier.noFailFast
         .newService(Name.bound(Address(host.getOrElse("localhost"), port.getOrElse(9410))), "zipkin-tracer")
 

--- a/marathon/src/main/scala/io/buoyant/marathon/v2/AppIdNamer.scala
+++ b/marathon/src/main/scala/io/buoyant/marathon/v2/AppIdNamer.scala
@@ -1,9 +1,10 @@
 package io.buoyant.marathon.v2
 
-import com.twitter.finagle.{Addr, Name, Namer, NameTree, Path}
+import com.twitter.finagle._
 import com.twitter.finagle.util.DefaultTimer
 import com.twitter.finagle.tracing.Trace
-import com.twitter.util._
+import com.twitter.util.{NonFatal => _, _}
+import scala.util.control.NonFatal
 
 object AppIdNamer {
   object Closed extends Throwable

--- a/namer/consul/src/main/scala/io/buoyant/namer/consul/DcServices.scala
+++ b/namer/consul/src/main/scala/io/buoyant/namer/consul/DcServices.scala
@@ -114,7 +114,7 @@ private[consul] object DcServices {
     Failure("consul did not return an index")
 
   private[this] val DcRelease =
-    Failure("dc observation released").flagged(Failure.Interrupted)
+    Failure("dc observation released", Failure.Interrupted)
 
   private[this] val toServices: v1.Indexed[Map[String, Seq[String]]] => v1.Indexed[Set[SvcKey]] = {
     case v1.Indexed(services, idx) =>

--- a/namer/consul/src/main/scala/io/buoyant/namer/consul/SvcAddr.scala
+++ b/namer/consul/src/main/scala/io/buoyant/namer/consul/SvcAddr.scala
@@ -122,8 +122,7 @@ private[consul] object SvcAddr {
   }
 
   private[this] val ServiceRelease =
-    Failure("service observation released")
-      .flagged(Failure.Interrupted)
+    Failure("service observation released", Failure.Interrupted)
 
   private[this] val NoIndexException =
     Failure(new IllegalArgumentException("consul did not return an index") with NoStackTrace)

--- a/namer/core/src/main/scala/io/buoyant/namer/DefaultInterpreterInitializer.scala
+++ b/namer/core/src/main/scala/io/buoyant/namer/DefaultInterpreterInitializer.scala
@@ -3,9 +3,9 @@ package io.buoyant.namer
 import com.twitter.finagle.Name.Bound
 import com.twitter.finagle._
 import com.twitter.finagle.naming.NameInterpreter
-import com.twitter.util.{Activity, NonFatal, Var}
+import com.twitter.util.{Activity, Var}
 import io.buoyant.namer.DelegateTree._
-import scala.util.control.NoStackTrace
+import scala.util.control.{NonFatal, NoStackTrace}
 import scala.{Exception => ScalaException}
 
 object DefaultInterpreterConfig {

--- a/namer/marathon/src/main/scala/io/buoyant/namer/marathon/Authenticator.scala
+++ b/namer/marathon/src/main/scala/io/buoyant/namer/marathon/Authenticator.scala
@@ -24,7 +24,7 @@ object Authenticator {
   }
   private[marathon] case class UnauthorizedResponse(rsp: http.Response) extends Throwable
   private[this] case class AuthToken(token: Option[String])
-  private[this] val closedException = Failure("closed").flagged(Failure.Interrupted)
+  private[this] val closedException = Failure("closed", Failure.Interrupted)
   private[this] val closedExceptionF = Future.exception(closedException)
   private[this] val missingTokenException = Failure("missing token")
   private[this] val missingTokenExceptionF = Future.exception(missingTokenException)

--- a/namerd/iface/interpreter-thrift/src/main/scala/io/buoyant/namerd/iface/ThriftNamerInterface.scala
+++ b/namerd/iface/interpreter-thrift/src/main/scala/io/buoyant/namerd/iface/ThriftNamerInterface.scala
@@ -6,7 +6,7 @@ import com.twitter.finagle.stats.StatsReceiver
 import com.twitter.finagle.tracing.Trace
 import com.twitter.io.Buf
 import com.twitter.logging.Logger
-import com.twitter.util._
+import com.twitter.util.{NonFatal => _, _}
 import io.buoyant.namer.{Metadata, DelegateTree, Delegator}
 import io.buoyant.namerd.Ns
 import io.buoyant.namerd.iface.ThriftNamerInterface.Capacity
@@ -14,6 +14,7 @@ import io.buoyant.namerd.iface.thriftscala.{Delegation, DtabRef, DtabReq}
 import io.buoyant.namerd.iface.{thriftscala => thrift}
 import java.nio.ByteBuffer
 import java.util.concurrent.atomic.AtomicLong
+import scala.util.control.NonFatal
 
 object ThriftNamerInterface {
 

--- a/project/Deps.scala
+++ b/project/Deps.scala
@@ -8,15 +8,15 @@ object Deps {
 
   // process lifecycle
   val twitterServer =
-    ("com.twitter" %% "twitter-server" % "1.25.0")
+    ("com.twitter" %% "twitter-server" % "1.26.0")
       .exclude("com.twitter", "finagle-zipkin_2.11")
 
   def twitterUtil(mod: String) =
-    "com.twitter" %% s"util-$mod" % "6.39.0"
+    "com.twitter" %% s"util-$mod" % "6.40.0"
 
   // networking
   def finagle(mod: String) =
-    "com.twitter" %% s"finagle-$mod" % "6.40.0"
+    "com.twitter" %% s"finagle-$mod" % "6.41.0"
 
   def netty4(mod: String) =
     "io.netty" % s"netty-$mod" % "4.1.4.Final"

--- a/router/h2/src/e2e/scala/io/buoyant/router/h2/RouterEndToEndTest.scala
+++ b/router/h2/src/e2e/scala/io/buoyant/router/h2/RouterEndToEndTest.scala
@@ -102,7 +102,7 @@ class RouterEndToEndTest
       val reqStream = await(dogReqP)
       assert(!rspF.isDefined)
 
-      rspF.raise(Failure("failz").flagged(Failure.Interrupted))
+      rspF.raise(Failure("failz", Failure.Interrupted))
       assert(await(rspF.liftToTry) == Throw(Reset.Cancel))
       eventually(assert(serverInterrupted == Some(Reset.Cancel)))
 
@@ -188,7 +188,7 @@ class RouterEndToEndTest
       val _ = await(dogReqP)
       assert(!rspF.isDefined)
 
-      dogRspP.setException(Failure("failz").flagged(Failure.Rejected))
+      dogRspP.setException(Failure("failz", Failure.Rejected))
       assert(await(rspF.liftToTry) == Throw(Reset.Refused))
 
     } finally {


### PR DESCRIPTION
* `com.twitter.util.NonFatal` deprecated in favor of `scala.util.control.NonFatal`
* `Failure.flagged` is now private, use constructor that accepts flags instead
* `ThriftClientFramedCodec()` is deprecated, use stack-API to build zipkin client instead.