### PR TITLE
Increase `eventually` timeout in tests

### DIFF
--- a/test-util/src/main/scala/io/buoyant/test/Awaits.scala
+++ b/test-util/src/main/scala/io/buoyant/test/Awaits.scala
@@ -1,14 +1,18 @@
 package io.buoyant.test
 
 import com.twitter.conversions.time._
-import com.twitter.util.{Await, Duration, Future, Time, TimeoutException}
+import com.twitter.util.{Await, Duration, Future, TimeoutException}
 import org.scalatest.concurrent.Eventually
 import org.scalatest.exceptions.TestFailedException
+import org.scalatest.time.{Millis, Span}
 
 trait Awaits extends Eventually {
 
   def defaultWait: Duration =
     sys.env.get("CI_TERRIBLENESS").map(Duration.parse(_)).getOrElse(2.seconds)
+
+  implicit override val patienceConfig =
+    PatienceConfig(timeout = scaled(Span(defaultWait.inMillis, Millis)))
 
   def awaitStackDepth: Int = 4
 


### PR DESCRIPTION
# Problem: 
We see occasional CI failures when an `eventually` block times out.  
# Solution:
Increase the `eventually` timeout to be the same as the `await` timeout.  Note that this can be configured with the `CI_TERRIBLENESS` env var.