### PR TITLE
Fix prometheus histogram key issue

### DIFF
--- a/linkerd/docs/routers.md
+++ b/linkerd/docs/routers.md
@@ -26,7 +26,8 @@ routers:
   originator: true
   timeoutMs: 10000
   bindingTimeoutMs: 5000
-  responseClassifier: io.l5d.nonRetryable5XX
+  responseClassifier:
+    kind: io.l5d.nonRetryable5XX
 ```
 
 Key | Default Value | Description

--- a/telemetry/common-metrics/src/main/scala/io/buoyant/telemetry/commonMetrics/PrometheusStatsHandler.scala
+++ b/telemetry/common-metrics/src/main/scala/io/buoyant/telemetry/commonMetrics/PrometheusStatsHandler.scala
@@ -26,7 +26,7 @@ private[telemetry] object PrometheusStatsHandler {
     def replaceAllIn(str: String) = regex.replaceAllIn(str, replace)
   }
   private[this] val delimiter = Escape("[/]".r, ":")
-  private[this] val statPattern = """(.*)\.(count|sum|avg|min|max|stddev|p50|p90|p95|p99|p9990)$""".r
+  private[this] val statPattern = """(.*)\.(count|sum|avg|min|max|stddev|p[0-9]+)$""".r
   private[this] val disallowedChars = Escape("[^a-zA-Z0-9:]".r, "_")
 
   private[this] def escapeKey(key: String) = {

--- a/telemetry/common-metrics/src/test/scala/io/buoyant/telemetry/commonMetrics/PrometheusStatsHandlerTest.scala
+++ b/telemetry/common-metrics/src/test/scala/io/buoyant/telemetry/commonMetrics/PrometheusStatsHandlerTest.scala
@@ -9,9 +9,17 @@ class PrometheusStatsHandlerTest extends FunSuite {
     assert(key == "foo:bar_baz_abc123:go_zoo_default:size")
   }
 
-  test("Extract labels from the key") {
-    val key = PrometheusStatsHandler.formatKey("rt/http/srv/0.0.0.0/12345/handletime_us.max")
-    assert(key == "rt:http:srv:0_0_0_0:12345:handletime_us{stat=\"max\"}")
+  test("Extract histogram labels from the key") {
+    val labels = Seq("count", "sum", "avg", "min", "max", "stddev", "p50", "p90", "p95", "p99", "p9990", "p9999")
+    for (label <- labels) {
+      val key = PrometheusStatsHandler.formatKey(s"rt/http/srv/0.0.0.0/12345/handletime_us.${label}")
+      assert(key == s"""rt:http:srv:0_0_0_0:12345:handletime_us{stat=\"${label}\"}""")
+    }
+  }
+
+  test("Does not extract non-histogram labels from the key") {
+    val key = PrometheusStatsHandler.formatKey(s"rt/http/srv/0.0.0.0/12345/handletime_us.custom")
+    assert(key == s"rt:http:srv:0_0_0_0:12345:handletime_us_custom")
   }
 
   test("Preserve non-histogram stats") {


### PR DESCRIPTION
## Problem

The regex that we're using to match histogram stats when generating prometheus metrics doesn't capture all possible stat labels. Before this change:

```
rt:http:dst:path:http:1_1:GET:default:request_latency_ms{stat="p50"} 0
rt:http:dst:path:http:1_1:GET:default:request_latency_ms{stat="p90"} 1
rt:http:dst:path:http:1_1:GET:default:request_latency_ms{stat="p95"} 1
rt:http:dst:path:http:1_1:GET:default:request_latency_ms{stat="p99"} 3
rt:http:dst:path:http:1_1:GET:default:request_latency_ms{stat="p9990"} 10
rt:http:dst:path:http:1_1:GET:default:request_latency_ms_p9999 221
```

## Solution

Update the regex to be more inclusive. After this change:

```
rt:http:dst:path:http:1_1:GET:default:request_latency_ms{stat="p50"} 1
rt:http:dst:path:http:1_1:GET:default:request_latency_ms{stat="p90"} 2
rt:http:dst:path:http:1_1:GET:default:request_latency_ms{stat="p95"} 2
rt:http:dst:path:http:1_1:GET:default:request_latency_ms{stat="p99"} 4
rt:http:dst:path:http:1_1:GET:default:request_latency_ms{stat="p9990"} 9
rt:http:dst:path:http:1_1:GET:default:request_latency_ms{stat="p9999"} 235
```

Am also including a small docs fix as part of this change.
