### PR TITLE
Stop logging harmless reader discarded errors in k8s namer

### DIFF
--- a/k8s/src/main/scala/io/buoyant/k8s/ClientConfig.scala
+++ b/k8s/src/main/scala/io/buoyant/k8s/ClientConfig.scala
@@ -2,6 +2,8 @@ package io.buoyant.k8s
 
 import com.twitter.finagle.tracing.NullTracer
 import com.twitter.finagle.{Http, Stack}
+import com.twitter.io.Reader.ReaderDiscarded
+import com.twitter.util.Monitor
 
 /**
  * Meant to be implemented by configuration classes that need to
@@ -12,6 +14,10 @@ trait ClientConfig {
   protected val DefaultHost = "localhost"
   protected val DefaultNamespace = "default"
   protected val DefaultPort = 8001
+
+  protected val ReaderDiscardedMonitor = Monitor.mk {
+    case _: ReaderDiscarded => true
+  }
 
   def host: Option[String]
   def portNum: Option[Int]
@@ -29,6 +35,7 @@ trait ClientConfig {
     Http.client.withParams(Http.client.params ++ params)
       .withHttpStats
       .withTracer(NullTracer)
+      .withMonitor(ReaderDiscardedMonitor)
       .withStreaming(true)
       .filtered(setHost)
   }

--- a/k8s/src/main/scala/io/buoyant/k8s/Watchable.scala
+++ b/k8s/src/main/scala/io/buoyant/k8s/Watchable.scala
@@ -11,6 +11,7 @@ import com.twitter.finagle.tracing.Trace
 import com.twitter.finagle.util.DefaultTimer
 import com.twitter.finagle.{Failure, Filter, http}
 import com.twitter.io.Reader
+import com.twitter.io.Reader.ReaderDiscarded
 import com.twitter.util.TimeConversions._
 import com.twitter.util.{NonFatal => _, _}
 import scala.util.control.NonFatal
@@ -41,6 +42,8 @@ private[k8s] abstract class Watchable[O <: KubeObject: TypeReference, W <: Watch
         true
       // Don't retry on interruption
       case (_, Throw(e: Failure)) if e.isFlagged(Failure.Interrupted) => false
+      // Don't retry on reader discarded
+      case (_, Throw(_: ReaderDiscarded)) => false
       case (_, Throw(NonFatal(ex))) =>
         log.warning("retrying k8s request to %s on error %s", path, ex)
         true


### PR DESCRIPTION
When Linkerd cancels watches to the k8s API, ReaderDiscarded errors are logged to the console.  These errors are harmless but clutter up the log and make it look as though something is wrong.

Stop logging these errors.

Tested by starting Linkerd configured with a k8s namer.  Send some requests to k8s services though the Linkerd, then shut down Linkerd with SIGINT.  Notice that no ReaderDiscarded errors are logged as Linkerd cancels its API watches and shuts down.

Fixes #1896

Signed-off-by: Alex Leong <alex@buoyant.io>