### PR TITLE
make admin work on arbitrary base paths

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,6 +5,7 @@ project/boot/
 project/plugins/project/
 project/plugins/src_managed/
 http.pid
+npm-debug.log
 .sbt-launch.jar
 .idea
 .iml

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -2,6 +2,7 @@
 
 * Add experimental StatsD telemeter
 * Add a recent requests log in the linkerd admin dashboard
+* Admin dashboard now works if served at a non-root url
 
 ## 0.8.5 2017-01-06
 

--- a/admin/src/main/resources/io/buoyant/admin/js/main-linkerd.js
+++ b/admin/src/main/resources/io/buoyant/admin/js/main-linkerd.js
@@ -35,7 +35,7 @@ require([
   linkerdDtabPlayground
 ) {
   // poor man's routing
-  if (window.location.pathname.indexOf("delegator") === 1) {
+  if (window.location.pathname.endsWith("/delegator")) {
     adminPage.initialize(true);
     new linkerdDtabPlayground();
   } else {

--- a/admin/src/main/resources/io/buoyant/admin/js/src/admin.js
+++ b/admin/src/main/resources/io/buoyant/admin/js/src/admin.js
@@ -17,7 +17,7 @@ define([
       $(".dropdown-toggle .router-label").text(label)
     }
 
-    $.get("/config.json").done(function(routersRsp) {
+    $.get("config.json").done(function(routersRsp) {
       var template = Handlebars.compile(templateRsp);
       var routers = routersRsp.routers;
 

--- a/admin/src/main/resources/io/buoyant/admin/js/src/dashboard.js
+++ b/admin/src/main/resources/io/buoyant/admin/js/src/dashboard.js
@@ -21,7 +21,7 @@ define([
      */
     var UPDATE_INTERVAL = 1000;
 
-    $.get("/admin/metrics.json").done(function(metricsJson) {
+    $.get("admin/metrics.json").done(function(metricsJson) {
       var metricsCollector = MetricsCollector(metricsJson);
       var routers = Routers(metricsJson, metricsCollector);
 

--- a/admin/src/main/resources/io/buoyant/admin/js/src/delegator.js
+++ b/admin/src/main/resources/io/buoyant/admin/js/src/delegator.js
@@ -47,7 +47,7 @@ define(['jQuery', 'src/dtab_viewer'], function($, DtabViewer) {
         var path = $('#path-input').val();
         window.location.hash = encodeURIComponent(path);
         var request = $.get(
-          "/delegator.json?" + $.param({ path: path, dtab: dtabViewer.dtabStr(), namespace: namespace }),
+          "delegator.json?" + $.param({ path: path, dtab: dtabViewer.dtabStr(), namespace: namespace }),
           renderAll.bind(this));
         request.fail(function( jqXHR ) {
           $(".error-modal").html(templates.errorModal(jqXHR.responseText));

--- a/admin/src/main/resources/io/buoyant/admin/js/src/logger-overrides.js
+++ b/admin/src/main/resources/io/buoyant/admin/js/src/logger-overrides.js
@@ -5,15 +5,15 @@ $(function() {
   var navbar = '<nav class="navbar navbar-inverse">' +
   '      <div class="navbar-container">' +
   '        <div class="navbar-header">' +
-  '          <a class="navbar-brand-img" href="/">' +
-  '            <img alt="Logo" src="/files/images/linkerd-horizontal-white-transbg-vectorized.svg">' +
+  '          <a class="navbar-brand-img" href="../">' +
+  '            <img alt="Logo" src="../files/images/linkerd-horizontal-white-transbg-vectorized.svg">' +
   '          </a>' +
   '        </div>' +
   '        <div id="navbar" class="collapse navbar-collapse">' +
   '          <ul class="nav navbar-nav">' +
-  '            <li><a href="/delegator">dtab</a></li>' +
-  '            <li><a href="/admin/logging">logging</a></li>' +
-  '            <li><a href="/help">help</a></li>' +
+  '            <li><a href="../delegator">dtab</a></li>' +
+  '            <li><a href="logging">logging</a></li>' +
+  '            <li><a href="../help">help</a></li>' +
   '          </ul>' +
   '        </div>' +
   '      </div>' +

--- a/admin/src/main/resources/io/buoyant/admin/js/src/metrics.js
+++ b/admin/src/main/resources/io/buoyant/admin/js/src/metrics.js
@@ -4,8 +4,8 @@
 /* globals getSelectedRouter, Routers, UpdateableChart */
 
 $.when(
-  $.get("/files/js/template/metrics.template"),
-  $.get("/admin/metrics.json")
+  $.get("files/js/template/metrics.template"),
+  $.get("admin/metrics.json")
 ).done(function(templateRsp, jsonRsp) {
   $(function() {
     init(Handlebars.compile(templateRsp[0]), jsonRsp[0]);

--- a/admin/src/main/resources/io/buoyant/admin/js/src/metrics_collector.js
+++ b/admin/src/main/resources/io/buoyant/admin/js/src/metrics_collector.js
@@ -7,8 +7,8 @@
 define(['jQuery'], function($) {
 
   var MetricsCollector = (function() {
-    var generalUpdateUri = "/admin/metrics.json";
-    var metricsUpdateUri = "/admin/metrics";
+    var generalUpdateUri = "admin/metrics.json";
+    var metricsUpdateUri = "admin/metrics";
     var listeners = [];
 
     function requestBody(listeners, defaultMetrics) {

--- a/admin/src/main/resources/io/buoyant/admin/js/template/metrics.template
+++ b/admin/src/main/resources/io/buoyant/admin/js/template/metrics.template
@@ -12,7 +12,7 @@
     <div id="metrics-title">
       <div class="metrics-json">
         <span>Raw data: </span>
-        <a href="/admin/metrics.json">/admin/metrics.json</a>
+        <a href="admin/metrics.json">admin/metrics.json</a>
       </div>
       <span class="name">&nbsp;</span>
       <span class="value stat">&nbsp;</span>

--- a/admin/src/main/scala/io/buoyant/admin/StyleOverrideFilter.scala
+++ b/admin/src/main/scala/io/buoyant/admin/StyleOverrideFilter.scala
@@ -9,17 +9,19 @@ class StyleOverrideFilter extends SimpleFilter[Request, Response] {
 
   val stylesAndJavascripts =
     s"""
-    <link type="text/css" href="/files/css/lib/bootstrap.min.css" rel="stylesheet"/>
-    <link type="text/css" href="/files/css/logger-overrides.css" rel="stylesheet"/>
-    <link type="text/css" href="/files/css/dashboard.css" rel="stylesheet"/>
-    <script src="/files/js/lib/jquery.min.js"></script>
-    <script src="/files/js/lib/bootstrap.min.js"></script>
-    <script src="/files/js/src/logger-overrides.js"></script>
+    <link type="text/css" href="../files/css/lib/bootstrap.min.css" rel="stylesheet"/>
+    <link type="text/css" href="../files/css/logger-overrides.css" rel="stylesheet"/>
+    <link type="text/css" href="../files/css/dashboard.css" rel="stylesheet"/>
+    <script src="../files/js/lib/jquery.min.js"></script>
+    <script src="../files/js/lib/bootstrap.min.js"></script>
+    <script src="../files/js/src/logger-overrides.js"></script>
       """
 
   def apply(req: Request, svc: Service[Request, Response]) = {
     svc(req).map { response =>
-      response.setContentString(response.contentString + stylesAndJavascripts)
+      val content = response.contentString + stylesAndJavascripts
+      response.setContentString(content)
+      response.contentLength = content.length
       response
     }
   }

--- a/linkerd/admin/src/main/scala/io/buoyant/linkerd/admin/AdminHandler.scala
+++ b/linkerd/admin/src/main/scala/io/buoyant/linkerd/admin/AdminHandler.scala
@@ -19,16 +19,16 @@ object AdminHandler extends HtmlView {
             <span class="icon-bar"></span>
           </button>
 
-          <a class="navbar-brand-img" href="/">
-            <img alt="Logo" src="/files/images/linkerd-horizontal-white-transbg-vectorized.svg">
+          <a class="navbar-brand-img" href=".">
+            <img alt="Logo" src="files/images/linkerd-horizontal-white-transbg-vectorized.svg">
           </a>
         </div>
         <div id="navbar" class="collapse navbar-collapse">
           <ul class="nav navbar-nav">
-            <li><a href="/delegator">dtab</a></li>
-            <li><a href="/requests">requests</a></li>
-            <li><a href="/admin/logging">logging</a></li>
-            <li><a href="/help">help</a></li>
+            <li><a href="delegator">dtab</a></li>
+            <li><a href="requests">requests</a></li>
+            <li><a href="admin/logging">logging</a></li>
+            <li><a href="help">help</a></li>
           </ul>
           <ul class="nav navbar-nav navbar-right">
             <li class="dropdown">
@@ -61,17 +61,16 @@ object AdminHandler extends HtmlView {
     navbar: String = navBar
   ): String = {
     val cssesHtml = csses.map { css =>
-      s"""<link type="text/css" href="/files/css/$css" rel="stylesheet"/>"""
+      s"""<link type="text/css" href="files/css/$css" rel="stylesheet"/>"""
     }.mkString("\n")
-
     s"""
       <!doctype html>
       <html>
         <head>
           <title>linkerd admin</title>
-          <link type="text/css" href="/files/css/lib/bootstrap.min.css" rel="stylesheet"/>
-          <link type="text/css" href="/files/css/dashboard.css" rel="stylesheet"/>
-          <link rel="shortcut icon" href="/files/images/favicon.png" />
+          <link type="text/css" href="files/css/lib/bootstrap.min.css" rel="stylesheet"/>
+          <link type="text/css" href="files/css/dashboard.css" rel="stylesheet"/>
+          <link rel="shortcut icon" href="files/images/favicon.png" />
           <link href='https://fonts.googleapis.com/css?family=Source+Sans+Pro:400,300,600' rel='stylesheet' type='text/css'>
           $cssesHtml
         </head>
@@ -83,7 +82,7 @@ object AdminHandler extends HtmlView {
           </div>
           $tailContent
 
-          <script data-main="/files/js/main-linkerd" src="/files/js/lib/require.js"></script>
+          <script data-main="files/js/main-linkerd" src="files/js/lib/require.js"></script>
 
         </body>
       </html>

--- a/linkerd/admin/src/test/scala/io/buoyant/linkerd/admin/LinkerdAdminTest.scala
+++ b/linkerd/admin/src/test/scala/io/buoyant/linkerd/admin/LinkerdAdminTest.scala
@@ -26,10 +26,10 @@ class LinkerdAdminTest extends FunSuite with Awaits {
     }
   }
 
-  test("serves buoyant static files at /files") {
+  test("serves buoyant static files at files") {
     val _ = new BuoyantMainTest {
       override def main() {
-        val rsp = await(client(Request("/files/css/dashboard.css")))
+        val rsp = await(client(Request("files/css/dashboard.css")))
         assert(rsp.status == Status.Ok)
       }
     }
@@ -38,34 +38,34 @@ class LinkerdAdminTest extends FunSuite with Awaits {
   test("serves 404 for a non-existent route") {
     val _ = new BuoyantMainTest {
       override def main() {
-        val rsp = await(client(Request("/foo")))
+        val rsp = await(client(Request("foo")))
         assert(rsp.status == Status.NotFound)
       }
     }
   }
 
-  test("serves twitter-server admin at /admin") {
+  test("serves twitter-server admin at admin") {
     val _ = new BuoyantMainTest {
       override def main() {
-        val rsp = await(client(Request("/admin")))
+        val rsp = await(client(Request("admin")))
         assert(rsp.status == Status.Ok)
       }
     }
   }
 
-  test("serves twitter-server static files at /admin/files") {
+  test("serves twitter-server static files at admin/files") {
     val _ = new BuoyantMainTest {
       override def main() {
-        val rsp = await(client(Request("/admin/files/css/dashboard.css")))
+        val rsp = await(client(Request("admin/files/css/dashboard.css")))
         assert(rsp.status == Status.Ok)
       }
     }
   }
 
-  test("serves /admin/metrics.json") {
+  test("serves admin/metrics.json") {
     val _ = new BuoyantMainTest {
       override def main() {
-        val rsp = await(client(Request("/admin/metrics.json")))
+        val rsp = await(client(Request("admin/metrics.json")))
         assert(rsp.status == Status.Ok)
       }
     }

--- a/linkerd/examples/admin.yaml
+++ b/linkerd/examples/admin.yaml
@@ -1,0 +1,36 @@
+# Simple config for testing admin parameters and relative paths.
+# localhost:9990 and localhost:4140/foo/ should display the same page.
+# when running namerd, localhost:9991 and localhost:4141/foo/ should display the same page.
+
+admin:
+  ip: 0.0.0.0
+  port: 9990
+
+telemetry:
+- kind: io.l5d.commonMetrics
+- kind: io.l5d.recentRequests
+  sampleRate: 1.0
+
+routers:
+- protocol: http
+  label: linkerd-admin
+  baseDtab: |
+    /http/* => /$/inet/127.1/9990;
+  identifier:
+    kind: io.l5d.path
+    segments: 1
+    consume: true
+  servers:
+  - port: 4140
+    ip: 0.0.0.0
+- protocol: http
+  label: namerd-admin
+  baseDtab: |
+    /http/* => /$/inet/127.1/9991;
+  identifier:
+    kind: io.l5d.path
+    segments: 1
+    consume: true
+  servers:
+  - port: 4141
+    ip: 0.0.0.0

--- a/namerd/main/src/main/scala/io/buoyant/namerd/DtabHandler.scala
+++ b/namerd/main/src/main/scala/io/buoyant/namerd/DtabHandler.scala
@@ -35,10 +35,10 @@ class DtabHandler(
       <html>
         <head>
           <title>namerd admin</title>
-          <link rel="shortcut icon" href="/files/images/favicon.png" />
-          <link type="text/css" href="/files/css/lib/bootstrap.min.css" rel="stylesheet"/>
-          <link type="text/css" href="/files/css/dashboard.css" rel="stylesheet"/>
-          <link type="text/css" href="/files/css/delegator.css" rel="stylesheet"/>
+          <link rel="shortcut icon" href="../files/images/favicon.png" />
+          <link type="text/css" href="../files/css/lib/bootstrap.min.css" rel="stylesheet"/>
+          <link type="text/css" href="../files/css/dashboard.css" rel="stylesheet"/>
+          <link type="text/css" href="../files/css/delegator.css" rel="stylesheet"/>
         </head>
         <body>
           <div class="container-fluid">
@@ -52,7 +52,7 @@ class DtabHandler(
           </div>
 
           <script id="data" type="application/json">{"namespace": "$name", "dtab": ${DelegateApiHandler.Codec.writeStr(dtab)}}</script>
-          <script data-main="/files/js/main-namerd" src="/files/js/lib/require.js"></script>
+          <script data-main="../files/js/main-namerd" src="../files/js/lib/require.js"></script>
         </body>
       </html>
     """

--- a/namerd/main/src/main/scala/io/buoyant/namerd/DtabListHandler.scala
+++ b/namerd/main/src/main/scala/io/buoyant/namerd/DtabListHandler.scala
@@ -28,9 +28,9 @@ class DtabListHandler(
       <html>
         <head>
           <title>namerd admin</title>
-          <link rel="shortcut icon" href="/files/images/favicon.png" />
-          <link type="text/css" href="/files/css/lib/bootstrap.min.css" rel="stylesheet"/>
-          <link type="text/css" href="/files/css/dashboard.css" rel="stylesheet"/>
+          <link rel="shortcut icon" href="files/images/favicon.png" />
+          <link type="text/css" href="files/css/lib/bootstrap.min.css" rel="stylesheet"/>
+          <link type="text/css" href="files/css/dashboard.css" rel="stylesheet"/>
         </head>
         <body>
           <div class="container-fluid">

--- a/namerd/main/src/main/scala/io/buoyant/namerd/NamerdAdmin.scala
+++ b/namerd/main/src/main/scala/io/buoyant/namerd/NamerdAdmin.scala
@@ -23,7 +23,7 @@ object NamerdAdmin {
 
   def dtabs(dtabStore: DtabStore, namers: Map[Path, Namer]): Admin.Handlers = Seq(
     "/" -> new DtabListHandler(dtabStore),
-    "/delegator.json" -> new DelegateApiHandler(ns => ConfiguredNamersInterpreter(namers.toSeq)),
+    "/dtab/delegator.json" -> new DelegateApiHandler(ns => ConfiguredNamersInterpreter(namers.toSeq)),
     "/dtab/" -> new DtabHandler(dtabStore)
   )
 

--- a/telemetry/recent-requests/src/main/scala/io/buoyant/telemetry/recentRequests/RecentRequestsAdminHandler.scala
+++ b/telemetry/recent-requests/src/main/scala/io/buoyant/telemetry/recentRequests/RecentRequestsAdminHandler.scala
@@ -15,8 +15,8 @@ class RecentRequestsAdminHandler(tracer: RecentRequetsTracer) extends Handler {
       val encodedLogicalName = URLEncoder.encode(requestMeta.logicalName, ISO_8859_1.toString)
       val encodedConcreteName = URLEncoder.encode(requestMeta.concreteName, ISO_8859_1.toString)
 
-      val logicalNameUrl = s"/delegator?router=${requestMeta.router}#$encodedLogicalName"
-      val concreteNameUrl = s"/delegator?router=${requestMeta.router}#$encodedConcreteName"
+      val logicalNameUrl = s"delegator?router=${requestMeta.router}#$encodedLogicalName"
+      val concreteNameUrl = s"delegator?router=${requestMeta.router}#$encodedConcreteName"
 
       val row = Seq(
         requestMeta.timestamp.toString,


### PR DESCRIPTION
fixes #397 

this change makes every url/ajax/href/src in admin relative.

initially i had planned to add a new linkerd config flag specifying the base path. this was problematic for two reasons:
1) the base path would need to be passed from config -> admin -> templates -> js
2) it would prevent linkerd from running with multiple base paths. primary example is DC/OS runs admin on `/service/linkerd/`, but the user can still also access any linkerd in their cluster by browsing directly to the admin port. if `/service/linkerd/` were coded into the config, this would not be possible.

![linkerd-dcos](https://cloud.githubusercontent.com/assets/236915/22088044/47f1d4ea-dd96-11e6-8fd1-3db6341da373.png)
