### PR TITLE
[sbt] Move base settings keys into companion object

### DIFF
--- a/ci/docker-publish.sh
+++ b/ci/docker-publish.sh
@@ -22,9 +22,9 @@ if [ "${NO_PUSH:-}" = "1" ]; then
 fi
 
 if [ -n "$tag" ]; then
-  ./sbt "set dockerTag in (linkerd, Bundle) := \"${tag}\"" "linkerd/bundle:${docker_target}" \
-        "set dockerTag in (namerd, Bundle) := \"${tag}\"" "namerd/bundle:${docker_target}" \
-        "set dockerTag in (namerd, Dcos) := \"dcos-${tag}\"" "namerd/dcos:${docker_target}"
+  ./sbt "set Base.dockerTag in (linkerd, Bundle) := \"${tag}\"" "linkerd/bundle:${docker_target}" \
+        "set Base.dockerTag in (namerd, Bundle) := \"${tag}\"" "namerd/bundle:${docker_target}" \
+        "set Base.dockerTag in (namerd, Dcos) := \"dcos-${tag}\"" "namerd/dcos:${docker_target}"
 else
   ./sbt "linkerd/bundle:${docker_target}" \
         "namerd/bundle:${docker_target}" \

--- a/project/Base.scala
+++ b/project/Base.scala
@@ -17,6 +17,7 @@ import scoverage.ScoverageSbtPlugin
  * Base project configuration.
  */
 class Base extends Build {
+  import Base._
   val headVersion = "0.8.4"
 
   object Git {
@@ -27,9 +28,6 @@ class Base extends Build {
       case _ => s"$headVersion-SNAPSHOT"
     }
   }
-
-  val developTwitterDeps = settingKey[Boolean]("use SNAPSHOT twitter dependencies")
-  val doDevelopTwitterDeps = (developTwitterDeps in Global) ?? false
 
   val baseSettings = Seq(
     organization := "io.buoyant",
@@ -103,11 +101,6 @@ class Base extends Build {
        |exec "${JAVA_HOME:-/usr}/bin/java" -XX:+PrintCommandLineFlags $JVM_OPTIONS -server -jar $0 "$@"
        |""".stripMargin.split("\n").toSeq
 
-  val dockerEnvPrefix = settingKey[String]("prefix to be applied to environment variables")
-  val dockerJavaImage = settingKey[String]("base docker image, providing java")
-  val dockerTag = settingKey[String]("docker image tag")
-  val assemblyExecScript = settingKey[Seq[String]]("script used to execute the application")
-
   val appPackagingSettings = assemblySettings ++ baseDockerSettings ++ Seq(
     assemblyExecScript := defaultExecScript,
     assemblyOption in assembly := (assemblyOption in assembly).value.copy(
@@ -145,9 +138,6 @@ class Base extends Build {
       tag = Some(dockerTag.value)
     )
   )
-
-  val configFile = settingKey[File]("path to config file")
-  val runtimeConfiguration = settingKey[Configuration]("runtime configuration")
 
   // Examples are named by a .yaml config file
   def exampleSettings(runtime: Project) = Seq(
@@ -262,4 +252,17 @@ class Base extends Build {
   }
 
   implicit def pimpMyProject(p: Project): ProjectHelpers = ProjectHelpers(p)
+}
+
+object Base {
+  val developTwitterDeps = settingKey[Boolean]("use SNAPSHOT twitter dependencies")
+  val doDevelopTwitterDeps = (developTwitterDeps in Global) ?? false
+
+  val dockerEnvPrefix = settingKey[String]("prefix to be applied to environment variables")
+  val dockerJavaImage = settingKey[String]("base docker image, providing java")
+  val dockerTag = settingKey[String]("docker image tag")
+  val assemblyExecScript = settingKey[Seq[String]]("script used to execute the application")
+
+  val configFile = settingKey[File]("path to config file")
+  val runtimeConfiguration = settingKey[Configuration]("runtime configuration")
 }

--- a/project/Grpc.scala
+++ b/project/Grpc.scala
@@ -7,6 +7,7 @@ import scala.language.implicitConversions
 import scoverage.ScoverageKeys._
 
 object Grpc extends Base {
+  import Base._
 
   val execScript =
     """|#!/bin/sh

--- a/project/LinkerdBuild.scala
+++ b/project/LinkerdBuild.scala
@@ -7,6 +7,7 @@ import sbtunidoc.Plugin._
 import scoverage.ScoverageKeys._
 
 object LinkerdBuild extends Base {
+  import Base._
 
   val Minimal = config("minimal")
   val Bundle = config("bundle") extend Minimal


### PR DESCRIPTION
If multiple projects extend Base, they will each have a copy of the settings keys defined in Base.  This leads to ambiguous imports like this:

```
<set>:1: error: reference to dockerTag is ambiguous;
it is imported twice in the same scope by
import Grpc._
and import LinkerdBuild._
dockerTag in (linkerd, Bundle) := "nightly"
^
[error] Type error in expression
```

Instead, move the base settings keys into the Base companion object.