### PR TITLE
Add `stripDomain` parameter for Consul CatalogNamer to optionally strip domains from Consul service name lookups

### DIFF
--- a/linkerd/docs/namer.md
+++ b/linkerd/docs/namer.md
@@ -163,6 +163,7 @@ namers:
   includeTag: true
   useHealthCheck: true
   setHost: true
+  stripDomain: true
   consistencyMode: stale
 ```
 
@@ -184,6 +185,7 @@ includeTag | `false` | If `true`, read a Consul tag from the path.
 useHealthCheck | `false` | If `true`, exclude app instances that are failing Consul health checks. Even if `false`, linkerd's built-in resiliency algorithms will still apply.
 token | no authentication | The auth token to use when making API calls.
 setHost | `false` | If `true`, HTTP requests resolved by Consul will have their Host header overwritten to `${serviceName}.service.${datacenter}.${domain}`. `$domain` is fetched from Consul.
+stripDomain | `false` | If `true`, Service names resolved by Consul will have any domains stripped before lookup. e.g. `servicename.service.local` -> `servicename`.
 consistencyMode | `default` | Select between [Consul API consistency modes](https://www.consul.io/docs/agent/http.html) such as `default`, `stale` and `consistent`.
 failFast | `false` | If `false`, disable fail fast and failure accrual for Consul client. Keep it `false` when using a local agent but change it to `true` when talking directly to an HA Consul API.
 

--- a/namer/consul/src/main/scala/io/buoyant/namer/consul/ConsulInitializer.scala
+++ b/namer/consul/src/main/scala/io/buoyant/namer/consul/ConsulInitializer.scala
@@ -38,6 +38,7 @@ case class ConsulConfig(
   useHealthCheck: Option[Boolean],
   token: Option[String] = None,
   setHost: Option[Boolean] = None,
+  stripDomain: Option[Boolean] = None,
   consistencyMode: Option[ConsistencyMode] = None,
   failFast: Option[Boolean] = None
 ) extends NamerConfig {
@@ -77,11 +78,11 @@ case class ConsulConfig(
     includeTag match {
       case Some(true) =>
         ConsulNamer.tagged(
-          prefix, consul, agent, setHost.getOrElse(false), consistencyMode, stats
+          prefix, consul, agent, setHost.getOrElse(false), stripDomain.getOrElse(false), consistencyMode, stats
         )
       case _ =>
         ConsulNamer.untagged(
-          prefix, consul, agent, setHost.getOrElse(false), consistencyMode, stats
+          prefix, consul, agent, setHost.getOrElse(false), stripDomain.getOrElse(false), consistencyMode, stats
         )
     }
   }

--- a/namer/consul/src/main/scala/io/buoyant/namer/consul/ConsulNamer.scala
+++ b/namer/consul/src/main/scala/io/buoyant/namer/consul/ConsulNamer.scala
@@ -12,11 +12,12 @@ object ConsulNamer {
     consulApi: v1.ConsulApi,
     agentApi: v1.AgentApi,
     setHost: Boolean = false,
+    stripDomain: Boolean = false,
     consistency: Option[v1.ConsistencyMode] = None,
     stats: StatsReceiver = NullStatsReceiver
   ): Namer = {
     val lookup = new LookupCache(consulApi, agentApi, setHost, consistency, stats)
-    new TaggedNamer(lookup, prefix)
+    new TaggedNamer(lookup, prefix, stripDomain)
   }
 
   def untagged(
@@ -24,31 +25,32 @@ object ConsulNamer {
     consulApi: v1.ConsulApi,
     agentApi: v1.AgentApi,
     setHost: Boolean = false,
+    stripDomain: Boolean = false,
     consistency: Option[v1.ConsistencyMode] = None,
     stats: StatsReceiver = NullStatsReceiver
   ): Namer = {
     val lookup = new LookupCache(consulApi, agentApi, setHost, consistency, stats)
-    new UntaggedNamer(lookup, prefix)
+    new UntaggedNamer(lookup, prefix, stripDomain)
   }
 
-  private[this] class TaggedNamer(lookup: LookupCache, prefix: Path) extends Namer {
+  private[this] class TaggedNamer(lookup: LookupCache, prefix: Path, stripDomain: Boolean) extends Namer {
 
     def lookup(path: Path): Activity[NameTree[Name]] =
       path.take(3) match {
         case id@Path.Utf8(dc, tag, service) =>
-          val k = SvcKey(service, Some(tag))
+          val k = if (stripDomain) SvcKey(service.takeWhile(_ != '.'), Some(tag)) else SvcKey(service, Some(tag))
           lookup(dc, k, prefix ++ id, path.drop(3))
 
         case _ => Activity.value(NameTree.Neg)
       }
   }
 
-  private[this] class UntaggedNamer(lookup: LookupCache, prefix: Path) extends Namer {
+  private[this] class UntaggedNamer(lookup: LookupCache, prefix: Path, stripDomain: Boolean) extends Namer {
 
     def lookup(path: Path): Activity[NameTree[Name]] =
       path.take(2) match {
         case id@Path.Utf8(dc, service) =>
-          val k = SvcKey(service, None)
+          val k = if (stripDomain) SvcKey(service.takeWhile(_ != '.'), None) else SvcKey(service, None)
           lookup(dc, k, prefix ++ id, path.drop(2))
 
         case _ => Activity.value(NameTree.Neg)

--- a/namer/consul/src/test/scala/io/buoyant/namer/consul/ConsulTest.scala
+++ b/namer/consul/src/test/scala/io/buoyant/namer/consul/ConsulTest.scala
@@ -27,6 +27,7 @@ class ConsulTest extends FunSuite {
     val mapper = Parser.objectMapper(yaml, Iterable(Seq(ConsulInitializer)))
     val consul = mapper.readValue[NamerConfig](yaml).asInstanceOf[ConsulConfig]
     assert(consul.setHost.isEmpty)
+    assert(consul.stripDomain.isEmpty)
     assert(consul.includeTag.isEmpty)
     assert(!consul.disabled)
   }
@@ -39,6 +40,7 @@ class ConsulTest extends FunSuite {
                     |token: some-token
                     |includeTag: true
                     |setHost: true
+                    |stripDomain: true
                     |consistencyMode: stale
       """.stripMargin
 
@@ -48,6 +50,7 @@ class ConsulTest extends FunSuite {
     assert(consul.port == Some(Port(8600)))
     assert(consul.token == Some("some-token"))
     assert(consul.setHost == Some(true))
+    assert(consul.stripDomain == Some(true))
     assert(consul.includeTag == Some(true))
     assert(consul.consistencyMode == Some(ConsistencyMode.Stale))
     assert(!consul.disabled)


### PR DESCRIPTION
Proposed code changes to support #911 
