### PR TITLE
Prep 0.8.6

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -3,7 +3,7 @@
 * Add experimental StatsD telemeter
 * Admin dashboard
   * Add a log of recent requests
-  * Admin dashboard now works if served at a non-root url
+  * Now works if served at a non-root url
 * HTTP
   * Support the RFC 7329 `Forwarded` header
 * HTTP/2

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,8 +1,19 @@
-## In the next release...
+## 0.8.6 2017-01-19
 
 * Add experimental StatsD telemeter
-* Add a recent requests log in the linkerd admin dashboard
-* Admin dashboard now works if served at a non-root url
+* Admin dashboard
+  * Add a log of recent requests
+  * Admin dashboard now works if served at a non-root url
+* HTTP
+  * Support the RFC 7329 `Forwarded` header
+* HTTP/2
+  * H2 clients now properly advertise support for the “http2” protocol over
+    ALPN
+* Introduce io.buoyant.hostportPfx and io.buoyant.porthostPfx namers for
+  splitting port numbers out of hostnames
+* Bug fixes:
+  * Fix path identifier bug when slash precedes uri params
+  * Fix subdomainOfPfx handling of hostnames with port numbers
 
 ## 0.8.5 2017-01-06
 

--- a/README.md
+++ b/README.md
@@ -267,7 +267,7 @@ For local testing convenience, we supply a config that routes to a single
 backend on _localhost:8080_.
 
 ```
-$ docker run -p 4140:4140 -p 9990:9990 -v /path/to/linkerd/linkerd/examples:/config buoyantio/linkerd:0.8.4-SNAPSHOT /config/static_namer.yaml
+$ docker run -p 4140:4140 -p 9990:9990 -v /path/to/linkerd/linkerd/examples:/config buoyantio/linkerd:0.8.6-SNAPSHOT /config/static_namer.yaml
 ```
 
 The list of image names may be changed with a command like:
@@ -302,14 +302,14 @@ The assembly script executes two commands serially:
 
 ```bash
 $ ./sbt namerd/dcos:assembly
-$ namerd/target/scala-2.11/namerd-0.8.4-SNAPSHOT-dcos-exec namerd/examples/zk.yaml
+$ namerd/target/scala-2.11/namerd-0.8.6-SNAPSHOT-dcos-exec namerd/examples/zk.yaml
 ```
 
 ##### Run assembly script in docker #####
 
 ```bash
 $ ./sbt namerd/dcos:docker
-$ docker run -p 2181:2181 -p 4180:4180 -v /path/to/repo:/myapp -w /myapp buoyantio/namerd:0.8.4-SNAPSHOT-dcos namerd/examples/zk.yaml
+$ docker run -p 2181:2181 -p 4180:4180 -v /path/to/repo:/myapp -w /myapp buoyantio/namerd:0.8.6-SNAPSHOT-dcos namerd/examples/zk.yaml
 ```
 
 ### Contributing ###

--- a/project/Base.scala
+++ b/project/Base.scala
@@ -32,7 +32,7 @@ object Base {
 class Base extends Build {
   import Base._
 
-  val headVersion = "0.8.5"
+  val headVersion = "0.8.6"
 
   object Git {
     def git(arg: String, args: String*) = Process("git" +: arg +: args)


### PR DESCRIPTION
## 0.8.6 2017-01-19

* Add experimental StatsD telemeter
* Admin dashboard
  * Add a log of recent requests
  * Admin dashboard now works if served at a non-root url
* HTTP
  * Support the RFC 7329 `Forwarded` header
* HTTP/2
  * H2 clients now properly advertise support for the “http2” protocol over
    ALPN
* Introduce `io.buoyant.hostportPfx` and `io.buoyant.porthostPfx` namers for
  splitting port numbers out of hostnames
* Add the `io.l5d.rewrite` namer for arbitrary reordering of path segments
* Bug fixes:
  * Fix path identifier bug when slash precedes uri params
  * Fix subdomainOfPfx handling of hostnames with port numbers