### PR TITLE
[h2] Ignore URL params in io.l5d.headerPath

### DIFF
--- a/linkerd/protocol/h2/src/main/scala/io/buoyant/linkerd/protocol/h2/HeaderPathIdentifier.scala
+++ b/linkerd/protocol/h2/src/main/scala/io/buoyant/linkerd/protocol/h2/HeaderPathIdentifier.scala
@@ -85,7 +85,7 @@ object HeaderPathIdentifier {
     def unapply(uri: String): Option[String] =
       uri.indexOf('?') match {
         case -1 => Some(uri.stripSuffix("/"))
-        case idx => Some(uri.substring(idx + 1).stripSuffix("/"))
+        case idx => Some(uri.substring(0, idx).stripSuffix("/"))
       }
   }
 }


### PR DESCRIPTION
The io.l5d.headerPath identifier did not ignore URL params as it intended to.
Fix and test this identifier accordingly.

Fixes #877