### PR TITLE
Ensure that a trace id is set on incoming thrift requests

### DIFF
--- a/linkerd/protocol/thrift/src/main/scala/com/twitter/finagle/buoyant/linkerd/ThriftTraceInitializer.scala
+++ b/linkerd/protocol/thrift/src/main/scala/com/twitter/finagle/buoyant/linkerd/ThriftTraceInitializer.scala
@@ -1,0 +1,31 @@
+package com.twitter.finagle.buoyant.linkerd
+
+import com.twitter.finagle._
+import com.twitter.finagle.tracing.{Trace, TraceInitializerFilter, Tracer}
+
+object ThriftTraceInitializer {
+  val role = TraceInitializerFilter.role
+
+  val serverModule: Stackable[ServiceFactory[Array[Byte], Array[Byte]]] =
+    new Stack.Module1[param.Tracer, ServiceFactory[Array[Byte], Array[Byte]]] {
+      val role = ThriftTraceInitializer.role
+      val description = "Ensure that there is a trace id set"
+
+      def make(_tracer: param.Tracer, next: ServiceFactory[Array[Byte], Array[Byte]]) = {
+        val param.Tracer(tracer) = _tracer
+        new ServerFilter(tracer) andThen next
+      }
+    }
+
+  class ServerFilter(tracer: Tracer)
+    extends SimpleFilter[Array[Byte], Array[Byte]] {
+
+    def apply(req: Array[Byte], service: Service[Array[Byte], Array[Byte]]) = {
+      if (!Trace.hasId)
+        Trace.letTracerAndNextId(tracer) {
+          service(req)
+        }
+      else service(req)
+    }
+  }
+}

--- a/linkerd/protocol/thrift/src/main/scala/io/buoyant/linkerd/protocol/ThriftInitializer.scala
+++ b/linkerd/protocol/thrift/src/main/scala/io/buoyant/linkerd/protocol/ThriftInitializer.scala
@@ -6,6 +6,7 @@ import com.twitter.finagle.Path
 import com.twitter.finagle.Stack.Params
 import com.twitter.finagle.Thrift.param
 import com.twitter.finagle.Thrift.param.{AttemptTTwitterUpgrade, ProtocolFactory}
+import com.twitter.finagle.buoyant.linkerd.ThriftTraceInitializer
 import io.buoyant.config.Parser
 import io.buoyant.config.types.ThriftProtocol
 import io.buoyant.router.{RoutingFactory, Thrift}
@@ -23,7 +24,11 @@ class ThriftInitializer extends ProtocolInitializer {
     .configured(RoutingFactory.DstPrefix(Path.Utf8(name)))
 
   protected val adapter = Thrift.Router.IngestingFilter
-  protected val defaultServer = Thrift.server
+  protected val defaultServer = {
+    val stack = Thrift.server.stack
+      .replace(ThriftTraceInitializer.role, ThriftTraceInitializer.serverModule)
+    Thrift.server.withStack(stack)
+  }
 
   override def defaultServerPort: Int = 4114
 


### PR DESCRIPTION
# Problem

If no trace id is set on an incoming thrift request, no trace id is set into the context until the client stack.  This means that records on the server span will have a completely different traceId than the records on the client span.

# Solution

Add a server module that generates a traceId if one does not exist yet.

# Result

For requests that otherwise don't have trace data, a traceId will be generated for the server span and the spanId will be incremented for the clientSpan.