### PR TITLE
Clean up template passing in dashboard js

### DIFF
--- a/admin/src/main/resources/io/buoyant/admin/js/src/dashboard.js
+++ b/admin/src/main/resources/io/buoyant/admin/js/src/dashboard.js
@@ -6,34 +6,14 @@ define([
   'src/routers',
   'src/process_info',
   'src/request_totals',
-  'src/router_controller',
-  'text!template/router_container.template',
-  'text!template/router_server.template',
-  'text!template/router_client.template',
-  'text!template/router_client_container.template',
-  'text!template/router_server_container.template',
-  'text!template/server_rate_metric.partial.template',
-  'text!template/metric.partial.template',
-  'text!template/router_summary.template',
-  'text!template/process_info.template',
-  'text!template/request_totals.template'
+  'src/router_controller'
 ], function(
   $, Handlebars, bootstrap,
   MetricsCollector,
   Routers,
   ProcInfo,
   RequestTotals,
-  RouterController,
-  routerContainerTemplate,
-  routerServerTemplate,
-  routerClientTemplate,
-  routerClientContainerTemplate,
-  routerServerContainerTemplate,
-  serverMetricPartialTemplate,
-  metricPartialTemplate,
-  routerSummaryTemplate,
-  overviewStatsTemplate,
-  requestTotalsTemplate
+  RouterController
 ) {
   return function() {
     /**
@@ -42,26 +22,16 @@ define([
     var UPDATE_INTERVAL = 1000;
 
     $.get("/admin/metrics.json").done(function(metricsJson) {
-      var routerTemplates = {
-        summary: Handlebars.compile(routerSummaryTemplate),
-        container: Handlebars.compile(routerContainerTemplate),
-        server: Handlebars.compile(routerServerTemplate),
-        client: Handlebars.compile(routerClientTemplate),
-        clientContainer: Handlebars.compile(routerClientContainerTemplate),
-        serverContainer: Handlebars.compile(routerServerContainerTemplate),
-        serverMetric: Handlebars.compile(serverMetricPartialTemplate),
-        metric: Handlebars.compile(metricPartialTemplate)
-      }
-
       var metricsCollector = MetricsCollector(metricsJson);
       var routers = Routers(metricsJson, metricsCollector);
 
       var $serverData = $(".server-data");
       var buildVersion = $serverData.data("linkerd-version");
       var selectedRouter = $serverData.data("router-name");
-      ProcInfo(metricsCollector, $(".proc-info"), Handlebars.compile(overviewStatsTemplate), buildVersion);
-      RequestTotals(metricsCollector, selectedRouter, $(".request-totals"), Handlebars.compile(requestTotalsTemplate), _.keys(metricsJson));
-      RouterController(metricsCollector, selectedRouter, routers, routerTemplates, $(".dashboard-container"));
+
+      ProcInfo(metricsCollector, $(".proc-info"), buildVersion);
+      RequestTotals(metricsCollector, selectedRouter, $(".request-totals"), _.keys(metricsJson));
+      RouterController(metricsCollector, selectedRouter, routers, $(".dashboard-container"));
 
       $(function() {
         metricsCollector.start(UPDATE_INTERVAL);

--- a/admin/src/main/resources/io/buoyant/admin/js/src/process_info.js
+++ b/admin/src/main/resources/io/buoyant/admin/js/src/process_info.js
@@ -1,9 +1,10 @@
 "use strict";
 
 define([
-  'jQuery',
-  'src/utils'
-  ], function($, Utils) {
+  'jQuery', 'Handlebars',
+  'src/utils',
+  'text!template/process_info.template'
+  ], function($, Handlebars, Utils, overviewStatsTemplate) {
   /**
    * Process info for topline summary
    */
@@ -11,7 +12,7 @@ define([
 
     var msToStr = new Utils.MsToStringConverter();
     var bytesToStr = new Utils.BytesToStringConverter();
-    var template;
+    var template = Handlebars.compile(overviewStatsTemplate);
 
     var stats = [
       { description: "version", dataKey: "" },
@@ -43,8 +44,7 @@ define([
       $root.html(template({stats: templateData}))
     }
 
-    return function(metricsCollector, $root, t, buildVersion) {
-      template = t
+    return function(metricsCollector, $root, buildVersion) {
       stats[0].value = buildVersion;
 
       if (metricsCollector) {

--- a/admin/src/main/resources/io/buoyant/admin/js/src/request_totals.js
+++ b/admin/src/main/resources/io/buoyant/admin/js/src/request_totals.js
@@ -1,8 +1,14 @@
 "use strict";
 
-define(["jQuery", 'src/query'], function($, Query) {
+define([
+  'jQuery', 'Handlebars',
+  'src/query',
+  'text!template/request_totals.template'
+  ], function($, Handlebars, Query, requestTotalsTemplate) {
 
   var RequestTotals = (function() {
+    var template = Handlebars.compile(requestTotalsTemplate);
+
     var metricDefinitions = [
       {
         description: "Current requests",
@@ -27,13 +33,13 @@ define(["jQuery", 'src/query'], function($, Query) {
       return Query.filter(new RegExp(metaQuery.join("|")), possibleMetrics);
     }
 
-    function render($root, template, metricData) {
+    function render($root, metricData) {
       $root.html(template({
         metrics : metricData
       }));
     }
 
-    return function(metricsCollector, selectedRouter, $root, template) {
+    return function(metricsCollector, selectedRouter, $root) {
       function onMetricsUpdate(data) {
         var transformedData = _.map(metricDefinitions, function(defn) {
           var metricsByQuery = Query.filter(defn.query, data.specific);
@@ -44,11 +50,11 @@ define(["jQuery", 'src/query'], function($, Query) {
           };
         });
 
-        render($root, template, transformedData);
+        render($root, transformedData);
       }
 
       if (!selectedRouter) {
-        render($root, template, metricDefinitions);
+        render($root, metricDefinitions);
         metricsCollector.registerListener(onMetricsUpdate, desiredMetrics);
       } else {
         $root.hide();

--- a/admin/src/main/resources/io/buoyant/admin/js/src/router_client.js
+++ b/admin/src/main/resources/io/buoyant/admin/js/src/router_client.js
@@ -6,11 +6,18 @@ define([
   'Handlebars',
   'src/utils',
   'src/query',
-  'src/success_rate_graph'
-], function($, _, Handlebars, Utils, Query, SuccessRateGraph) {
-
+  'src/success_rate_graph',
+  'text!template/metric.partial.template',
+  'text!template/router_client.template'
+], function($, _, Handlebars,
+  Utils,
+  Query,
+  SuccessRateGraph,
+  metricPartialTemplate,
+  routerClientTemplate) {
   var RouterClient = (function() {
-    var template;
+    var template = Handlebars.compile(routerClientTemplate);
+
     var metricToColorShade = {
       "max": "light",
       "p9990": "tint",
@@ -92,9 +99,10 @@ define([
       return summary;
     }
 
-    return function (metricsCollector, routers, client, $metricsEl, routerName, clientTemplate, metricPartial, $chartEl, colors, $toggleLinks, shouldExpandInitially) {
-      template = clientTemplate;
+    return function (metricsCollector, routers, client, $metricsEl, routerName, $chartEl, colors, $toggleLinks, shouldExpandInitially) {
+      var metricPartial = Handlebars.compile(metricPartialTemplate);
       Handlebars.registerPartial('metricPartial', metricPartial);
+
       var clientColor = colors.color;
       var latencyLegend = createLatencyLegend(colors.colorFamily);
       var metricDefinitions = getMetricDefinitions(routerName, client.label);

--- a/admin/src/main/resources/io/buoyant/admin/js/src/router_clients.js
+++ b/admin/src/main/resources/io/buoyant/admin/js/src/router_clients.js
@@ -1,10 +1,14 @@
 "use strict";
 
 define([
-  'jQuery',
+  'jQuery', 'Handlebars',
   'src/router_client',
-  'src/combined_client_graph'
-], function($, RouterClient, CombinedClientGraph) {
+  'src/combined_client_graph',
+  'text!template/router_client_container.template'
+], function($, Handlebars,
+  RouterClient,
+  CombinedClientGraph,
+  routerClientContainerTemplate) {
   var RouterClients = (function() {
     var EXPAND_CLIENT_THRESHOLD = 6;
 
@@ -22,7 +26,9 @@ define([
       return numClients < EXPAND_CLIENT_THRESHOLD;
     }
 
-    return function (metricsCollector, routers, $clientEl, routerName, clientTemplate, metricPartial, clientContainerTemplate, colors) {
+    return function (metricsCollector, routers, $clientEl, routerName, colors) {
+      var clientContainerTemplate = Handlebars.compile(routerClientContainerTemplate);
+
       var clientToColor = assignColorsToClients(colors, routers.clients(routerName));
       var combinedClientGraph = CombinedClientGraph(metricsCollector, routers, routerName, $clientEl.find(".router-graph"), clientToColor);
       var clients = routers.clients(routerName);
@@ -50,7 +56,7 @@ define([
         var $chart = $container.find(".chart-container");
         var $toggle = $container.find(".client-toggle");
 
-        return RouterClient(metricsCollector, routers, client, $metrics, routerName, clientTemplate, metricPartial, $chart, colorsForClient, $toggle, shouldExpand);
+        return RouterClient(metricsCollector, routers, client, $metrics, routerName, $chart, colorsForClient, $toggle, shouldExpand);
       }
 
       function addClients(addedClients) {

--- a/admin/src/main/resources/io/buoyant/admin/js/src/router_controller.js
+++ b/admin/src/main/resources/io/buoyant/admin/js/src/router_controller.js
@@ -1,15 +1,17 @@
 "use strict";
 
 define([
-  'lodash',
+  'lodash', 'Handlebars',
   'src/router_summary',
   'src/router_servers',
-  'src/router_clients'
+  'src/router_clients',
+  'text!template/router_container.template'
 ], function(
-  _,
+  _, Handlebars,
   RouterSummary,
   RouterServers,
-  RouterClients
+  RouterClients,
+  routerContainerTemplate
 ) {
 
   var RouterController = (function () {
@@ -93,7 +95,8 @@ define([
       return routerData;
     }
 
-    function initializeRouterContainers(selectedRouter, routers, $parentContainer, template) {
+    function initializeRouterContainers(selectedRouter, routers, $parentContainer) {
+      var template = Handlebars.compile(routerContainerTemplate);
       var routerData = getSelectedRouterData(selectedRouter, routers);
       var containers = template({ routers: _.keys(routerData) });
       $parentContainer.html(containers);
@@ -107,17 +110,17 @@ define([
       return routerContainers;
     }
 
-    return function(metricsCollector, selectedRouter, routers, templates, $parentContainer) {
-      var routerContainerEls = initializeRouterContainers(selectedRouter, routers, $parentContainer, templates.container);
+    return function(metricsCollector, selectedRouter, routers, $parentContainer) {
+      var routerContainerEls = initializeRouterContainers(selectedRouter, routers, $parentContainer);
 
       _.each(routerContainerEls, function(container, router) {
         var $summaryEl = $(container.find(".summary")[0]);
         var $serversEl = $(container.find(".servers")[0]);
         var $clientsEl = $(container.find(".clients")[0]);
 
-        RouterSummary(metricsCollector, templates.summary, $summaryEl, router);
-        RouterServers(metricsCollector, routers, $serversEl, router, templates.server, templates.serverMetric, templates.serverContainer);
-        RouterClients(metricsCollector, routers, $clientsEl, router , templates.client, templates.metric, templates.clientContainer, colorOrder);
+        RouterSummary(metricsCollector, $summaryEl, router);
+        RouterServers(metricsCollector, routers, $serversEl, router);
+        RouterClients(metricsCollector, routers, $clientsEl, router, colorOrder);
       });
 
       return {};

--- a/admin/src/main/resources/io/buoyant/admin/js/src/router_server.js
+++ b/admin/src/main/resources/io/buoyant/admin/js/src/router_server.js
@@ -1,10 +1,12 @@
 "use strict";
 
 define([
+  'Handlebars',
   'src/success_rate_graph',
   'src/query',
-  'src/utils'
-], function(SuccessRateGraph, Query, Utils) {
+  'src/utils',
+  'text!template/router_server.template'
+], function(Handlebars, SuccessRateGraph, Query, Utils, routerServerTemplate) {
   var RouterServer = (function() {
     var template;
 
@@ -89,8 +91,8 @@ define([
       return [{ name: "successRate", delta: successRate * 100 }];
     }
 
-    return function (metricsCollector, server, $serverEl, routerName, serverTemplate) {
-      template = serverTemplate;
+    return function (metricsCollector, server, $serverEl, routerName) {
+      template = Handlebars.compile(routerServerTemplate);
       var $metricsEl = $serverEl.find(".server-metrics");
       var $chartEl = $serverEl.find(".server-success-chart");
       var chart = SuccessRateGraph($chartEl, "#4AD8AC");

--- a/admin/src/main/resources/io/buoyant/admin/js/src/router_servers.js
+++ b/admin/src/main/resources/io/buoyant/admin/js/src/router_servers.js
@@ -4,17 +4,22 @@ define([
   'jQuery',
   'lodash',
   'Handlebars',
-  'src/router_server'
-], function($, _, Handlebars, RouterServer) {
+  'src/router_server',
+  'text!template/router_server_container.template',
+  'text!template/server_rate_metric.partial.template'
+], function($, _, Handlebars, RouterServer, routerServerContainerTemplate, serverMetricPartialTemplate) {
+    var serverContainerTemplate = Handlebars.compile(routerServerContainerTemplate);
+    var rateMetricPartial = Handlebars.compile(serverMetricPartialTemplate);
+
     var RouterServers = (function() {
-    return function (metricsCollector, routers, $serverEl, routerName, serverTemplate, rateMetricPartial, serverContainerTemplate) {
+    return function (metricsCollector, routers, $serverEl, routerName) {
       var servers = routers.servers(routerName);
       Handlebars.registerPartial('rateMetricPartial', rateMetricPartial);
 
       _.map(servers, function(server) {
         var $el = $(serverContainerTemplate());
         $serverEl.append($el);
-        RouterServer(metricsCollector, server, $el, routerName, serverTemplate);
+        RouterServer(metricsCollector, server, $el, routerName);
       });
     }
   })();

--- a/admin/src/main/resources/io/buoyant/admin/js/src/router_summary.js
+++ b/admin/src/main/resources/io/buoyant/admin/js/src/router_summary.js
@@ -2,10 +2,18 @@
 
 define([
   'jQuery',
+  'Handlebars',
   'src/query',
-  'src/utils'
-], function($, Query, Utils) {
+  'src/utils',
+  'text!template/router_summary.template'
+], function($, Handlebars,
+  Query,
+  Utils,
+  routerSummaryTemplate
+) {
   var RouterSummary = (function() {
+    var template = Handlebars.compile(routerSummaryTemplate);
+
     function processResponses(data, routerName) {
       var process = function(metricName) { return processResponse(data, routerName, metricName); };
 
@@ -46,18 +54,18 @@ define([
       }
     }
 
-    function renderRouterSummary(routerData, template, routerName, $summaryEl) {
+    function renderRouterSummary(routerData, routerName, $summaryEl) {
       $summaryEl.html(template(routerData));
     }
 
-    return function(metricsCollector, summaryTemplate, $summaryEl, routerName) {
+    return function(metricsCollector, $summaryEl, routerName) {
       var query = Query.serverQuery().allServers().withRouter(routerName).withMetrics(["load", "requests", "success", "failures"]).build();
 
-      renderRouterSummary({ router: routerName }, summaryTemplate, routerName, $summaryEl);
+      renderRouterSummary({ router: routerName }, routerName, $summaryEl);
 
       metricsCollector.registerListener(function(data) {
           var summaryData = processResponses(data.specific, routerName);
-          renderRouterSummary(summaryData, summaryTemplate, routerName, $summaryEl);
+          renderRouterSummary(summaryData, routerName, $summaryEl);
         }, function(metrics) { return Query.filter(query, metrics); });
 
       return {};


### PR DESCRIPTION
Now that we are using require, we don't need to pass down templates all the way from the root.
Instead, let's include the template alongside the module that uses it.